### PR TITLE
WIP: Generic apply function for the Surfaces collection class

### DIFF
--- a/src/xtgeo/surface/surfaces.py
+++ b/src/xtgeo/surface/surfaces.py
@@ -118,6 +118,32 @@ class Surfaces(object):
         """Derive surfaces from a 3D grid"""
         _surfs_import.from_grid3d(self, grid, subgrids, rfactor)
 
+    def apply(self, func, *args, **kwargs):
+        """Apply a function to the surface array.
+        The return value of the function must be a numpy array of the same shape 
+        as the surface. 
+        E.g. surfs.apply(np.nanmean, axis=0) will return the mean surface.
+
+        Args:
+            func: Function to apply
+            args: The function arguments
+            kwargs: The function keyword arguments
+
+        """
+        
+        template = self.surfaces[0].copy()
+        slist = []
+        for surf in self.surfaces:
+            status = template.compare_topology(surf, strict=False)
+            if not status:
+                raise ValueError("Cannot so statistics, surfaces differs in topology")
+            slist.append(np.ma.filled(surf.values, fill_value=np.nan))
+
+        xlist = np.array(slist)
+
+        template.values = func(xlist, *args, **kwargs)
+        return template.copy()
+
     def statistics(self):
         """Return statistical measures from the surfaces.
 
@@ -126,7 +152,7 @@ class Surfaces(object):
         * std: the standard deviation surface (where ddof = 1)
 
         Currently this function expects that the surfaces all have the same
-        shape/topology
+        shape/topology.
 
         Returns:
             dict: A dictionary of statistical measures, see list above

--- a/src/xtgeo/surface/surfaces.py
+++ b/src/xtgeo/surface/surfaces.py
@@ -130,7 +130,7 @@ class Surfaces(object):
             kwargs: The function keyword arguments
 
         """
-        
+
         template = self.surfaces[0].copy()
         slist = []
         for surf in self.surfaces:

--- a/src/xtgeo/surface/surfaces.py
+++ b/src/xtgeo/surface/surfaces.py
@@ -120,8 +120,8 @@ class Surfaces(object):
 
     def apply(self, func, *args, **kwargs):
         """Apply a function to the surface array.
-        The return value of the function must be a numpy array of the same shape 
-        as the surface. 
+        The return value of the function must be a numpy array of the same shape
+        as the surface.
         E.g. surfs.apply(np.nanmean, axis=0) will return the mean surface.
 
         Args:

--- a/tests/test_surface/test_surfaces.py
+++ b/tests/test_surface/test_surfaces.py
@@ -129,11 +129,6 @@ def test_surfaces_apply():
     so = xtgeo.Surfaces(surfs)
     res = so.apply(np.nanmean, axis=0)
 
-    # theoretical stdev:
-    sum2 = 0.0
-    for inum in range(0, 101):
-        sum2 += (float(inum) - 50.0) ** 2
-    stdev = math.sqrt(sum2 / 100.0)  # total 101 samples, use N-1
     tsetup.assert_almostequal(res.values.mean(), bmean + 50.0, 0.0001)
 
 def test_get_surfaces_from_3dgrid():

--- a/tests/test_surface/test_surfaces.py
+++ b/tests/test_surface/test_surfaces.py
@@ -5,6 +5,8 @@ from __future__ import print_function
 import math
 from os.path import join
 
+import numpy as np
+
 import xtgeo
 import test_common.test_xtg as tsetup
 
@@ -114,6 +116,25 @@ def test_more_statistics():
     tsetup.assert_almostequal(res["mean"].values.mean(), bmean + 50.0, 0.0001)
     tsetup.assert_almostequal(res["std"].values.mean(), stdev, 0.0001)
 
+def test_surfaces_apply():
+    base = xtgeo.RegularSurface(TESTSET1A)
+    base.values *= 0.0
+    bmean = base.values.mean()
+    surfs = [base]
+    for inum in range(1, 101):
+        tmp = base.copy()
+        tmp.values += float(inum)
+        surfs.append(tmp)
+
+    so = xtgeo.Surfaces(surfs)
+    res = so.apply(np.nanmean, axis=0)
+
+    # theoretical stdev:
+    sum2 = 0.0
+    for inum in range(0, 101):
+        sum2 += (float(inum) - 50.0) ** 2
+    stdev = math.sqrt(sum2 / 100.0)  # total 101 samples, use N-1
+    tsetup.assert_almostequal(res.values.mean(), bmean + 50.0, 0.0001)
 
 def test_get_surfaces_from_3dgrid():
     """Create surfaces from a 3D grid"""


### PR DESCRIPTION
Relates to #170 
Relates to https://github.com/equinor/webviz-subsurface/issues/69

This PR adds an `apply` function to the surface collection class to calculate statistics.
The function must return a numpy array with the same shape as the input surface.

Example:
```python
so = xtgeo.surface.surfaces.Surfaces([list of surfaces])
res = so.apply(np.nanstd, axis=0, ddof=1)
print(res)
res = so.apply(np.nanmin, axis=0)
print(res)
res = so.apply(np.nanmax, axis=0)
print(res)
res = so.apply(np.nanmean, axis=0)
print(res)
```