### PR TITLE
Changes CONSTANT system so only defined by xtgeo for Python

### DIFF
--- a/src/xtgeo/common/constants.py
+++ b/src/xtgeo/common/constants.py
@@ -1,23 +1,18 @@
 # -*- coding: utf-8 -*-
 """Module for basic XTGeo constants"""
 
-import xtgeo.cxtgeo._cxtgeo as _cxtgeo
+# align with cxtgeo libxtg.h!
 
-UNDEF = -999
-UNDEF_LIMIT = -999
-UNDEF_INT = -999
-UNDEF_INT_LIMIT = -999
-VERYLARGEPOSITIVE = -999
-VERYLARGENEGATIVE = -999
+M_PI = 3.14159265358979323846
+PI = M_PI
+PIHALF = 1.57079632679489661923
 
+UNDEF = 10E32
+UNDEF_LIMIT = 9.9E32
+UNDEF_INT = 2000000000
+UNDEF_INT_LIMIT = 1999999999
 
-try:
-    UNDEF = _cxtgeo.UNDEF
-    UNDEF_LIMIT = _cxtgeo.UNDEF_LIMIT
-    UNDEF_INT = _cxtgeo.UNDEF_INT
-    UNDEF_INT_LIMIT = _cxtgeo.UNDEF_INT_LIMIT
-    VERYLARGENEGATIVE = _cxtgeo.VERYLARGENEGATIVE
-    VERYLARGEPOSITIVE = _cxtgeo.VERYLARGEPOSITIVE
-except AttributeError:
-    print("Cannot import cxtgeo")
-    raise
+VERYLARGEPOSITIVE = 10E30
+VERYLARGENEGATIVE = -10E30
+
+UNDEF_MAP_IRAPB = 1E30

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -12,6 +12,7 @@ import numpy as np
 import numpy.ma as ma
 import pandas as pd
 
+import xtgeo
 import xtgeo.cxtgeo._cxtgeo as _cxtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.common.calc import find_flip
@@ -301,7 +302,7 @@ def get_ijk_from_points(
     proplist["KZ"] = karr
 
     mydataframe = pd.DataFrame.from_dict(proplist)
-    mydataframe.replace(_cxtgeo.UNDEF_INT, -1, inplace=True)
+    mydataframe.replace(xtgeo.UNDEF_INT, -1, inplace=True)
 
     result = mydataframe
     if not dataframe:

--- a/src/xtgeo/plot/xtmap.py
+++ b/src/xtgeo/plot/xtmap.py
@@ -9,7 +9,6 @@ import numpy as np
 import numpy.ma as ma
 import six
 
-import xtgeo
 from xtgeo.common import XTGeoDialog
 from .baseplot import BasePlot
 

--- a/src/xtgeo/plot/xtmap.py
+++ b/src/xtgeo/plot/xtmap.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.ma as ma
 import six
 
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from .baseplot import BasePlot
 
@@ -129,7 +130,7 @@ class Map(BasePlot):
         plt.setp(self._ax.xaxis.get_majorticklabels(), rotation=xlabelrotation)
 
         # zi = ma.masked_where(zimask, zi)
-        # zi = ma.masked_greater(zi, _cxtgeo.UNDEF_LIMIT)
+        # zi = ma.masked_greater(zi, xtgeo.UNDEF_LIMIT)
         logger.info("Current colormap is %s, requested is %s", self.colormap, colormap)
         logger.info("Current colormap name is %s", self.colormap.name)
 

--- a/src/xtgeo/surface/_regsurf_cube.py
+++ b/src/xtgeo/surface/_regsurf_cube.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import numpy as np
 import numpy.ma as ma
 
+import xtgeo
 import xtgeo.cxtgeo._cxtgeo as _cxtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.common import XTGShowProgress
@@ -58,7 +59,7 @@ def slice_cube(
 
     if deadtraces:
         # set dead traces to cxtgeo UNDEF -> special treatment in the C code
-        olddead = cube.values_dead_traces(_cxtgeo.UNDEF)
+        olddead = cube.values_dead_traces(xtgeo.UNDEF)
 
     cubeval1d = np.ravel(cube.values, order="C")
 
@@ -335,7 +336,7 @@ def _slice_constant_window2(  # pylint: disable=unused-argument
 
     if deadtraces:
         # set dead traces to cxtgeo UNDEF -> special treatment in the C code
-        olddead = cube.values_dead_traces(_cxtgeo.UNDEF)
+        olddead = cube.values_dead_traces(xtgeo.UNDEF)
 
     cubeval1d = np.ravel(cube.values, order="C")
 

--- a/src/xtgeo/surface/_regsurf_export.py
+++ b/src/xtgeo/surface/_regsurf_export.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 from struct import pack
 
 import xtgeo
+from xtgeo.common.constants import UNDEF_MAP_IRAPB
 import xtgeo.cxtgeo._cxtgeo as _cxtgeo  # pylint: disable=import-error
 from xtgeo.common import XTGeoDialog
 
@@ -71,7 +72,7 @@ def _export_irap_binary_cxtgeo(self, mfile):
 
     fout = xtgeo._XTGeoCFile(mfile, mode="wb")
 
-    vals = self.get_values1d(fill_value=_cxtgeo.UNDEF_MAP_IRAPB, order="F")
+    vals = self.get_values1d(fill_value=UNDEF_MAP_IRAPB, order="F")
     ier = _cxtgeo.surf_export_irap_bin(
         fout.fhandle,
         self._ncol,
@@ -98,7 +99,7 @@ def _export_irap_binary_python(self, mfile, bstream=False):
     with BytesIO.
     """
 
-    vals = self.get_values1d(fill_value=_cxtgeo.UNDEF_MAP_IRAPB, order="F")
+    vals = self.get_values1d(fill_value=UNDEF_MAP_IRAPB, order="F")
 
     ap = pack(
         ">3i6f3i3f10i",  # > means big endian storage

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -13,7 +13,6 @@ import scipy.interpolate
 import scipy.ndimage
 
 import xtgeo
-import xtgeo.cxtgeo._cxtgeo as _cxtgeo
 
 xtg = xtgeo.common.XTGeoDialog()
 

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -12,8 +12,8 @@ import numpy.ma as ma
 import scipy.interpolate
 import scipy.ndimage
 
-import xtgeo.cxtgeo._cxtgeo as _cxtgeo
 import xtgeo
+import xtgeo.cxtgeo._cxtgeo as _cxtgeo
 
 xtg = xtgeo.common.XTGeoDialog()
 
@@ -118,7 +118,7 @@ def avgsum_from_3dprops_gridding(
         maxpp = ppx.max()
 
     # avoid artifacts from inactive cells that slips through somehow...(?)
-    if dzprop.max() > _cxtgeo.UNDEF_LIMIT:
+    if dzprop.max() > xtgeo.UNDEF_LIMIT:
         raise RuntimeError("Bug: DZ with unphysical values present")
 
     trimbydz = False
@@ -316,8 +316,8 @@ def _zone_averaging(
         mpr = ma.dstack(newm)
         zpr.astype(np.int32)
 
-    xpr = ma.filled(xpr, fill_value=_cxtgeo.UNDEF)
-    ypr = ma.filled(ypr, fill_value=_cxtgeo.UNDEF)
+    xpr = ma.filled(xpr, fill_value=xtgeo.UNDEF)
+    ypr = ma.filled(ypr, fill_value=xtgeo.UNDEF)
     zpr = ma.filled(zpr, fill_value=0)
     dpr = ma.filled(dpr, fill_value=0.0)
 

--- a/src/xtgeo/surface/_regsurf_import.py
+++ b/src/xtgeo/surface/_regsurf_import.py
@@ -68,7 +68,7 @@ def import_irap_binary(self, mfile, values=True):
 
     val = np.reshape(val, (self._ncol, self._nrow), order="C")
 
-    val = ma.masked_greater(val, _cxtgeo.UNDEF_LIMIT)
+    val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
 
     if np.isnan(val).any():
         logger.info("NaN values are found, will mask...")
@@ -144,7 +144,7 @@ def import_irap_binary(self, mfile, values=True):
 
     # val = np.reshape(val, (self._ncol, self._nrow), order="C")
 
-    # val = ma.masked_greater(val, _cxtgeo.UNDEF_LIMIT)
+    # val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
 
     # if np.isnan(val).any():
     #     logger.info("NaN values are found, will mask...")
@@ -174,7 +174,7 @@ def import_irap_ascii(self, mfile):
 
     val = np.reshape(val, (ncol, nrow), order="C")
 
-    val = ma.masked_greater(val, _cxtgeo.UNDEF_LIMIT)
+    val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
 
     if np.isnan(val).any():
         logger.info("NaN values are found, will mask...")
@@ -231,7 +231,7 @@ def import_ijxyz_ascii(self, mfile):  # pylint: disable=too-many-locals
 
     logger.info(xlist)
 
-    val = ma.masked_greater(val, _cxtgeo.UNDEF_LIMIT)
+    val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
 
     self._xori = xori
     self._xinc = xinc
@@ -266,7 +266,7 @@ def import_ijxyz_ascii_tmpl(self, mfile, template):
         fin.fhandle, template.ilines, template.xlines, nxy, 0
     )
 
-    val = ma.masked_greater(val, _cxtgeo.UNDEF_LIMIT)
+    val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
 
     self._xori = template.xori
     self._xinc = template.xinc


### PR DESCRIPTION
I.e. not any longer by _ctgeo.UNDEF etc. This reason for this is that some build did not transfer
the define CONSTANT with consistent names; a SWIG issue I think