### PR TITLE
API: change initialization for RegularSurface

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
+deprecation
 numpy>=1.13
 shapely>=1.6.2
 matplotlib>=1.5

--- a/src/clib/xtg/surf_export_irap_ascii.c
+++ b/src/clib/xtg/surf_export_irap_ascii.c
@@ -59,7 +59,7 @@ surf_export_irap_ascii(FILE *fc,
 
     /* local declarations */
     int i, j, ic, nn, fcode;
-    float myfloat, xmax, ymax;
+    double myfloat, xmax, ymax;
 
     logger_info(LI, FI, FU, "Write IRAP ascii map file ... (%s)", __FUNCTION__);
 
@@ -100,7 +100,7 @@ surf_export_irap_ascii(FILE *fc,
      */
 
     fprintf(fc, "%d %d %lf %lf\n", -996, my, xinc, yinc);
-    fprintf(fc, "%lf %f %lf %f\n", xori, xmax, yori, ymax);
+    fprintf(fc, "%lf %lf %lf %lf\n", xori, xmax, yori, ymax);
     fprintf(fc, "%d %lf %lf %lf\n", mx, rot, xori, yori);
     fprintf(fc, "0 0 0 0 0 0 0\n");
 

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -8,6 +8,7 @@
 
 import os
 import timeit
+import warnings
 
 
 try:
@@ -192,5 +193,6 @@ from xtgeo.xyz.polygons import polygons_from_roxar
 from xtgeo.xyz.points import points_from_file
 from xtgeo.xyz.points import points_from_roxar
 
+warnings.filterwarnings("default", category=DeprecationWarning, module="xtgeo")
 
 _xprint("XTGEO __init__ done")

--- a/src/xtgeo/common/sys.py
+++ b/src/xtgeo/common/sys.py
@@ -152,6 +152,9 @@ class _XTGeoFile(object):
         elif isinstance(fobj, io.BytesIO):
             self._file = fobj
             self._memstream = True
+        elif isinstance(fobj, io.StringIO):
+            self._file = fobj
+            self._memstream = True
         elif isinstance(fobj, _XTGeoFile):
             raise RuntimeError("Reinstancing object, not allowed", self.__class__)
         else:

--- a/src/xtgeo/surface/_regsurf_export.py
+++ b/src/xtgeo/surface/_regsurf_export.py
@@ -259,7 +259,6 @@ def _export_zmap_ascii_purepy(self, mfile):
 
     yinc = scopy._yinc * scopy._yflip
 
-    vals = scopy._values.copy()
     vals = scopy.get_values1d(order="C", asmasked=False, fill_value=undef)
 
     xmax = scopy.xori + (scopy.ncol - 1) * scopy.xinc
@@ -275,7 +274,6 @@ def _export_zmap_ascii_purepy(self, mfile):
     buf += "@\n"
 
     vals = vals.tolist()
-    ic = 0
     ncol = 0
     for icol in range(scopy.ncol):
         for jrow in range(scopy.nrow - 1, -1, -1):

--- a/src/xtgeo/surface/_regsurf_roxapi.py
+++ b/src/xtgeo/surface/_regsurf_roxapi.py
@@ -1,6 +1,5 @@
 # coding: utf-8
 """Roxar API functions for XTGeo RegularSurface."""
-import numpy as np
 from xtgeo.common import XTGeoDialog
 from xtgeo import RoxUtils
 
@@ -10,23 +9,24 @@ logger = xtg.functionlogger(__name__)
 
 
 def import_horizon_roxapi(
-    self, project, name, category, stype, realisation
+    project, name, category, stype, realisation
 ):  # pragma: no cover
     """Import a Horizon surface via ROXAR API spec."""
     rox = RoxUtils(project, readonly=True)
 
     proj = rox.project
 
-    _roxapi_import_surface(self, proj, name, category, stype, realisation)
+    args = _roxapi_import_surface(proj, name, category, stype, realisation)
 
     rox.safe_close()
+    return args
 
 
 def _roxapi_import_surface(
-    self, proj, name, category, stype, realisation
+    proj, name, category, stype, realisation
 ):  # pragma: no cover
-
-    self._name = name
+    args = {}
+    args["name"] = name
 
     if stype == "horizons":
         if name not in proj.horizons:
@@ -37,7 +37,7 @@ def _roxapi_import_surface(
             )
         try:
             rox = proj.horizons[name][category].get_grid(realisation)
-            _roxapi_horizon_to_xtgeo(self, rox)
+            args.update(_roxapi_horizon_to_xtgeo(rox))
         except KeyError as kwe:
             logger.error(kwe)
 
@@ -50,7 +50,7 @@ def _roxapi_import_surface(
             )
         try:
             rox = proj.zones[name][category].get_grid(realisation)
-            _roxapi_horizon_to_xtgeo(self, rox)
+            args.update(_roxapi_horizon_to_xtgeo(rox))
         except KeyError as kwe:
             logger.error(kwe)
 
@@ -64,25 +64,26 @@ def _roxapi_import_surface(
         else:
             rox = proj.clipboard
         roxsurf = rox[name].get_grid(realisation)
-        _roxapi_horizon_to_xtgeo(self, roxsurf)
+        args.update(_roxapi_horizon_to_xtgeo(roxsurf))
 
     else:
         raise ValueError("Invalid stype")
+    return args
 
 
-def _roxapi_horizon_to_xtgeo(self, rox):  # pragma: no cover
+def _roxapi_horizon_to_xtgeo(rox):  # pragma: no cover
     """Tranforming surfaces from ROXAPI to XTGeo object."""
     # local function
+    args = {}
     logger.info("Surface from roxapi to xtgeo...")
-    self._xori, self._yori = rox.origin
-    self._ncol, self._nrow = rox.dimensions
-    self._xinc, self._yinc = rox.increment
-    self._rotation = rox.rotation
-    self._ilines = np.array(range(1, self._ncol + 1), dtype=np.int32)
-    self._xlines = np.array(range(1, self._nrow + 1), dtype=np.int32)
+    args["xori"], args["yori"] = rox.origin
+    args["ncol"], args["nrow"] = rox.dimensions
+    args["xinc"], args["yinc"] = rox.increment
+    args["rotation"] = rox.rotation
 
-    self._values = rox.get_values()
+    args["values"] = rox.get_values()
     logger.info("Surface from roxapi to xtgeo... DONE")
+    return args
 
 
 def export_horizon_roxapi(

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -308,7 +308,7 @@ class RegularSurface:
             xinc: X increment.
             yinc: Y increment.
             yflip: If 1, the map grid is left-handed (assuming depth downwards),
-                otherwise -1 menas that Y axsis is flipped (right-handed).
+                otherwise -1 means that Y axis is flipped (right-handed).
             rotation: rotation in degrees, anticlock from X axis between 0, 360.
             values: A scalar (for constant values) or a "array-like" input that has
                 ncol * nrow elements. As result, a 2D (masked) numpy array of shape

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -256,20 +256,6 @@ def allow_deprecated_default_init(func):
             if "yinc" not in kwargs:
                 warnings.warn(_deprecation_msg.format("yinc"), DeprecationWarning)
                 kwargs["yinc"] = 25.0
-            default = (
-                kwargs["ncol"] == 5
-                and kwargs["nrow"] == 3
-                and kwargs["xori"] == kwargs["yori"] == 0.0
-                and kwargs["xinc"] == kwargs["yinc"] == 25
-            )
-            values = kwargs.get("values", None)
-            if values is None and default:
-                # make default surface (mostly for unit testing)
-                kwargs["values"] = np.array(
-                    [[1, 6, 11], [2, 7, 12], [3, 8, 1e33], [4, 9, 14], [5, 10, 15]],
-                    dtype=np.float64,
-                    order="C",
-                )
 
         return func(cls, *args, **kwargs)
 

--- a/tests/test_surface/conftest.py
+++ b/tests/test_surface/conftest.py
@@ -1,0 +1,8 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def setup_tmpdir(tmpdir):
+    with tmpdir.as_cwd():
+        yield

--- a/tests/test_surface/conftest.py
+++ b/tests/test_surface/conftest.py
@@ -6,3 +6,20 @@ import pytest
 def setup_tmpdir(tmpdir):
     with tmpdir.as_cwd():
         yield
+
+
+@pytest.fixture
+def default_surface():
+    yield {
+        "ncol": 5,
+        "nrow": 3,
+        "xori": 0.0,
+        "yori": 0.0,
+        "xinc": 25,
+        "yinc": 25,
+        "values": np.array(
+            [[1, 6, 11], [2, 7, 12], [3, 8, 1e33], [4, 9, 14], [5, 10, 15]],
+            dtype=np.float64,
+            order="C",
+        ),
+    }

--- a/tests/test_surface/test_deprecation.py
+++ b/tests/test_surface/test_deprecation.py
@@ -1,0 +1,68 @@
+import functools
+
+import pytest
+import deprecation
+from packaging import version
+
+import xtgeo
+
+
+def fail_if_not_removed(version_limit, msg=None):
+    if msg is None:
+        msg = "This method has reached its deprecation limit and must be removed"
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            func(*args, **kwargs)
+            if version.parse(xtgeo.version) > version.parse(version_limit):
+                pytest.fail(msg)
+
+        return wrapper
+
+    return decorator
+
+
+@fail_if_not_removed(version_limit="4")
+def test_default_init_deprecation():
+    xtgeo.RegularSurface()
+
+
+@fail_if_not_removed(version_limit="3", msg="nx as input has passed deprecation period")
+def test_nx_deprecation(default_surface):
+    default_surface.pop("ncol")
+    default_surface["nx"] = 5
+    xtgeo.RegularSurface(**default_surface)
+
+
+@fail_if_not_removed(version_limit="3", msg="ny as input has passed deprecation period")
+def test_ny_deprecation(default_surface):
+    default_surface.pop("nrow")
+    default_surface["ny"] = 3
+    xtgeo.RegularSurface(**default_surface)
+
+
+@deprecation.fail_if_not_removed
+@pytest.mark.usefixtures("setup_tmpdir")
+def test_from_file_deprecation(default_surface):
+    surface = xtgeo.RegularSurface(**default_surface)
+    surface.to_file("my_file")
+    surface.from_file("my_file")
+
+
+@deprecation.fail_if_not_removed
+def test_from_grid3d_deprecation(default_surface):
+    mygrid = xtgeo.Grid()
+    surface = xtgeo.RegularSurface(**default_surface)
+    surface.from_grid3d(mygrid)
+
+
+@fail_if_not_removed(
+    version_limit="4",
+    msg="Creating directly from file has passed deprecation period and must be removed",
+)
+@pytest.mark.usefixtures("setup_tmpdir")
+def test_init_from_file_deprecation(default_surface):
+    surface = xtgeo.RegularSurface(**default_surface)
+    surface.to_file("my_file")
+    xtgeo.RegularSurface("my_file")

--- a/tests/test_surface/test_file_io.py
+++ b/tests/test_surface/test_file_io.py
@@ -1,0 +1,194 @@
+import pytest
+import deprecation
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+import numpy as np
+
+from xtgeo import RegularSurface, Cube
+import xtgeo
+
+
+def assert_equal_to_init(init, result):
+    init = init.copy()
+    init.pop("values")
+    result_dict = {key: getattr(result, key) for key in init.keys()}
+    assert result_dict == pytest.approx(init)
+
+
+@st.composite
+def generate_data(draw):
+    base_data = st.fixed_dictionaries(
+        {
+            "ncol": st.integers(min_value=1, max_value=10),
+            "nrow": st.integers(min_value=1, max_value=10),
+            "xori": st.floats(
+                min_value=-1e8,
+                max_value=1e8,
+            ),
+            "yori": st.floats(
+                min_value=-1e8,
+                max_value=1e8,
+            ),
+            "xinc": st.floats(
+                min_value=1e-2,
+                max_value=xtgeo.UNDEF_LIMIT,
+            ),
+            "yinc": st.floats(
+                min_value=1e-2,
+                max_value=xtgeo.UNDEF_LIMIT,
+            ),
+        }
+    )
+    base = draw(base_data)
+    values = st.fixed_dictionaries(
+        {
+            "values": st.lists(
+                st.floats(
+                    allow_nan=False,
+                    max_value=1e29,
+                    min_value=-xtgeo.UNDEF_LIMIT,
+                ),
+                min_size=base["ncol"] * base["nrow"],
+                max_size=base["ncol"] * base["nrow"],
+            )
+        }
+    )
+    vals = draw(values)
+
+    return {**base, **vals}
+
+
+@pytest.mark.usefixtures("setup_tmpdir")
+@pytest.mark.parametrize("engine", ["cxtgeo", "python"])
+@pytest.mark.parametrize(
+    "fformat",
+    [
+        "irap_binary",
+        "irap_ascii",
+        # "ijxyz",  # This fails horribly
+        "petromod",
+        "xtgregsurf",
+    ],
+)
+@pytest.mark.parametrize(
+    "input_val, expected_result",
+    [
+        (1, [[1.0, 1.0], [1.0, 1.0]]),
+        ([1, 2, 3, 4], [[1.0, 2.0], [3.0, 4.0]]),
+        (np.zeros((2, 2)), [[0.0, 0.0], [0.0, 0.0]]),
+        (np.ma.zeros((2, 2)), [[0.0, 0.0], [0.0, 0.0]]),
+        (np.ma.ones((2, 2)), [[1.0, 1.0], [1.0, 1.0]]),
+    ],
+)
+def test_simple_io(input_val, expected_result, fformat, engine):
+    if engine == "python" and fformat not in ["irap_ascii", "irap_binary"]:
+        pytest.skip("Only one engine available")
+    init_dict = {"ncol": 2, "nrow": 2, "xinc": 2.0, "yinc": 2.0, "values": input_val}
+    surf = RegularSurface(**init_dict)
+    surf.to_file("my_file", fformat=fformat)
+    surf_from_file = RegularSurface._read_file(
+        "my_file", fformat=fformat, engine=engine
+    )
+    assert_equal_to_init(init_dict, surf_from_file)
+    assert surf_from_file.values.data.tolist() == expected_result
+
+
+@settings(deadline=None)
+@pytest.mark.usefixtures("setup_tmpdir")
+@pytest.mark.parametrize("input_engine", ["cxtgeo", "python"])
+@pytest.mark.parametrize("output_engine", ["cxtgeo", "python"])
+@pytest.mark.parametrize(
+    "fformat",
+    [
+        "irap_binary",
+        "irap_ascii",
+        # "ijxyz",  # This fails horribly
+        "petromod",
+        "xtgregsurf",
+    ],
+)
+@given(data=generate_data())
+def test_complex_io(data, fformat, output_engine, input_engine):
+    if (input_engine == "python" or output_engine == "python") and fformat not in [
+        "irap_ascii",
+        "irap_binary",
+    ]:
+        pytest.skip("Only one engine available")
+    if fformat == "petromod":
+        pytest.xfail("Several hypotesis failures (4)")
+    surf = RegularSurface(**data)
+    assert_equal_to_init(data, surf)
+    surf.to_file("my_file", fformat=fformat, engine=output_engine)
+    surf_from_file = RegularSurface._read_file(
+        "my_file", fformat=fformat, engine=input_engine
+    )
+    assert_equal_to_init(data, surf_from_file)
+    assert surf_from_file.values.data.flatten().tolist() == pytest.approx(
+        data["values"]
+    )
+
+
+@deprecation.fail_if_not_removed
+@pytest.mark.usefixtures("setup_tmpdir")
+@given(
+    data=st.lists(
+        st.floats(
+            allow_nan=False, max_value=xtgeo.UNDEF_LIMIT, min_value=-xtgeo.UNDEF_LIMIT
+        ),
+        min_size=9,
+        max_size=9,
+    )
+)
+def test_complex_io_hdf(data):
+    surf = RegularSurface(3, 3, 0.0, 0.0, values=data)
+    surf.to_hdf("my_file")
+    surf_from_file = RegularSurface(1, 1, 0.0, 0.0)  # <- unimportant as it gets reset
+    surf_from_file.from_hdf("my_file")
+    assert surf_from_file.values.data.flatten().tolist() == pytest.approx(data)
+
+
+@pytest.mark.usefixtures("setup_tmpdir")
+@given(
+    data=st.lists(
+        st.floats(
+            allow_nan=False, max_value=xtgeo.UNDEF_LIMIT, min_value=-xtgeo.UNDEF_LIMIT
+        ),
+        min_size=9,
+        max_size=9,
+    )
+)
+def test_complex_io_hdf_classmethod(data):
+    surf = RegularSurface(3, 3, 0.0, 0.0, values=data)
+    surf.to_hdf("my_file")
+    surf_from_file = xtgeo.surface_from_file("my_file", fformat="hdf5")
+    assert surf_from_file.values.data.flatten().tolist() == pytest.approx(data)
+
+
+@given(
+    data=st.floats(
+        allow_nan=False, max_value=xtgeo.UNDEF_LIMIT, min_value=-xtgeo.UNDEF_LIMIT
+    ),
+)
+def test_read_cube(data):
+    cube_input = {
+        "xori": 1.0,
+        "yori": 2.0,
+        "zori": 3.0,
+        "ncol": 3,
+        "nrow": 3,
+        "nlay": 2,
+        "xinc": 20.0,
+        "yinc": 25.0,
+        "zinc": 2.0,
+    }
+    cube = Cube(**cube_input)
+    surf_from_cube = RegularSurface._read_cube(cube, data)
+    assert set(surf_from_cube.values.data.flatten().tolist()) == pytest.approx({data})
+
+    cube_input.pop("zinc")
+    cube_input.pop("nlay")
+    cube_input.pop("zori")
+    # Make sure it is properly constructed:
+    result = {key: getattr(surf_from_cube, key) for key in cube_input}
+    assert result == cube_input

--- a/tests/test_surface/test_new_surface.py
+++ b/tests/test_surface/test_new_surface.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+import hypothesis.strategies as st
+from hypothesis import given, assume
+from xtgeo import RegularSurface, Grid
+
+
+def test_default_values():
+    surf = RegularSurface(2, 2, 0.0, 0.0)
+    assert surf.values.data.tolist() == [[0.0, 0.0], [0.0, 0.0]]
+
+
+@pytest.mark.parametrize(
+    "input_val, expected_result",
+    [
+        (1, [[1.0, 1.0], [1.0, 1.0]]),
+        ([1, 2, 3, 4], [[1.0, 2.0], [3.0, 4.0]]),
+        (np.zeros((2, 2)), [[0.0, 0.0], [0.0, 0.0]]),
+        (None, [[0.0, 0.0], [0.0, 0.0]]),
+        (
+            np.ma.MaskedArray([[2, 2], [2, 2]], mask=[[True, False], [False, True]]),
+            [[2.0, 2.0], [2.0, 2.0]],
+        ),
+    ],
+)
+def test_values_type(input_val, expected_result):
+    surf = RegularSurface(2, 2, 0.0, 0.0, values=input_val)
+    assert isinstance(surf.values, np.ma.MaskedArray)
+    assert surf.values.data.tolist() == expected_result
+
+
+@pytest.mark.parametrize("input_values", [None, 2])
+@pytest.mark.parametrize(
+    "input_val, expected_result",
+    [
+        (1, [[1.0, 1.0], [1.0, 1.0]]),
+        ([1, 2, 3, 4], [[1.0, 2.0], [3.0, 4.0]]),
+        (np.zeros((2, 2)), [[0.0, 0.0], [0.0, 0.0]]),
+        (np.ma.zeros((2, 2)), [[0.0, 0.0], [0.0, 0.0]]),
+        (np.ma.ones((2, 2)), [[1.0, 1.0], [1.0, 1.0]]),
+    ],
+)
+def test_values_setter(input_values, input_val, expected_result):
+    surf = RegularSurface(2, 2, 0.0, 0.0, values=input_values)
+    surf.values = input_val
+    assert surf.values.data.tolist() == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_val, expected_data, expected_mask",
+    [
+        (1, [2.0, 1.0, 1.0, 2.0], [[True, False], [False, True]]),
+        ([1, 2, 3, 4], [1.0, 2.0, 3.0, 4.0], [[False, False], [False, False]]),
+        ([1, 1e33, 3, 4], [1.0, 1e33, 3.0, 4.0], [[False, True], [False, False]]),
+        (np.zeros((2, 2)), [0.0, 0.0, 0.0, 0.0], [[False, False], [False, False]]),
+        (np.ma.zeros((2, 2)), [0.0, 0.0, 0.0, 0.0], [[False, False], [False, False]]),
+        (np.ma.ones((2, 2)), [1.0, 1.0, 1.0, 1.0], [[False, False], [False, False]]),
+    ],
+)
+def test_values_mask_setter(input_val, expected_data, expected_mask):
+    surf = RegularSurface(
+        2,
+        2,
+        0.0,
+        0.0,
+        values=np.ma.MaskedArray([[2, 2], [2, 2]], mask=[[True, False], [False, True]]),
+    )
+    surf.values = input_val
+    assert surf.values.mask.tolist() == expected_mask
+    assert list(surf.values.data.flatten()) == expected_data
+
+
+@given(data=st.lists(st.floats(allow_nan=False), min_size=100, max_size=100))
+def test_input_lists(data):
+    surf = RegularSurface(10, 10, 0.0, 0.0, values=data)
+    assert surf.values.data.flatten().tolist() == pytest.approx(data)
+
+
+@given(data=st.lists(st.floats(allow_nan=False)))
+def test_wrong_size_input_lists(data):
+    assume(len(data) != 100)
+    with pytest.raises(ValueError, match=r"Cannot reshape array:"):
+        RegularSurface(10, 10, 0.0, 0.0, values=data)
+
+
+@given(data=st.one_of(st.floats(allow_nan=False), st.integers()))
+def test_input_numbers(data):
+    surf = RegularSurface(10, 10, 0.0, 0.0, values=data)
+    assert set(surf.values.data.flatten().tolist()) == pytest.approx({data})
+
+
+def test_read_grid3d():
+    grid = Grid()  # this creates an example Grid (no other way to do it currently)
+    surf = RegularSurface._read_grid3d(grid=grid)
+    # There is some resolution changes between the grid and the surface, so we cant
+    # expect identical sizes, even for regular grids.
+    assert (surf.ncol, surf.nrow) == (3, 3)

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -59,31 +59,27 @@ def test_create():
     x.describe()
 
 
-def test_values():
+def test_values(default_surface):
     """Test behaviour of values attribute."""
-    srf = xtgeo.RegularSurface()
-    id1 = id(srf.values)
+    srf = xtgeo.RegularSurface(**default_surface)
 
     newvalues = srf.values.copy()
     srf.values = newvalues
-    assert id(srf.values) == id1
+    assert (srf.values.data == default_surface["values"]).all()
 
     srf.values = 44
-    assert id(srf.values) == id1
+    assert set(srf.values.data.flatten()) == {1e33, 44.0}
 
-    srf.values = None
-    assert srf.values is None
-
-    srf = xtgeo.RegularSurface()
-    id1 = id(srf.values)
+    srf = xtgeo.RegularSurface(**default_surface)
     newvalues = np.ones((srf.ncol, srf.nrow))
     srf.values = newvalues
     assert isinstance(srf.values, np.ma.MaskedArray)
+    assert set(srf.values.data.flatten()) == {1.0}
 
     newvalues = np.arange(15).reshape(srf.ncol, srf.nrow)
     newvalues = np.ma.masked_where(newvalues < 3, newvalues)
     srf.values = newvalues
-    assert id(srf.values) != id1
+    assert (srf.values.data == newvalues.data).all()
 
     # list like input with undefined value
     newvalues = list(range(15))
@@ -103,9 +99,9 @@ def test_values():
         srf.values = "text"
 
 
-def test_set_values1d():
+def test_set_values1d(default_surface):
     """Test behaviour of set_values1d method."""
-    srf = xtgeo.RegularSurface()
+    srf = xtgeo.RegularSurface(**default_surface)
     new = srf.copy()
     assert np.ma.count_masked(new.values) == 1
 
@@ -309,11 +305,11 @@ def test_petromodbin_import_export():
         petromod.to_file("TMP/null", fformat="petromod", pmd_dataunits=(-2, 999))
 
 
-def test_zmap_import_export():
+def test_zmap_import_export(default_surface):
     """Import and export ZMAP ascii example."""
     logger.info("Import and export...")
 
-    zmap = RegularSurface()
+    zmap = RegularSurface(**default_surface)
     zmap.to_file(join(TMPD, "zmap1.zmap"), fformat="zmap_ascii")
     zmap2 = RegularSurface()
     zmap2.from_file(join(TMPD, "zmap1.zmap"), fformat="zmap_ascii")
@@ -509,7 +505,7 @@ def test_minmax_rotated_map():
     assert_almostequal(x.ymax, 5939998.7, 0.1)
 
 
-def test_operator_overload():
+def test_operator_overload(**default_surface):
     """Test operations between two surface in different ways"""
 
     surf1 = xtgeo.RegularSurface(ncol=100, nrow=50, rotation=10, values=100)
@@ -600,9 +596,9 @@ def test_surface_comparisons():
     assert id(surf1) == id1
 
 
-def test_surface_subtract_etc():
+def test_surface_subtract_etc(default_surface):
     """Test the simple surf.subtract etc methods"""
-    surf1 = xtgeo.RegularSurface()
+    surf1 = xtgeo.RegularSurface(**default_surface)
     id1 = id(surf1)
     mean1 = surf1.values.mean()
 
@@ -667,10 +663,10 @@ def test_irapbin_io():
     assert_equal(cc.ncol, 554)
 
 
-def test_get_values1d():
+def test_get_values1d(default_surface):
     """Get the 1D array, different variants as masked, notmasked, order, etc"""
 
-    xmap = xtgeo.RegularSurface()
+    xmap = xtgeo.RegularSurface(**default_surface)
     print(xmap.values)
 
     v1d = xmap.get_values1d(order="C", asmasked=False, fill_value=-999)
@@ -755,10 +751,10 @@ def test_get_values1d():
     ]
 
 
-def test_ij_map_indices():
+def test_ij_map_indices(default_surface):
     """Get the IJ MAP indices"""
 
-    xmap = xtgeo.RegularSurface()
+    xmap = xtgeo.RegularSurface(**default_surface)
     print(xmap.values)
 
     ixc, jyc = xmap.get_ij_values1d(activeonly=True, order="C")
@@ -871,10 +867,10 @@ def test_dataframe_more():
     dfrcy.to_csv(os.path.join(TMPD, "regsurf_df_noij_c_all.csv"))
 
 
-def test_get_xy_value_lists_small():
+def test_get_xy_value_lists_small(default_surface):
     """Get the xy list and value list from small test case"""
 
-    x = xtgeo.RegularSurface()  # default instance
+    x = xtgeo.RegularSurface(**default_surface)  # default instance
 
     xylist, valuelist = x.get_xy_value_lists(valuefmt="8.3f", xyfmt="12.2f")
 
@@ -1105,9 +1101,9 @@ def test_fence():
         ),
     ],
 )
-def test_fence_sampling(infence, sampling, expected):
+def test_fence_sampling(infence, sampling, expected, default_surface):
     """Test a very simple fence with different sampling methods."""
-    surf = xtgeo.RegularSurface()
+    surf = xtgeo.RegularSurface(**default_surface)
 
     myfence = np.array(infence)
     myfence[myfence == -999] = np.nan

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -228,10 +228,11 @@ def test_irapbin_import_quickplot():
 
 def test_irapbin_import_metadatafirst_simple():
     srf = xtgeo.RegularSurface(TESTSET2, values=False)
-    assert srf.values is None
+    assert set(srf.values.data.flatten().tolist()) == {0.0}
     assert srf.ncol == 1264
 
     srf.load_values()
+    assert srf.values.mean() == pytest.approx(1672.8242448561361)
 
 
 def test_irapbin_import_metadatafirst():

--- a/tests/test_surface/test_surfaces.py
+++ b/tests/test_surface/test_surfaces.py
@@ -82,7 +82,7 @@ def test_statistics():
     assert_almostequal(res["std"].values.min(), 3.7039, 0.0001)
 
 
-def test_more_statistics():
+def test_more_statistics(default_surface):
     """Find the mean etc measures of the surfaces."""
     base = xtgeo.RegularSurface(TESTSET1A)
     base.values *= 0.0
@@ -108,7 +108,7 @@ def test_more_statistics():
     assert_almostequal(res["mean"].values.mean(), bmean + 50.0, 0.0001)
     assert_almostequal(res["std"].values.mean(), stdev, 0.0001)
 
-    small = xtgeo.RegularSurface()
+    small = xtgeo.RegularSurface(**default_surface)
     so2 = xtgeo.Surfaces()
 
     for inum in range(10):


### PR DESCRIPTION
This shows an extended example of how we could handle the initialization in a more consistent matter. A couple of notes:

1. ~~In a real implementation we would swap the place of these two classes to avoid breaking the API~~ Now it is an example of a real implementation
2. ~~This is meant as an example, and is not complete (would add all the import functions to `data_import_factory`)~~
3. The reasoning behind this pattern of coding is that explicit is better than implicit
4. This has a side effect of making it much easier to test the class, as there is only one way to initialize, meaning we can test that in isolation, and not for each possible file type.
5. We can also easily test the import functions, as they are only meant to read a file and return some values
6. ~~Using a second, dummy class as a front~~ Using a decorator we should be able to avoid breaking the API immediately, but the idea would be to remove it in the next major bump

The main take away is the the `__init__` is much simplified.