### PR TITLE
Include filename in error message if file does not exist

### DIFF
--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -662,7 +662,7 @@ class Cube(object):  # pylint: disable=too-many-public-methods
 
         """
         if not os.path.isfile(sfile):
-            msg = "Does file exist? {}".format("test")
+            msg = "Does file exist? {}".format(sfile)
             logger.critical(msg)
             raise IOError(msg)
 

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -664,8 +664,9 @@ class Cube(object):  # pylint: disable=too-many-public-methods
         if os.path.isfile(sfile):
             pass
         else:
-            logger.critical("Not OK file")
-            raise IOError("Input file for Cube cannot be read")
+            msg = "Does file exist? {}".format(sfile)
+            logger.critical(msg)
+            raise IOError(msg)
 
         # work on file extension
         _froot, fext = os.path.splitext(sfile)

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -661,10 +661,8 @@ class Cube(object):  # pylint: disable=too-many-public-methods
 
 
         """
-        if os.path.isfile(sfile):
-            pass
-        else:
-            msg = "Does file exist? {}".format(sfile)
+        if not os.path.isfile(sfile):
+            msg = "Does file exist? {}".format("test")
             logger.critical(msg)
             raise IOError(msg)
 

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -443,9 +443,7 @@ class Well(object):  # pylint: disable=useless-object-inheritance
         .. versionchanged:: 2.1.0 ``strict`` now defaults to False
         """
 
-        if os.path.isfile(wfile):
-            pass
-        else:
+        if not os.path.isfile(wfile):
             msg = "Does file exist? {}".format(wfile)
             logger.critical(msg)
             raise IOError(msg)

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -446,8 +446,9 @@ class Well(object):  # pylint: disable=useless-object-inheritance
         if os.path.isfile(wfile):
             pass
         else:
-            logger.critical("Not OK file")
-            raise os.error
+            msg = "Does file exist? {}".format(wfile)
+            logger.critical(msg)
+            raise IOError(msg)
 
         if fformat is None or fformat == "rms_ascii":
             _well_io.import_rms_ascii(

--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -118,9 +118,7 @@ class XYZ(object):
 
         logger.info("Reading from file %s...", pfile)
 
-        if os.path.isfile(pfile):
-            pass
-        else:
+        if not os.path.isfile(pfile):
             msg = "Does file exist? {}".format(pfile)
             logger.critical(msg)
             raise IOError(msg)

--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -121,8 +121,9 @@ class XYZ(object):
         if os.path.isfile(pfile):
             pass
         else:
-            logger.critical("Not OK file")
-            raise os.error
+            msg = "Does file exist? {}".format(pfile)
+            logger.critical(msg)
+            raise IOError(msg)
 
         froot, fext = os.path.splitext(pfile)
         if fformat == "guess":


### PR DESCRIPTION
`Cube`, `Well` and `xyz`  `from_file()` does not report the name of the file if the file is missing.
For larger scripts it can be hard to figure out which file is the culprit.

Duplicated the code from `RegularSurface.from_file` into these classes.