### PR TITLE
TST: Refactor test_system to use testdata fixture

### DIFF
--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -65,52 +65,31 @@ def fixture_reek_grid_path(testpath):
     return pathlib.Path(testpath) / "3dgrids/reek"
 
 
-@pytest.mark.parametrize(
-    "filename, does_exist",
-    [
-        ("REEK.EGRID", True),
-        ("", True),
-        ("NOSUCH.EGRID", False),
-        ("NOSUCH/NOSUCH.EGRID", False),
-    ],
-)
-def test_file_exist(reek_grid_path, filename, does_exist):
+@pytest.mark.parametrize("filename", ["REEK.EGRID", "."])
+def test_file_does_exist(reek_grid_path, filename):
     xtgeo_file = xtgeo._XTGeoFile(reek_grid_path / filename)
-    assert xtgeo_file.exists() is does_exist
+    assert xtgeo_file.exists() is True
 
 
-@pytest.mark.parametrize(
-    "filename, check_ok",
-    [
-        ("REEK.EGRID", True),
-        ("NOSUCH.EGRID", False),
-        ("NOSUCH/NOSUCH.EGRID", False),
-    ],
-)
-def test_check_file(reek_grid_path, filename, check_ok):
+@pytest.mark.parametrize("filename", ["NOSUCH.EGRID", "NOSUCH/NOSUCH.EGRID"])
+def test_file_does_not_exist(reek_grid_path, filename):
     xtgeo_file = xtgeo._XTGeoFile(reek_grid_path / filename)
-    assert xtgeo_file.check_file() is check_ok
-
-    if not check_ok:
-        with pytest.raises(OSError):
-            xtgeo_file.check_file(raiseerror=OSError)
+    assert xtgeo_file.exists() is False
 
 
-@pytest.mark.parametrize(
-    "filename, check_ok",
-    [
-        ("REEK.EGRID", True),
-        ("NOSUCH.EGRID", True),
-        ("NOSUCH/NOSUCH.EGRID", False),
-    ],
-)
-def test_check_folder(reek_grid_path, filename, check_ok):
+@pytest.mark.parametrize("filename", ["REEK.EGRID", "REEK.INIT"])
+def test_check_file_is_ok(reek_grid_path, filename):
     xtgeo_file = xtgeo._XTGeoFile(reek_grid_path / filename)
-    assert xtgeo_file.check_folder() is check_ok
+    assert xtgeo_file.check_file() is True
 
-    if not check_ok:
-        with pytest.raises(OSError):
-            xtgeo_file.check_folder(raiseerror=OSError)
+
+@pytest.mark.parametrize("filename", ["NOSUCH.EGRID", "NOSUCH/NOSUCH.EGRID"])
+def test_check_file(reek_grid_path, filename):
+    xtgeo_file = xtgeo._XTGeoFile(reek_grid_path / filename)
+    assert xtgeo_file.check_file() is False
+
+    with pytest.raises(OSError):
+        xtgeo_file.check_file(raiseerror=OSError)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -1,36 +1,15 @@
 # -*- coding: utf-8 -*-
 import hashlib
-import os
-import pathlib
 import io
+import pathlib
+from os.path import abspath, join
 
 import pytest
 
-import tests.test_common.test_xtg as tsetup
 import xtgeo
 import xtgeo.common.sys as xsys
 
 xtg = xtgeo.XTGeoDialog()
-
-TRAVIS = False
-if "TRAVISRUN" in os.environ:
-    TRAVIS = True
-
-TPATH = xtg.testpathobj
-TMPD = xtg.tmpdirobj
-
-TEST_ECL_ROOT = TPATH / "3dgrids/reek/REEK"
-TESTFILE = TPATH / "3dgrids/reek/REEK.EGRID"
-TESTFOLDER = TPATH / "3dgrids/reek"
-TESTNOEXISTFILE = TPATH / "3dgrids/reek/NOSUCH.EGRID"
-TESTNOEXISTFOLDER = TPATH / "3dgrids/noreek/NOSUCH.EGRID"
-TESTSURF = TPATH / "surfaces/reek/1/topupperreek.gri"
-TESTSURF2 = TPATH / "surfaces/reek/1/reek_stooip_map.gri"
-TESTSURF3 = TPATH / "surfaces/etc/seabed_p.pmd"
-TESTROFFGRIDB = TPATH / "3dgrids/reek/reek_geo_grid.roff"
-TESTROFFGRIDA = TPATH / "3dgrids/reek/reek_geogrid.roffasc"
-TESTWELL1 = TPATH / "wells/battle/1/WELL12.rmswell"
-MDFILE = TPATH / "README.md"  # to test a file not relevant for fformat
 
 
 def test_generic_hash():
@@ -52,9 +31,17 @@ def test_generic_hash():
     assert ahash == "fd6639af1cc457b72148d78e90df45df4d344ca3b66fa44598148ce4"
 
 
-def test_resolve_alias():
+surface_files_formats = {
+    join("surfaces", "reek", "1", "topupperreek.gri"): "irap_binary",
+    join("surfaces", "reek", "1", "reek_stooip_map.gri"): "irap_binary",
+    join("surfaces", "etc", "seabed_p.pmd"): "petromod",
+}
+
+
+@pytest.mark.parametrize("filename", surface_files_formats.keys())
+def test_resolve_alias(testpath, filename):
     """Testing resolving file alias function."""
-    surf = xtgeo.RegularSurface(TESTSURF)
+    surf = xtgeo.RegularSurface(join(testpath, filename))
     md5hash = surf.generate_hash("md5")
 
     mname = xtgeo._XTGeoFile("whatever/$md5sum.gri", obj=surf)
@@ -74,180 +61,164 @@ def test_resolve_alias():
     assert str(mname.file) == "whatever/topvalysar--depth_surface.gri"
 
 
-@tsetup.skipifmac
-@tsetup.skipifwindows
-def test_xtgeocfile():
-    """Test basic system file io etc functions."""
-    gfile = xtgeo._XTGeoFile(TESTFILE)
-    xfile = xtgeo._XTGeoFile(TESTNOEXISTFILE)
-    yfile = xtgeo._XTGeoFile(TESTNOEXISTFOLDER)
-    gfolder = xtgeo._XTGeoFile(TESTFOLDER)
+@pytest.fixture
+def reek_grid_path(testpath):
+    return join(testpath, "3dgrids", "reek")
+
+
+@pytest.mark.parametrize(
+    "filename, does_exist",
+    [
+        ("REEK.EGRID", True),
+        ("", True),
+        ("NOSUCH.EGRID", False),
+        (join("NOSUCH", "NOSUCH.EGRID"), False),
+    ],
+)
+def test_file_exist(reek_grid_path, filename, does_exist):
+    xtgeo_file = xtgeo._XTGeoFile(join(reek_grid_path, filename))
+    assert xtgeo_file.exists() is does_exist
+
+
+@pytest.mark.parametrize(
+    "filename, check_ok",
+    [
+        ("REEK.EGRID", True),
+        ("NOSUCH.EGRID", False),
+        (join("NOSUCH", "NOSUCH.EGRID"), False),
+    ],
+)
+def test_check_file(reek_grid_path, filename, check_ok):
+    xtgeo_file = xtgeo._XTGeoFile(join(reek_grid_path, filename))
+    assert xtgeo_file.check_file() is check_ok
+
+    if not check_ok:
+        with pytest.raises(OSError):
+            xtgeo_file.check_file(raiseerror=OSError)
+
+
+@pytest.mark.parametrize(
+    "filename, check_ok",
+    [
+        ("REEK.EGRID", True),
+        ("NOSUCH.EGRID", True),
+        (join("NOSUCH", "NOSUCH.EGRID"), False),
+    ],
+)
+def test_check_folder(reek_grid_path, filename, check_ok):
+    xtgeo_file = xtgeo._XTGeoFile(join(reek_grid_path, filename))
+    assert xtgeo_file.check_folder() is check_ok
+
+    if not check_ok:
+        with pytest.raises(OSError):
+            xtgeo_file.check_folder(raiseerror=OSError)
+
+
+@pytest.mark.parametrize(
+    "filename, stem, extension",
+    [
+        (join("3dgrids", "reek", "REEK.EGRID"), "REEK", "EGRID"),
+        (join("/tmp", "text.txt"), "text", "txt"),
+        (join("/tmp", "null"), "null", ""),
+    ],
+)
+def test_file_splitext(filename, stem, extension):
+    xtgeo_file = xtgeo._XTGeoFile(filename)
+    assert (stem, extension) == xtgeo_file.splitext(lower=False)
+
+
+files_formats = dict(
+    surface_files_formats,
+    **{
+        join("3dgrids", "reek", "REEK.EGRID"): "egrid",
+        join("3dgrids", "reek", "REEK.UNRST"): "unrst",
+        join("3dgrids", "reek", "REEK.INIT"): "init",
+        join("3dgrids", "reek", "reek_geo_grid.roff"): "roff_binary",
+        join("3dgrids", "reek", "reek_geogrid.roffasc"): "roff_ascii",
+        join("wells", "battle", "1", "WELL12.rmswell"): "rmswell",
+    },
+)
+
+
+@pytest.mark.parametrize("filename", files_formats.keys())
+def xtgeo_file_properties(testpath, filename):
+    gfile = xtgeo._XTGeoFile(join(testpath, filename))
 
     assert isinstance(gfile, xtgeo._XTGeoFile)
-
     assert isinstance(gfile._file, pathlib.Path)
 
     assert gfile._memstream is False
     assert gfile._mode == "rb"
     assert gfile._delete_after is False
-    assert gfile.name == os.path.abspath(TESTFILE)
-    assert xfile.name == os.path.abspath(TESTNOEXISTFILE)
-
-    # exists, check_*
-    assert gfile.exists() is True
-    assert gfolder.exists() is True
-    assert xfile.exists() is False
-
-    assert gfile.check_file() is True
-    assert xfile.check_file() is False
-    assert yfile.check_file() is False
-
-    with pytest.raises(OSError):
-        xfile.check_file(raiseerror=OSError)
-
-    assert gfile.check_folder() is True
-    assert xfile.check_folder() is True
-    assert yfile.check_folder() is False
-    with pytest.raises(OSError):
-        yfile.check_folder(raiseerror=OSError)
+    assert gfile.name == abspath(join(testpath, filename))
 
     assert "Swig" in str(gfile.get_cfhandle())
     assert gfile.cfclose() is True
 
-    # extensions:
-    stem, suff = gfile.splitext(lower=False)
-    assert stem == "REEK"
-    assert suff == "EGRID"
 
+@pytest.mark.parametrize("filename", files_formats.keys())
+def test_file_c_handle(testpath, filename):
+    any_xtgeo_file = xtgeo._XTGeoFile(join(testpath, filename))
 
-@tsetup.skipifmac
-@tsetup.skipifwindows
-def test_xtgeocfile_fhandle():
-    """Test in particular C handle SWIG system."""
+    handle_count = any_xtgeo_file._cfhandlecount
 
-    gfile = xtgeo._XTGeoFile(TESTFILE)
-    chandle1 = gfile.get_cfhandle()
-    chandle2 = gfile.get_cfhandle()
-    assert gfile._cfhandlecount == 2
-    assert chandle1 == chandle2
-    assert gfile.cfclose() is False
-    assert gfile.cfclose() is True
+    c_handle_1 = any_xtgeo_file.get_cfhandle()
+    assert handle_count + 1 == any_xtgeo_file._cfhandlecount
+
+    c_handle_2 = any_xtgeo_file.get_cfhandle()
+    assert handle_count + 2 == any_xtgeo_file._cfhandlecount
+
+    assert c_handle_1 == c_handle_2
+
+    assert any_xtgeo_file.cfclose() is False
+    assert any_xtgeo_file.cfclose() is True
 
     # try to close a cfhandle that does not exist
     with pytest.raises(RuntimeError):
-        gfile.cfclose()
+        any_xtgeo_file.cfclose()
 
 
-def test_detect_fformat():
-    """Test to guess/detect file formats based on various criteria."""
-    # irap binary as file
-    gfile = xtgeo._XTGeoFile(TESTSURF2)
-    assert gfile.detect_fformat() == "irap_binary"
-
-    # irap binary as memory stream
+@pytest.mark.parametrize("filename", surface_files_formats.keys())
+def test_surface_file_roundtrip_stream(testpath, filename):
     stream = io.BytesIO()
-    surf = xtgeo.RegularSurface(TESTSURF2)
+    surf = xtgeo.RegularSurface(join(testpath, filename))
     surf.to_file(stream)
-    sfile = xtgeo._XTGeoFile(stream)
-    assert sfile.memstream is True
-    assert sfile.detect_fformat() == "irap_binary"
+    stream_file = xtgeo._XTGeoFile(stream)
 
-    # petromod binary as file
-    gfile = xtgeo._XTGeoFile(TESTSURF3)
-    assert gfile.detect_fformat() == "petromod"
+    assert stream_file.memstream is True
+    assert stream_file.detect_fformat() == "irap_binary"
 
-    # HDF xtgeo surface file
-    newfile = TMPD / "hdf_surf.hdf"
-    surf.to_hdf(newfile)
-    gfile = xtgeo._XTGeoFile(newfile)
-    assert gfile.detect_fformat() == "hdf"
-    assert gfile.detect_fformat(details=True) == "hdf RegularSurface xtgeo"
 
-    # HDF xtgeo surface as stream
+@pytest.mark.parametrize("filename, expected_format", files_formats.items())
+def test_detect_fformat(testpath, filename, expected_format):
+    xtgeo_file = xtgeo._XTGeoFile(join(testpath, filename))
+    assert xtgeo_file.detect_fformat() == expected_format
+
+
+@pytest.mark.parametrize("filename", surface_files_formats.keys())
+def test_detect_fformat_hdf_stream(testpath, filename):
     stream = io.BytesIO()
-    surf = xtgeo.RegularSurface(TESTSURF2)
+    surf = xtgeo.RegularSurface(join(testpath, filename))
     surf.to_hdf(stream)
     sfile = xtgeo._XTGeoFile(stream)
     assert sfile.memstream is True
     assert sfile.detect_fformat() == "hdf"
 
-    # Eclipse egrid as file
-    gfile = xtgeo._XTGeoFile(TEST_ECL_ROOT.with_suffix(".EGRID"))
-    assert gfile.detect_fformat() == "egrid"
-    # Eclipse restart (unified) as file
-    gfile = xtgeo._XTGeoFile(TEST_ECL_ROOT.with_suffix(".UNRST"))
-    assert gfile.detect_fformat() == "unrst"
-    # Eclipse init as file
-    gfile = xtgeo._XTGeoFile(TEST_ECL_ROOT.with_suffix(".INIT"))
-    assert gfile.detect_fformat() == "init"
-    # Eclipse init as file, extension only
-    gfile = xtgeo._XTGeoFile(TEST_ECL_ROOT.with_suffix(".INIT"))
-    assert gfile.detect_fformat(suffixonly=True) == "init"
 
-    # ROFF bin as file
-    gfile = xtgeo._XTGeoFile(TESTROFFGRIDB)
-    assert gfile.detect_fformat() == "roff_binary"
-    # ROFF asc as file
-    gfile = xtgeo._XTGeoFile(TESTROFFGRIDA)
-    assert gfile.detect_fformat() == "roff_ascii"
-
-    # RMS ascii well file
-    wfile = xtgeo._XTGeoFile(TESTWELL1)
-    assert wfile.detect_fformat() == "rmswell"
-
-    # RMS ascii well file by suffix only
-    wfile = xtgeo._XTGeoFile(TESTWELL1)
-    assert wfile.detect_fformat(suffixonly=True) == "rmswell"
-
-    # Some invalid case
-    wfile = xtgeo._XTGeoFile(MDFILE)
-    assert wfile.detect_fformat(suffixonly=True) == "unknown"
+@pytest.mark.parametrize("filename", surface_files_formats.keys())
+def test_detect_fformat_hdf_to_file(tmpdir, testpath, filename):
+    newfile = join(tmpdir, "hdf_surf.hdf")
+    surf = xtgeo.RegularSurface(join(testpath, filename))
+    surf.to_hdf(newfile)
+    gfile = xtgeo._XTGeoFile(newfile)
+    assert gfile.detect_fformat() == "hdf"
+    assert gfile.detect_fformat(details=True) == "hdf RegularSurface xtgeo"
 
 
-# @tsetup.skipifwindows
-# @tsetup.skipifpython2
-# def test_xtgeocfile_bytesio():
-
-#     with open(TESTFILE, "rb") as fin:
-#         stream = io.BytesIO(fin.read())
-
-#     gfile = xtgeo._XTGeoFile(stream)
-
-#     assert isinstance(gfile, xtgeo._XTGeoFile)
-
-#     assert "Swig" in str(gfile.fhandle)
-
-#     assert gfile.close() is True
-
-
-# @tsetup.equinor
-# def test_check_folder():
-#     """testing that folder checks works in different scenaria"""
-
-#     status = xsys.check_folder("setup.py")
-#     assert status is True
-
-#     status = xsys.check_folder("xxxxx/whatever")
-#     assert status is False
-
-#     status = xsys.check_folder("src/xtgeo")
-#     assert status is True
-
-#     if "WINDOWS" in platform.system().upper():
-#         return
-#     if not TRAVIS:
-#         print("Non travis test")
-#         # skipped for travis, as travis runs with root rights
-#         folder = "TMP/nonwritable"
-#         myfile = os.path.join(folder, "somefile")
-#         if not os.path.exists(folder):
-#             os.mkdir(folder, 0o440)
-
-#         status = xsys.check_folder(myfile)
-#         assert status is False
-
-#         status = xsys.check_folder(folder)
-#         assert status is False
-
-#         with pytest.raises(ValueError):
-#             xsys.check_folder(folder, raiseerror=ValueError)
+@pytest.mark.parametrize(
+    "filename, expected_format",
+    list(files_formats.items()) + [("README.md", "unknown")],
+)
+def test_detect_fformat_suffix_only(testpath, filename, expected_format):
+    xtgeo_file = xtgeo._XTGeoFile(join(testpath, filename))
+    assert xtgeo_file.detect_fformat(suffixonly=True) == expected_format

--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -60,8 +60,8 @@ def test_resolve_alias(testpath, filename):
     assert str(mname.file) == "whatever/topvalysar--depth_surface.gri"
 
 
-@pytest.fixture
-def reek_grid_path(testpath):
+@pytest.fixture(name="reek_grid_path")
+def fixture_reek_grid_path(testpath):
     return pathlib.Path(testpath) / "3dgrids/reek"
 
 


### PR DESCRIPTION
Refactor of `test_system.py` to use testdata fixture. Uses parametrization to use more testdata, but executes the same tests.

This continues the work started in https://github.com/equinor/xtgeo/pull/479