### PR TITLE
xsection: Interpolation for plot_grid3d()

### DIFF
--- a/src/xtgeo/plot/xsection.py
+++ b/src/xtgeo/plot/xsection.py
@@ -910,7 +910,13 @@ class XSection(BasePlot):
             self._fig.colorbar(img, ax=ax)
 
     def plot_grid3d(
-        self, colormap="rainbow", vmin=None, vmax=None, alpha=0.7, zinc=0.5
+        self,
+        colormap="rainbow",
+        vmin=None,
+        vmax=None,
+        alpha=0.7,
+        zinc=0.5,
+        interpolation="antialiased",
     ):
         """Plot a sampled grid with gridproperty backdrop.
 
@@ -920,6 +926,8 @@ class XSection(BasePlot):
             vmax (float); Maximum value in plot
             alpha (float): Alpha blending number beween 0 and 1.
             zinc (float): Sampling vertically, default is 0.5
+            interpolation (str): Interpolation for plotting, cf. matplotlib
+                documentation on this.
 
         Raises:
             ValueError: No grid or gridproperty is loaded
@@ -952,6 +960,9 @@ class XSection(BasePlot):
                 colormap = "rainbow"
             self._colormap_grid = self.define_any_colormap(colormap)
 
+        if self._gridproperty.isdiscrete:
+            interpolation = "nearest"
+
         img = ax.imshow(
             arr,
             cmap=self._colormap_grid,
@@ -960,6 +971,7 @@ class XSection(BasePlot):
             extent=(h1, h2, v2, v1),
             aspect="auto",
             alpha=alpha,
+            interpolation=interpolation,
         )
 
         logger.info("Actual VMIN and VMAX: %s", img.get_clim())

--- a/src/xtgeo/plot/xsection.py
+++ b/src/xtgeo/plot/xsection.py
@@ -471,6 +471,7 @@ class XSection(BasePlot):
 
         # Restore xaxis limits and set axis title
         ax.set_xlim(lim)
+        ax.set_ylabel("TVD MSL [m]", fontsize=12.0)
         ax.set_xlabel("Measured Depth [m]", fontsize=12)
 
     def _plot_well_traj(self, ax, zv, hv, welltrajcolor, linewidth):
@@ -927,7 +928,8 @@ class XSection(BasePlot):
             alpha (float): Alpha blending number beween 0 and 1.
             zinc (float): Sampling vertically, default is 0.5
             interpolation (str): Interpolation for plotting, cf. matplotlib
-                documentation on this.
+                documentation on this. "auto" uses "nearest" for discrete
+                parameters and "antialiased" for floats.
 
         Raises:
             ValueError: No grid or gridproperty is loaded

--- a/src/xtgeo/plot/xsection.py
+++ b/src/xtgeo/plot/xsection.py
@@ -916,7 +916,7 @@ class XSection(BasePlot):
         vmax=None,
         alpha=0.7,
         zinc=0.5,
-        interpolation="antialiased",
+        interpolation="auto",
     ):
         """Plot a sampled grid with gridproperty backdrop.
 
@@ -960,8 +960,11 @@ class XSection(BasePlot):
                 colormap = "rainbow"
             self._colormap_grid = self.define_any_colormap(colormap)
 
-        if self._gridproperty.isdiscrete:
-            interpolation = "nearest"
+        if interpolation == "auto":
+            if self._gridproperty.isdiscrete:
+                interpolation = "nearest"
+            else:
+                interpolation = "antialiased"
 
         img = ax.imshow(
             arr,


### PR DESCRIPTION
Interpolation parameter added for plot_grid3d(). Interpolation will be set to 'nearest' if grid param is discrete.
Fixes https://github.com/equinor/xtgeo/issues/399