### PR TITLE
Make Surfaces init more explicit

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,6 +7,7 @@ segyio>1.8.0
 pandas>=0.18
 h5py>=3
 hdf5plugin>=2.3
+typing-extensions; python_version < '3.8'
 # await pytables on pypi for PY3.9 macos, win
 tables>=3.5.1; python_version < "3.9" and platform_system != "Linux"
 tables>=3.5.1; platform_system == "Linux"

--- a/src/xtgeo/surface/_surfs_import.py
+++ b/src/xtgeo/surface/_surfs_import.py
@@ -9,8 +9,8 @@ xtg = XTGeoDialog()
 logger = xtg.functionlogger(__name__)
 
 
-def from_grid3d(self, grid, subgrids, rfactor):
-    """Get surfaces from 3D grid, including subgrids"""
+def from_grid3d(grid, subgrids, rfactor):
+    """Get surfaces, subtype and order from 3D grid, including subgrids"""
 
     logger.info("Extracting surface from 3D grid...")
 
@@ -41,8 +41,6 @@ def from_grid3d(self, grid, subgrids, rfactor):
         layer.name = names[inum]
         layerstack.append(layer)
 
-    self._surfaces = layerstack
-    self._subtype = "tops"
-    self._order = "stratigraphic"
-
     logger.info("Extracting surface from 3D grid... DONE")
+
+    return layerstack, "tops", "stratigraphic"


### PR DESCRIPTION
~~This PR is meant as a discussion topic. In several classes the construction of the objects are a bit complicated to read, and generally take in `*args` and `**kwargs`, there is nothing inherently wrong with that, but because they can be constructed in so many different ways I find it a bit hard to follow the code flow. I would propose we change to the pattern I have suggested in this PR, in that we make the constructor explicit, and provide `@classmethods` for the different initialization options instead, as that is more standard python. This is a breaking change, but I think it would be an improvement in the long run, and make it easier to extend the functionality.~~

~~To avoid having to bump the major version immediately it is possible to deprecate the old behavior by rewriting the old constructors and creating differently named functions for the `classmethods`.~~

~~So at the moment the following is not a breaking change, but it is a change in pattern.~~

We have more or less adopted this pattern, this brings Surfaces into that pattern.