### PR TITLE
Add testKomodo.sh file

### DIFF
--- a/ci/jenkins/testkomodo.sh
+++ b/ci/jenkins/testkomodo.sh
@@ -1,0 +1,38 @@
+copy_test_files () {
+    mkdir $CI_TEST_ROOT/testpath/
+
+    pushd $CI_TEST_ROOT/testpath
+    cp -r $CI_SOURCE_ROOT/tests tests
+    ln -s $CI_SOURCE_ROOT/examples
+    ln -s $CI_SOURCE_ROOT/xtgeo-testdata
+    git clone --depth=1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+    popd
+}
+
+install_package () {
+    pip install .
+}
+
+install_test_dependencies () {
+    pip install -r requirements_dev.txt
+}
+
+start_tests () {
+    pushd $CI_TEST_ROOT/testpath
+    pytest -vv
+    popd
+}
+
+run_tests() {
+    copy_test_files
+
+    if [ ! -z "${CI_PR_RUN:-}" ]
+    then
+        install_package
+    fi
+
+    install_test_dependencies
+
+    pushd $CI_TEST_ROOT
+    start_tests
+}

--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
+import hashlib
 import os
 import pathlib
-import hashlib
-
 
 import pytest
+
+import tests.test_common.test_xtg as tsetup
 import xtgeo
 import xtgeo.common.sys as xsys
-import tests.test_common.test_xtg as tsetup
 
 TRAVIS = False
 if "TRAVISRUN" in os.environ:
@@ -43,11 +43,13 @@ def test_generic_hash():
 def test_resolve_alias():
     """Testing resolving file alias function."""
     surf = xtgeo.RegularSurface(TESTSURF)
+    md5hash = surf.generate_hash("md5")
+
     mname = xtgeo._XTGeoFile("whatever/$md5sum.gri", obj=surf)
-    assert str(mname.file) == "whatever/df7e74965672a965afd758c1f62d32a0.gri"
+    assert str(mname.file) == f"whatever/{md5hash}.gri"
 
     mname = xtgeo._XTGeoFile(pathlib.Path("whatever/$md5sum.gri"), obj=surf)
-    assert str(mname.file) == "whatever/df7e74965672a965afd758c1f62d32a0.gri"
+    assert str(mname.file) == f"whatever/{md5hash}.gri"
 
     mname = xtgeo._XTGeoFile("whatever/$random.gri", obj=surf)
     assert len(str(mname.file)) == 45


### PR DESCRIPTION
Add testKomodo.sh used for the komodo test framework to run tests after building a new komodo release.