### PR TITLE
Gridprop linkgrid issue3

### DIFF
--- a/src/xtgeo/clib/xtg/grd3d_make_z_consistent.c
+++ b/src/xtgeo/clib/xtg/grd3d_make_z_consistent.c
@@ -1,5 +1,5 @@
 /*
-****************************************************************************************
+ ***************************************************************************************
  *
  * NAME:
  *    grd3d_make_z_consistent.c
@@ -24,44 +24,42 @@
  ***************************************************************************************
  */
 
-#include "logger.h"
 #include "libxtg.h"
 #include "libxtg_.h"
+#include "logger.h"
 
-
-void grd3d_make_z_consistent(
-    int nx,
-    int ny,
-    int nz,
-    double *zcornsv,
-    long nzcorn,
-    double zsep
-    )
+void
+grd3d_make_z_consistent(int nx,
+                        int ny,
+                        int nz,
+                        double *zcornsv,
+                        long nzcorn,
+                        double zsep)
 
 {
 
     logger_info(LI, FI, FU, "Entering %s with zsep %lf", FU, zsep);
 
-    int    i, j, k;
+    int i, j, k;
 
     for (j = 1; j <= ny; j++) {
-	for (i = 1; i <= nx; i++) {
-	    for (k = 2; k <= nz + 1; k++) {
+        for (i = 1; i <= nx; i++) {
+            for (k = 2; k <= nz + 1; k++) {
 
-		long ibp = x_ijk2ib(i, j, k - 1, nx, ny, nz + 1, 0);
-		long ibx = x_ijk2ib(i, j, k, nx, ny, nz + 1, 0);
+                long ibp = x_ijk2ib(i, j, k - 1, nx, ny, nz + 1, 0);
+                long ibx = x_ijk2ib(i, j, k, nx, ny, nz + 1, 0);
 
                 int ic;
-		for (ic = 1; ic <= 4; ic++) {
-		    double z1 = zcornsv[4 * ibp + 1 * ic - 1];
-		    double z2 = zcornsv[4 * ibx + 1 * ic - 1];
+                for (ic = 1; ic <= 4; ic++) {
+                    double z1 = zcornsv[4 * ibp + 1 * ic - 1];
+                    double z2 = zcornsv[4 * ibx + 1 * ic - 1];
 
-		    if ((z2 - z1) < zsep) {
-			zcornsv[4 * ibx + 1 * ic - 1] = z1 + zsep;
-		    }
-		}
-	    }
-	}
+                    if ((z2 - z1) < zsep) {
+                        zcornsv[4 * ibx + 1 * ic - 1] = z1 + zsep;
+                    }
+                }
+            }
+        }
     }
 
     logger_info(LI, FI, FU, "Exit from %s", FU);

--- a/src/xtgeo/grid3d/_gridprop_etc.py
+++ b/src/xtgeo/grid3d/_gridprop_etc.py
@@ -90,6 +90,7 @@ def gridproperty_fromfile(self, pfile, **kwargs):
         fformat=fformat,
         name=self._name,
         grid=self._geometry,
+        gridlink=kwargs.get("gridlink"),
         date=self._date,
         fracture=self._fracture,
     )

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -209,7 +209,7 @@ class Grid(Grid3D):
 
         if self.props is not None:
             for prop in self.props:
-                # logger.info("Deleting property instance %s", prop.name)
+                logger.info("Deleting property instance %s", prop.name)
                 prop.__del__()
 
     def __repr__(self):
@@ -407,8 +407,7 @@ class Grid(Grid3D):
 
     @property
     def gridprops(self):
-        """Return or set a XTGeo GridProperties objects attached to the Grid.
-        """
+        """Return or set a XTGeo GridProperties objects attached to the Grid."""
         # Note, internally, the _props is a GridProperties instance, which is
         # a class that holds a list of properties.
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -201,16 +201,16 @@ class Grid(Grid3D):
             )
         logger.info("Ran __init__ for %s", repr(self))
 
-    def __del__(self):
+    # def __del__(self):
 
-        self._coordsv = None
-        self._zcornsv = None
-        self._actnumsv = None
+    #     self._coordsv = None
+    #     self._zcornsv = None
+    #     self._actnumsv = None
 
-        if self.props is not None:
-            for prop in self.props:
-                logger.info("Deleting property instance %s", prop.name)
-                prop.__del__()
+    #     if self.props is not None:
+    #         for prop in self.props:
+    #             logger.info("Deleting property instance %s", prop.name)
+    #             prop.__del__()
 
     def __repr__(self):
         logger.info("Invoke __repr__ for grid")

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -182,10 +182,14 @@ class GridProperties(Grid3D):
 
         for prop in proplist:
             if isinstance(prop, GridProperty):
+                # an prop instance can only occur once
+                if prop not in self._props:
 
-                self._props.append(prop)
-                self._names.append(prop.name)
-                self._dates.append(prop.date)
+                    self._props.append(prop)
+                    self._names.append(prop.name)
+                    self._dates.append(prop.date)
+                else:
+                    logger.info("Not added. GridProperty instance already present")
             else:
                 raise ValueError("Input property is not a valid GridProperty " "object")
 

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -7,7 +7,7 @@ property from file, but it can also be created directly, as e.g.::
 
  poro = GridProperty(ncol=233, nrow=122, nlay=32)
 
-The grid property values `someinstance.values` by themselves are 3D masked
+The grid property values ``someinstance.values`` by themselves are 3D masked
 numpy as either float64 (double) or int32 (if discrete), and undefined
 cells are displayed as masked. The array order is now C_CONTIGUOUS.
 (i.e. not in Eclipse manner). A 1D view (C order) is achieved by the
@@ -58,7 +58,13 @@ logger = xtg.functionlogger(__name__)
 
 
 def gridproperty_from_file(
-    pfile, fformat="guess", name="unknown", grid=None, date=None, fracture=False
+    pfile,
+    fformat="guess",
+    name="unknown",
+    grid=None,
+    gridlink=True,
+    date=None,
+    fracture=False,
 ):
     """Make a GridProperty instance directly from file import.
 
@@ -76,7 +82,13 @@ def gridproperty_from_file(
 
     obj = GridProperty()
     obj.from_file(
-        pfile, fformat=fformat, name=name, grid=grid, date=date, fracture=fracture
+        pfile,
+        fformat=fformat,
+        name=name,
+        grid=grid,
+        gridlink=gridlink,
+        date=date,
+        fracture=fracture,
     )
 
     return obj
@@ -200,11 +212,11 @@ class GridProperty(Grid3D):
             # make instance purely from kwargs spec
             _gridprop_etc.gridproperty_fromspec(self, **kwargs)
 
-    def __del__(self):
-        logger.debug("DELETING property instance %s", self.name)
-        self._values = None
-        for myvar in vars(self).keys():
-            del myvar
+    # def __del__(self):
+    #     logger.debug("DELETING property instance %s", self.name)
+    #     self._values = None
+    #     for myvar in vars(self).keys():
+    #         del myvar
 
     def __repr__(self):
         myrp = (
@@ -243,8 +255,7 @@ class GridProperty(Grid3D):
 
     @property
     def geometry(self):
-        """Returns or set the linked geometry, i.e. the Grid instance)
-        """
+        """Returns or set the linked geometry, i.e. the Grid instance)"""
         return self._geometry
 
     @geometry.setter
@@ -562,8 +573,8 @@ class GridProperty(Grid3D):
                 required for Eclipse).
             gridlink (bool): If True, and grid is not None, a link from the grid
                 instance to the property is made. If False, no such link is made.
-                Avoiding links is recommended when running statistics of multiple
-                realisations of a property
+                Avoiding gridlink is recommended when running statistics of multiple
+                realisations of a property.
             fracture (bool): Only applicable for DUAL POROSITY systems, if True
                 then the fracture property is read; if False then the matrix
                 property is read. Names will be appended with "M" or "F"
@@ -580,6 +591,8 @@ class GridProperty(Grid3D):
 
         Returns:
            True if success, otherwise False
+
+        .. versionchanged:: 2.8 Added gridlink option, default is True
         """
 
         obj = _gridprop_import.from_file(
@@ -646,7 +659,7 @@ class GridProperty(Grid3D):
         self._filesrc = None
 
         _gridprop_roxapi.import_prop_roxapi(
-            self, projectname, gname, pname, realisation
+            self, projectname, gname, pname, realisation,
         )
 
     def to_roxar(self, projectname, gname, pname, saveproject=False, realisation=0):

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -201,7 +201,7 @@ class GridProperty(Grid3D):
             _gridprop_etc.gridproperty_fromspec(self, **kwargs)
 
     def __del__(self):
-        # logger.info("DELETING property instance %s", self.name)
+        logger.debug("DELETING property instance %s", self.name)
         self._values = None
         for myvar in vars(self).keys():
             del myvar
@@ -538,6 +538,7 @@ class GridProperty(Grid3D):
         fformat=None,
         name="unknown",
         grid=None,
+        gridlink=True,
         date=None,
         fracture=False,
         _roffapiv=1,
@@ -559,6 +560,10 @@ class GridProperty(Grid3D):
                 mnemonics like 'first', 'last' is also allowed.
             grid (Grid object): Grid Object for checks (optional for ROFF,
                 required for Eclipse).
+            gridlink (bool): If True, and grid is not None, a link from the grid
+                instance to the property is made. If False, no such link is made.
+                Avoiding links is recommended when running statistics of multiple
+                realisations of a property
             fracture (bool): Only applicable for DUAL POROSITY systems, if True
                 then the fracture property is read; if False then the matrix
                 property is read. Names will be appended with "M" or "F"
@@ -587,6 +592,10 @@ class GridProperty(Grid3D):
             fracture=fracture,
             _roffapiv=_roffapiv,
         )
+
+        if grid and gridlink:
+            grid.append_prop(self)
+
         return obj
 
     def to_file(self, pfile, fformat="roff", name=None, append=False, dtype=None):

--- a/src/xtgeo/well/_well_oper.py
+++ b/src/xtgeo/well/_well_oper.py
@@ -17,8 +17,6 @@ xtg = XTGeoDialog()
 
 logger = xtg.functionlogger(__name__)
 
-XTG_DEBUG = 0
-
 
 def delete_log(self, lname):
     """Delete/remove an existing log, or list of logs."""
@@ -218,7 +216,7 @@ def get_ijk_from_grid(self, grid, grid_id=""):
         wivec,
         wjvec,
         wkvec,
-        0
+        0,
     )
 
     if cstatus != 0:

--- a/tests/test_common/test_xtg.py
+++ b/tests/test_common/test_xtg.py
@@ -160,6 +160,8 @@ def test_more_logging_tests(caplog):
     locallogger.warning("Display warning")
     locallogger.critical("Display critical")
 
+    os.environ["XTG_LOGGING_LEVEL"] = "CRITICAL"
+
 
 def test_timer(capsys):
     """Test the timer function"""


### PR DESCRIPTION
This is done to restore a feature in version 2.0, cf. #325. Circular references could then be present again which could trigger memory leakage, so need to look at `weakref` possible to improve further.