### PR TITLE
Fix issues for report gridmatch

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,9 +2,9 @@
 
 ## Version 2
 
-### 2.11.0 (in prep)
+### 2.11.0
 * New features:
-  * Added kesy ``perflogrange`` and ``filterlogrange`` in Grid report_zone_mismatch()
+  * Added keys ``perflogrange`` and ``filterlogrange`` in Grid report_zone_mismatch()
 
 
 ### 2.10.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## Version 2
 
+### 2.11.0 (in prep)
+* New features:
+  * Added kesy ``perflogrange`` and ``filterlogrange`` in Grid report_zone_mismatch()
+
+
 ### 2.10.0
 * New features:
   * Added interpolation option in xsection when plotting 3D grids #401

--- a/src/xtgeo/grid3d/_grid_wellzone.py
+++ b/src/xtgeo/grid3d/_grid_wellzone.py
@@ -105,15 +105,25 @@ def report_zone_mismatch(
     dfuse1 = dfuse1.loc[dfuse1[zonelogname] > -888]
 
     dfuse1["zmatch1"] = np.where(dfuse1[zmodel] == dfuse1[zonelogname], 1, 0)
-    mcount1 = int(dfuse1["zmatch1"].sum())
-    tcount1 = int(dfuse1["zmatch1"].count())
+    mcount1 = dfuse1["zmatch1"].sum()
+    tcount1 = dfuse1["zmatch1"].count()
+    if not np.isnan(mcount1):
+        mcount1 = int(mcount1)
+    if not np.isnan(tcount1):
+        tcount1 = int(tcount1)
+
     res1 = dfuse1["zmatch1"].mean() * 100
 
     dfuse2 = df.copy(deep=True)
     dfuse2 = dfuse2.loc[(df[zmodel] > -888) | (df[zonelogname] > -888)]
     dfuse2["zmatch2"] = np.where(dfuse2[zmodel] == dfuse2[zonelogname], 1, 0)
-    mcount2 = int(dfuse2["zmatch2"].sum())
-    tcount2 = int(dfuse2["zmatch2"].count())
+    mcount2 = dfuse2["zmatch2"].sum()
+    tcount2 = dfuse2["zmatch2"].count()
+    if not np.isnan(mcount2):
+        mcount2 = int(mcount2)
+    if not np.isnan(tcount2):
+        tcount2 = int(tcount2)
+
     res2 = dfuse2["zmatch2"].mean() * 100
 
     # update Well() copy (segment only)

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -1704,7 +1704,9 @@ class Grid(Grid3D):
         zonelogshift=0,
         depthrange=None,
         perflogname=None,
+        perflogrange=(1, 9999),
         filterlogname=None,
+        filterlogrange=(1e-32, 9999.0),
         resultformat=1,
     ):
         """Reports mismatch between wells and a zone.
@@ -1731,10 +1733,14 @@ class Grid(Grid3D):
                 zonation
             zonelogrange (tuple): zone log range, from - to (inclusive)
             onelayergrid (Grid): Redundant from version 2.8, please skip!
-            zonelogshift (int): Deviation (numerical shift) between grid and zonelog
+            zonelogshift (int): Deviation (numerical shift) between grid and zonelog,
+                e.g. if Zone property starts with 1 and this corresponds to a zonelog
+                index of 3 in the well, the shift shall be -2.
             depthrange (tuple): Interval for search in TVD depth, to speed up
-            perflogname (str): Name of perforation log to filter on (> 0).
+            perflogname (str): Name of perforation log to filter on (> 0 default).
+            perflogrange (tuple): Range of values where perforations are present.
             filterlogname (str): General filter, work as perflog, filter on values > 0
+            filterlogrange (tuple): Range of values where filter shall be present.
             resultformat (int): If 1, consider the zonelogrange in the well as
                 basis for match ratio, return (percent, match count, total count).
                 If 2 then a dictionary is returned with various result members
@@ -1774,6 +1780,7 @@ class Grid(Grid3D):
                 print(response)
 
         .. versionchanged:: 2.8.0 Added several new keys and better precision in result
+        .. versionchanged:: 2.11.0 Added ``perflogrange`` and ``filterlogrange``
         """
 
         reports = _grid_wellzone.report_zone_mismatch(
@@ -1786,7 +1793,9 @@ class Grid(Grid3D):
             zonelogshift=zonelogshift,
             depthrange=depthrange,
             perflogname=perflogname,
+            perflogrange=perflogrange,
             filterlogname=filterlogname,
+            filterlogrange=filterlogrange,
             resultformat=resultformat,
         )
 


### PR DESCRIPTION
Fixed a compatibility issue with pandas version < 0.23 (as RMS uses 0.21.0). Added two new keys to report_zonemismatch function