### PR TITLE
Fix grd3d_get_randomline() for discrete parameters

### DIFF
--- a/src/xtgeo/grid3d/_grid3d_fence.py
+++ b/src/xtgeo/grid3d/_grid3d_fence.py
@@ -80,7 +80,7 @@ def get_randomline(
         self._coordsv,
         self._zcornsv,
         self._actnumsv,
-        gl.update_carray(prop),
+        gl.update_carray(prop, dtype=np.float64),
         self._tmp["onegrid"]._zcornsv,
         self._tmp["onegrid"]._actnumsv,
         nsamples,

--- a/src/xtgeo/grid3d/_gridprop_lowlevel.py
+++ b/src/xtgeo/grid3d/_gridprop_lowlevel.py
@@ -101,7 +101,7 @@ def update_carray(self, undef=None, discrete=None, dtype=None, order="F"):
         values = np.asfortranarray(values)
         values1d = np.ravel(values, order="K")
 
-    if values1d.dtype == "float64" and dstatus:
+    if values1d.dtype == "float64" and dstatus and not dtype:
         values1d = values1d.astype("int32")
         logger.debug("Casting has been done")
 


### PR DESCRIPTION
This allows me to run plot_grid3d() with discrete parameters, but it looks like there are some interpolation artifacts? Maybe better to fix `grd3d_get_randomline()` to work with int array?
![discrete_param](https://user-images.githubusercontent.com/35254400/87536093-cb845f00-c698-11ea-891b-c3a85687de25.png)
