### PR TITLE
Add testdatapath to pytest options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,24 @@ def fixture_demo():
         demo
     """
     print("THIS IS A DEMO")
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--testdatapath",
+        help="path to xtgeo-testdata, defaults to ../xtgeo-testdata"
+        "and is overriden by the XTG_TESTPATH environment variable."
+        "Experimental feature, not all tests obey this option.",
+        action="store",
+        default="../xtgeo-testdata",
+    )
+
+
+@pytest.fixture()
+def testpath(request):
+    testdatapath = request.config.getoption("--testdatapath")
+    environ_path = os.environ.get("XTG_TESTPATH", None)
+    if environ_path:
+        testdatapath = environ_path
+
+    return testdatapath

--- a/tests/test_grid3d/test_grid_dualporo.py
+++ b/tests/test_grid3d/test_grid_dualporo.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from __future__ import absolute_import, division, print_function
 
 import itertools
 import os
@@ -7,6 +6,7 @@ from os.path import basename, join
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_grid3d/test_grid_dualporo.py
+++ b/tests/test_grid3d/test_grid_dualporo.py
@@ -1,12 +1,14 @@
 # coding: utf-8
+from __future__ import absolute_import, division, print_function
 
-
+import itertools
 import os
-import numpy as np
+from os.path import basename, join
 
+import numpy as np
+import pytest
 import xtgeo
 from xtgeo.common import XTGeoDialog
-import tests.test_common.test_xtg as tsetup
 
 xtg = XTGeoDialog()
 logger = xtg.basiclogger(__name__)
@@ -14,292 +16,264 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     raise SystemExit
 
-TMPDIR = xtg.tmpdir
-TPATH = xtg.testpathobj
 
-DUALFILE1 = TPATH / "3dgrids/etc/TEST_DP"
-DUALFILE2 = TPATH / "3dgrids/etc/TEST_DPDK"  # dual poro + dual perm oil/water
-DUALFILE3 = TPATH / "3dgrids/etc/TEST2_DPDK_WG"  # aa but gas/water
-
-# =============================================================================
-# Do tests
-# =============================================================================
+@pytest.fixture
+def grids_etc_path(testpath):
+    return join(testpath, "3dgrids", "etc")
 
 
-def test_import_dualporo_grid():
-    """Test grid with flag for dual porosity setup, oil water"""
+@pytest.fixture
+def dual_poro_path(grids_etc_path):
+    return join(grids_etc_path, "TEST_DP")
 
-    grd = xtgeo.grid_from_file(DUALFILE1.with_suffix(".EGRID"))
 
-    assert grd.dualporo is True
-    assert grd.dualperm is False
-    assert grd.dimensions == (5, 3, 1)
+@pytest.fixture
+def dual_poro_dual_perm_path(dual_poro_path):
+    return dual_poro_path + "DK"
 
-    poro = xtgeo.gridproperty_from_file(
-        DUALFILE1.with_suffix(".INIT"), grid=grd, name="PORO"
+
+@pytest.fixture
+def dual_poro_dual_perm_wg_path(grids_etc_path):
+    # same as dual_poro_dual_perm but with water/gas
+    # instead of oil/water
+    return join(grids_etc_path, "TEST2_DPDK_WG")
+
+
+class GridCase:
+    def __init__(self, path, expected_dimensions, expected_perm):
+        self.path = path
+        self.expected_dimensions = expected_dimensions
+        self.expected_perm = expected_perm
+
+    @property
+    def grid(self):
+        return xtgeo.grid3d.Grid(self.path + ".EGRID")
+
+    def get_property_from_init(self, name, **kwargs):
+        return xtgeo.gridproperty_from_file(
+            self.path + ".INIT", grid=self.grid, name=name, **kwargs
+        )
+
+    def get_property_from_restart(self, name, date, **kwargs):
+
+        return xtgeo.gridproperty_from_file(
+            self.path + ".UNRST", grid=self.grid, date=date, name=name, **kwargs
+        )
+
+
+@pytest.fixture
+def dual_poro_case(dual_poro_path):
+    return GridCase(dual_poro_path, (5, 3, 1), False)
+
+
+@pytest.fixture
+def dual_poro_dual_perm_case(dual_poro_dual_perm_path):
+    return GridCase(dual_poro_dual_perm_path, (5, 3, 1), True)
+
+
+@pytest.fixture
+def dual_poro_dual_perm_wg_case(dual_poro_dual_perm_wg_path):
+    return GridCase(dual_poro_dual_perm_wg_path, (5, 3, 1), True)
+
+
+@pytest.fixture(
+    params=[
+        "dual_poro_case",
+        "dual_poro_dual_perm_case",
+        "dual_poro_dual_perm_wg_case",
+    ]
+)
+def dual_cases(request):
+    return request.getfixturevalue(request.param)
+
+
+def test_dual_cases_general_grid(tmpdir, dual_cases):
+    assert dual_cases.grid.dimensions == dual_cases.expected_dimensions
+    assert dual_cases.grid.dualporo is True
+    assert dual_cases.grid.dualperm is dual_cases.expected_perm
+
+    dual_cases.grid.to_file(join(tmpdir, basename(dual_cases.path)) + ".roff")
+    dual_cases.grid._dualactnum.to_file(
+        join(tmpdir, basename(dual_cases.path) + "dualact.roff")
     )
 
-    tsetup.assert_almostequal(poro.values[0, 0, 0], 0.1, 0.001)
-    tsetup.assert_almostequal(poro.values[1, 1, 0], 0.16, 0.001)
-    tsetup.assert_almostequal(poro.values[4, 2, 0], 0.24, 0.001)
-    assert poro.name == "POROM"
-    poro.describe()
 
-    poro = xtgeo.gridproperty_from_file(
-        DUALFILE1.with_suffix(".INIT"), grid=grd, name="PORO", fracture=True
+@pytest.mark.parametrize(
+    "date, name, fracture",
+    itertools.product([20170121, 20170131], ["SGAS", "SOIL", "SWAT"], [True, False]),
+)
+def test_dual_cases_restart_property_to_file(tmpdir, dual_cases, date, name, fracture):
+    prop = dual_cases.get_property_from_restart(name, date=date, fracture=fracture)
+    prop.describe()
+
+    if fracture:
+        assert prop.name == f"{name}F_{date}"
+    else:
+        assert prop.name == f"{name}M_{date}"
+
+    filename = join(tmpdir, basename(dual_cases.path) + str(date) + prop.name + ".roff")
+    prop.to_file(filename)
+
+    assert os.path.exists(filename)
+
+
+@pytest.mark.parametrize(
+    "name, fracture",
+    itertools.product(["PORO", "PERMX", "PERMY", "PERMZ"], [True, False]),
+)
+def test_dual_cases_init_property_to_file(tmpdir, dual_cases, name, fracture):
+    prop = dual_cases.get_property_from_init(name, fracture=fracture)
+    prop.describe()
+
+    if fracture:
+        assert prop.name == f"{name}F"
+    else:
+        assert prop.name == f"{name}M"
+
+    filename = join(tmpdir, basename(dual_cases.path) + prop.name + ".roff")
+    prop.to_file(filename)
+    assert os.path.exists(filename)
+
+
+def test_dual_grid_poro_property(tmpdir, dual_cases):
+    poro = dual_cases.get_property_from_init("PORO")
+
+    assert poro.values[0, 0, 0] == pytest.approx(0.1)
+    assert poro.values[1, 1, 0] == pytest.approx(0.16)
+    assert poro.values[4, 2, 0] == pytest.approx(0.24)
+
+
+def test_dual_grid_fractured_poro_property(tmpdir, dual_cases):
+    poro = dual_cases.get_property_from_init("PORO", fracture=True)
+
+    assert poro.values[0, 0, 0] == pytest.approx(0.25)
+    assert poro.values[4, 2, 0] == pytest.approx(0.39)
+
+
+def test_dualperm_fractured_poro_values(dual_poro_dual_perm_case):
+    poro = dual_poro_dual_perm_case.get_property_from_init(name="PORO", fracture=True)
+    assert poro.values[3, 0, 0] == pytest.approx(0.0)
+
+
+def test_dual_case_swat_values(dual_poro_case):
+    swat = dual_poro_case.get_property_from_restart("SWAT", date=20170121)
+    assert swat.values[0, 0, 0] == pytest.approx(0.609244)
+
+
+def test_dual_case_fractured_swat_values(dual_poro_case):
+    swat = dual_poro_case.get_property_from_restart(
+        "SWAT", date=20170121, fracture=True
     )
+    assert swat.values[0, 0, 0] == pytest.approx(0.989687)
 
-    tsetup.assert_almostequal(poro.values[0, 0, 0], 0.25, 0.001)
-    tsetup.assert_almostequal(poro.values[4, 2, 0], 0.39, 0.001)
-    assert poro.name == "POROF"
-    poro.describe()
 
-    swat = xtgeo.gridproperty_from_file(
-        DUALFILE1.with_suffix(".UNRST"),
-        grid=grd,
-        name="SWAT",
-        date=20170121,
-        fracture=False,
+def test_dualperm_swat_property(dual_poro_dual_perm_case):
+    swat = dual_poro_dual_perm_case.get_property_from_restart("SWAT", date=20170121)
+    assert swat.values[3, 0, 0] == pytest.approx(0.5547487)
+
+
+def test_dualperm_fractured_swat_property(dual_poro_dual_perm_case):
+    swat = dual_poro_dual_perm_case.get_property_from_restart(
+        "SWAT", date=20170121, fracture=True
     )
-    swat.describe()
-    tsetup.assert_almostequal(swat.values[0, 0, 0], 0.60924, 0.001)
+    assert swat.values[3, 0, 0] == pytest.approx(0.0)
 
-    swat = xtgeo.gridproperty_from_file(
-        DUALFILE1.with_suffix(".UNRST"),
-        grid=grd,
-        name="SWAT",
-        date=20170121,
-        fracture=True,
+
+def test_dualperm_wg_swat_property(dual_poro_dual_perm_wg_case):
+    swat = dual_poro_dual_perm_wg_case.get_property_from_restart("SWAT", date=20170121)
+    assert swat.values[3, 0, 0] == pytest.approx(0.933606)
+    assert swat.values[0, 1, 0] == pytest.approx(0.0)
+    assert swat.values[4, 2, 0] == pytest.approx(0.89304)
+
+
+def test_dualperm_wg_fractured_swat_property(dual_poro_dual_perm_wg_case):
+    swat = dual_poro_dual_perm_wg_case.get_property_from_restart(
+        "SWAT", date=20170121, fracture=True
     )
-    swat.describe()
-    tsetup.assert_almostequal(swat.values[0, 0, 0], 0.989687, 0.001)
-    swat.to_file("TMP/swat.roff")
+    assert swat.values[3, 0, 0] == pytest.approx(0.0)
+    assert swat.values[0, 1, 0] == pytest.approx(0.99818)
+    assert swat.values[4, 2, 0] == pytest.approx(0.821589)
 
 
-def test_import_dualperm_grid():
-    """Test grid with flag for dual perm setup (hence dual poro also) water/oil"""
+def test_dual_case_perm_property(tmpdir, dual_cases):
+    perm = dual_cases.get_property_from_init("PERMX")
 
-    grd = xtgeo.grid_from_file(DUALFILE2.with_suffix(".EGRID"))
+    assert perm.values[0, 0, 0] == pytest.approx(100.0)
+    assert perm.values[3, 0, 0] == pytest.approx(100.0)
+    assert perm.values[0, 1, 0] == pytest.approx(0.0)
+    assert perm.values[4, 2, 0] == pytest.approx(100)
 
-    assert grd.dualporo is True
-    assert grd.dualperm is True
-    assert grd.dimensions == (5, 3, 1)
-    grd.to_file(os.path.join(TMPDIR, "dual2.roff"))
 
-    poro = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".INIT"), grid=grd, name="PORO"
-    )
-    print(poro.values)
+def test_dual_case_fractured_perm_property(tmpdir, dual_cases):
+    perm = dual_cases.get_property_from_init("PERMX", fracture=True)
 
-    tsetup.assert_almostequal(poro.values[0, 0, 0], 0.1, 0.001)
-    tsetup.assert_almostequal(poro.values[1, 1, 0], 0.16, 0.001)
-    tsetup.assert_almostequal(poro.values[4, 2, 0], 0.24, 0.001)
-    assert poro.name == "POROM"
-    poro.describe()
+    assert perm.values[0, 0, 0] == pytest.approx(100.0)
+    assert perm.values[0, 1, 0] == pytest.approx(100.0)
+    assert perm.values[4, 2, 0] == pytest.approx(100)
 
-    poro = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".INIT"), grid=grd, name="PORO", fracture=True
-    )
 
-    tsetup.assert_almostequal(poro.values[0, 0, 0], 0.25, 0.001)
-    tsetup.assert_almostequal(poro.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(poro.values[4, 2, 0], 0.39, 0.001)
-    assert poro.name == "POROF"
-    poro.describe()
+def test_dualperm_perm_property(dual_poro_dual_perm_case):
+    perm = dual_poro_dual_perm_case.get_property_from_init("PERMX", fracture=True)
+    assert perm.values[3, 0, 0] == pytest.approx(0.0)
 
-    perm = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".INIT"), grid=grd, name="PERMX"
-    )
 
-    tsetup.assert_almostequal(perm.values[0, 0, 0], 100.0, 0.001)
-    tsetup.assert_almostequal(perm.values[3, 0, 0], 100.0, 0.001)
-    tsetup.assert_almostequal(perm.values[0, 1, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(perm.values[4, 2, 0], 100, 0.001)
-    assert perm.name == "PERMXM"
-    perm.to_file(os.path.join(TMPDIR, "dual2_permxm.roff"))
-
-    perm = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".INIT"), grid=grd, name="PERMX", fracture=True
-    )
-
-    tsetup.assert_almostequal(perm.values[0, 0, 0], 100.0, 0.001)
-    tsetup.assert_almostequal(perm.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(perm.values[0, 1, 0], 100.0, 0.001)
-    tsetup.assert_almostequal(perm.values[4, 2, 0], 100, 0.001)
-    assert perm.name == "PERMXF"
-    perm.to_file(os.path.join(TMPDIR, "dual2_permxf.roff"))
-
-    swat = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SWAT",
-        date=20170121,
-        fracture=False,
-    )
-    tsetup.assert_almostequal(swat.values[3, 0, 0], 0.55475, 0.001)
-
-    soil = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SOIL",
-        date=20170121,
-        fracture=False,
-    )
-    print(soil.values)
-    tsetup.assert_almostequal(soil.values[3, 0, 0], 0.44525, 0.001)
-    tsetup.assert_almostequal(soil.values[0, 1, 0], 0.0, 0.001)
+def test_dualperm_soil_property(dual_poro_dual_perm_case):
+    soil = dual_poro_dual_perm_case.get_property_from_restart("SOIL", date=20170121)
+    assert soil.values[3, 0, 0] == pytest.approx(0.4452512)
+    assert soil.values[0, 1, 0] == pytest.approx(0.0)
     assert np.ma.is_masked(soil.values[1, 2, 0])
-    tsetup.assert_almostequal(soil.values[3, 2, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(soil.values[4, 2, 0], 0.41271, 0.001)
+    assert soil.values[3, 2, 0] == pytest.approx(0.0)
+    assert soil.values[4, 2, 0] == pytest.approx(0.4127138)
 
-    swat = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SWAT",
-        date=20170121,
-        fracture=True,
+
+def test_dualperm_fractured_soil_property(dual_poro_dual_perm_case):
+    soil = dual_poro_dual_perm_case.get_property_from_restart(
+        "SOIL", date=20170121, fracture=True
     )
-    swat.describe()
-    assert "SWATF" in swat.name
-
-    tsetup.assert_almostequal(swat.values[3, 0, 0], 0.0, 0.001)
-    swat.to_file("TMP/swat.roff")
+    assert soil.values[3, 0, 0] == pytest.approx(0.0)
+    assert soil.values[0, 1, 0] == pytest.approx(0.01174145)
+    assert soil.values[3, 2, 0] == pytest.approx(0.11676442)
 
 
-def test_import_dualperm_grid_soil():
-    """Test grid with flag for dual perm setup (will also mean dual poro also)"""
+def test_dualpermwg_soil_property(dual_poro_dual_perm_wg_case):
+    soil = dual_poro_dual_perm_wg_case.get_property_from_restart("SOIL", date=20170121)
+    assert soil.values[3, 0, 0] == pytest.approx(0.0)
+    assert soil.values[0, 1, 0] == pytest.approx(0.0)
 
-    grd = xtgeo.grid_from_file(DUALFILE2.with_suffix(".EGRID"))
-    grd._dualactnum.to_file("TMP/dualact.roff")
 
-    sgas = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SGAS",
-        date=20170121,
-        fracture=False,
+def test_dualpermwg_fractured_soil_property(dual_poro_dual_perm_wg_case):
+    soil = dual_poro_dual_perm_wg_case.get_property_from_restart(
+        "SOIL", date=20170121, fracture=True
     )
-    sgas.describe()
-    tsetup.assert_almostequal(sgas.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(sgas.values[0, 1, 0], 0.0, 0.001)
+    assert soil.values[3, 0, 0] == pytest.approx(0.0)
+    assert soil.values[0, 1, 0] == pytest.approx(0.0)
 
-    soil = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SOIL",
-        date=20170121,
-        fracture=False,
+
+def test_dualperm_sgas_property(dual_poro_dual_perm_case):
+    sgas = dual_poro_dual_perm_case.get_property_from_restart("SGAS", date=20170121)
+    assert sgas.values[3, 0, 0] == pytest.approx(0.0)
+    assert sgas.values[0, 1, 0] == pytest.approx(0.0)
+
+
+def test_dualperm_fractured_sgas_property(dual_poro_dual_perm_case):
+    sgas = dual_poro_dual_perm_case.get_property_from_restart(
+        "SGAS", date=20170121, fracture=True
     )
-    soil.describe()
-    tsetup.assert_almostequal(soil.values[3, 0, 0], 0.44525, 0.001)
-    tsetup.assert_almostequal(soil.values[0, 1, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(soil.values[3, 2, 0], 0.0, 0.0001)
+    assert sgas.values[3, 0, 0] == pytest.approx(0.0)
+    assert sgas.values[0, 1, 0] == pytest.approx(0.0)
 
-    # fractures
 
-    sgas = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SGAS",
-        date=20170121,
-        fracture=True,
+def test_dualperm_wg_sgas_property(dual_poro_dual_perm_wg_case):
+    sgas = dual_poro_dual_perm_wg_case.get_property_from_restart("SGAS", date=20170121)
+    assert sgas.values[3, 0, 0] == pytest.approx(0.0663941)
+    assert sgas.values[0, 1, 0] == pytest.approx(0.0)
+    assert sgas.values[4, 2, 0] == pytest.approx(0.1069594)
+
+
+def test_dualperm_wg_fractured_sgas_property(dual_poro_dual_perm_wg_case):
+    sgas = dual_poro_dual_perm_wg_case.get_property_from_restart(
+        "SGAS", date=20170121, fracture=True
     )
-    tsetup.assert_almostequal(sgas.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(sgas.values[0, 1, 0], 0.0, 0.0001)
-
-    soil = xtgeo.gridproperty_from_file(
-        DUALFILE2.with_suffix(".UNRST"),
-        grid=grd,
-        name="SOIL",
-        date=20170121,
-        fracture=True,
-    )
-    tsetup.assert_almostequal(soil.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(soil.values[0, 1, 0], 0.011741, 0.0001)
-    tsetup.assert_almostequal(soil.values[3, 2, 0], 0.11676, 0.0001)
-
-
-def test_import_dualperm_grid_sgas():
-    """Test grid with flag for dual perm/poro setup gas/water"""
-
-    grd = xtgeo.grid_from_file(DUALFILE3.with_suffix(".EGRID"))
-
-    sgas = xtgeo.gridproperty_from_file(
-        DUALFILE3.with_suffix(".UNRST"),
-        grid=grd,
-        name="SGAS",
-        date=20170121,
-        fracture=False,
-    )
-    sgas.describe()
-    tsetup.assert_almostequal(sgas.values[3, 0, 0], 0.06639, 0.001)
-    tsetup.assert_almostequal(sgas.values[0, 1, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(sgas.values[4, 2, 0], 0.10696, 0.001)
-    assert "SGASM in sgas.name"
-
-    swat = xtgeo.gridproperty_from_file(
-        DUALFILE3.with_suffix(".UNRST"),
-        grid=grd,
-        name="SWAT",
-        date=20170121,
-        fracture=False,
-    )
-    swat.describe()
-    tsetup.assert_almostequal(swat.values[3, 0, 0], 0.93361, 0.001)
-    tsetup.assert_almostequal(swat.values[0, 1, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(swat.values[4, 2, 0], 0.89304, 0.001)
-    assert "SWATM in swat.name"
-
-    # shall be not soil actually
-    soil = xtgeo.gridproperty_from_file(
-        DUALFILE3.with_suffix(".UNRST"),
-        grid=grd,
-        name="SOIL",
-        date=20170121,
-        fracture=False,
-    )
-    soil.describe()
-    tsetup.assert_almostequal(soil.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(soil.values[0, 1, 0], 0.0, 0.001)
-    assert "SOILM" in soil.name
-
-    # fractures
-
-    sgas = xtgeo.gridproperty_from_file(
-        DUALFILE3.with_suffix(".UNRST"),
-        grid=grd,
-        name="SGAS",
-        date=20170121,
-        fracture=True,
-    )
-    sgas.describe()
-    tsetup.assert_almostequal(sgas.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(sgas.values[0, 1, 0], 0.0018198, 0.001)
-    tsetup.assert_almostequal(sgas.values[4, 2, 0], 0.17841, 0.001)
-    assert "SGASF" in sgas.name
-
-    swat = xtgeo.gridproperty_from_file(
-        DUALFILE3.with_suffix(".UNRST"),
-        grid=grd,
-        name="SWAT",
-        date=20170121,
-        fracture=True,
-    )
-    swat.describe()
-    tsetup.assert_almostequal(swat.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(swat.values[0, 1, 0], 0.99818, 0.001)
-    tsetup.assert_almostequal(swat.values[4, 2, 0], 0.82159, 0.001)
-    assert "SWATF" in swat.name
-
-    # shall be not soil actually
-    soil = xtgeo.gridproperty_from_file(
-        DUALFILE3.with_suffix(".UNRST"),
-        grid=grd,
-        name="SOIL",
-        date=20170121,
-        fracture=True,
-    )
-    soil.describe()
-    tsetup.assert_almostequal(soil.values[3, 0, 0], 0.0, 0.001)
-    tsetup.assert_almostequal(soil.values[0, 1, 0], 0.0, 0.001)
-    assert "SOILF" in soil.name
+    assert sgas.values[3, 0, 0] == pytest.approx(0.0)
+    assert sgas.values[0, 1, 0] == pytest.approx(0.00181985)
+    assert sgas.values[4, 2, 0] == pytest.approx(0.178411)


### PR DESCRIPTION
Adresses #478 

In order to more easily set the path to location of xtgeo-testdata, a fixture containing the path, set by the environment/cli-options is added. Currently, some tests assume the location is `../xtgeo-testdata` and some use the environment variable `XTG_TESTPATH`. The idea is to move all useage of xtgeo-testdata to get the path through fixtures.