### PR TITLE
Fix an issue wrt #426

### DIFF
--- a/src/xtgeo/surface/_regsurf_cube_window_v2.py
+++ b/src/xtgeo/surface/_regsurf_cube_window_v2.py
@@ -83,14 +83,11 @@ def slice_cube_window(
             deadtraces,
         )
 
-    if isinstance(attrs, dict) and len(attrs) == 1:
+    # if attribute is str, self shall be updated and None returned, otherwise a dict
+    # of attributes objects shall be returned
+    if isinstance(attrs, dict) and len(attrs) == 1 and isinstance(attribute, str):
 
-        if isinstance(attribute, list):
-            myattr = attribute[0]
-        else:
-            myattr = attribute
-
-        self.values = attrs[myattr].values
+        self.values = attrs[attribute].values
         return None
 
     return attrs
@@ -120,6 +117,7 @@ def _slice_cube_window(
 
     logger.info("Slice cube window method v2")
 
+    olddead = None
     if deadtraces:
         olddead = cube.values_dead_traces(xtgeo.UNDEF)
 

--- a/tests/test_surface/test_regular_surface_vs_cube.py
+++ b/tests/test_surface/test_regular_surface_vs_cube.py
@@ -326,9 +326,21 @@ def test_slice_attr_window_max(load_cube_rsgy1):
     logger.info("Loading cube")
     kube = load_cube_rsgy1
 
-    xs1.slice_cube_window(kube, attribute="max", sampling="trilinear", algorithm=2)
+    ret = xs1.slice_cube_window(
+        kube, attribute="max", sampling="trilinear", algorithm=2
+    )
     logger.info(xs1.values.mean())
-    tsetup.assert_almostequal(xs1.values.mean(), 0.08494559, 0.01)
+    assert ret is None
+    tsetup.assert_almostequal(xs1.values.mean(), 0.08619, 0.001)
+
+    # one attribute but in a list context shall return a dict
+    xs1 = RegularSurface(RTOP1)
+    ret = xs1.slice_cube_window(
+        kube, attribute=["max"], sampling="trilinear", algorithm=2
+    )
+    assert isinstance(ret, dict)
+
+    tsetup.assert_almostequal(ret["max"].values.mean(), 0.08619, 0.001)
 
 
 @tsetup.bigtest

--- a/tests/test_surface/test_surface_cube_attrs.py
+++ b/tests/test_surface/test_surface_cube_attrs.py
@@ -110,7 +110,7 @@ def test_various_attrs_algorithm2(loadsfile1):
         cube1,
         other=surf2,
         other_position="below",
-        attribute=["mean"],
+        attribute="mean",
         sampling="trilinear",
         snapxy=True,
         ndiv=None,


### PR DESCRIPTION
If `attribute` is given in list context, a dict shall be returned even if there is just one attribute, #426