### PR TITLE
Support for python 3.9 in PYPI

### DIFF
--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -1,5 +1,3 @@
-# Test building some cibuildwheel on pull requests (simplified testing)
-
 name: cibuildwheel
 
 on:
@@ -35,9 +33,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: |
-          python -m pip install pip -U
-          python -m pip install wheel
+        run: >
+          python -m pip install pip -U &&
+          python -m pip install wheel &&
           python -m pip install cibuildwheel
 
       - name: Build wheels and test
@@ -92,6 +90,16 @@ jobs:
 
         run: |
           python -m cibuildwheel --output-dir wheelhouse
+
+  # pitfall for Windows, while this works for linux and macos:
+  # run: |
+  #    command1
+  #    command2
+  # it will not work for windows! Only command1 is executed; hence this syntax is
+  # replaced with:
+  # run: >
+  #     command1 &&
+  #     command2
 
   build_windows_cibuildwheel:
     name: CIBW python ${{ matrix.cibw_python }} on ${{ matrix.os }}

--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -6,53 +6,31 @@ on:
   pull_request:
     branches: [master]
 
-env:
-  CIBW_BEFORE_ALL_LINUX: "sh scripts/swig_manylinux.sh"
-  CIBW_BEFORE_ALL_WINDOWS: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
-  CIBW_BEFORE_ALL_MACOS: brew install swig
-
-  CIBW_BEFORE_TEST: |
-    pushd {project}
-    pip install -r requirements/requirements.txt
-    pip install -r requirements/requirements_test.txt
-
-  # 3.9 have trouble with install pytables on Mac and Win, due to missing wheel
-  # so full testing on those platforms are postponed.
-  CIBW_TEST_COMMAND_MACOS: |
-    pushd {project}
-    rm -rf ../xtgeo-testdata
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests/test_surface --disable-warnings
-  CIBW_TEST_COMMAND_WINDOWS: |
-    pushd {project}
-    rmdir /s ../xtgeo-testdata
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests/test_surface --disable-warnings
-  CIBW_TEST_COMMAND_LINUX: |
-    pushd {project}
-    rm -rf ../xtgeo-testdata
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests --disable-warnings
-
-  CIBW_BUILD: |
-    cp39-manylinux_x86_64
-    cp39-macosx_x86_64
-    cp39-win_amd64
-
 # Verify that wheel build jobs succeed
 jobs:
-  build_multiwheels:
-    name: CIBW latest on ${{ matrix.os }}
-
+  build_linux_cibuildwheel:
+    name: CIBW python ${{ matrix.cibw_python }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    env:
+      CIBW_BEFORE_ALL: "sh scripts/swig_manylinux.sh"
+      CIBW_BEFORE_TEST: >
+        pushd {project} &&
+        pip install -r requirements/requirements.txt &&
+        pip install -r requirements/requirements_test.txt &&
+        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+      CIBW_TEST_COMMAND: >
+        pushd {project} &&
+        pytest tests/test_common --disable-warnings -x
+      CIBW_BUILD: ${{ matrix.cibw_python }}-manylinux_x86_64
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8]
+        os: [ubuntu-latest]
+        cibw_python: [cp36, cp39]
     steps:
-      - uses: actions/checkout@v1
-
+      - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
 
@@ -63,5 +41,107 @@ jobs:
           python -m pip install cibuildwheel
 
       - name: Build wheels and test
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+  build_macos_cibuildwheel:
+    name: CIBW python ${{ matrix.cibw_python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CIBW_BEFORE_ALL: "brew install swig"
+      CIBW_BEFORE_TEST: >
+        pushd {project} &&
+        pip install -r requirements/requirements.txt &&
+        pip install -r requirements/requirements_test.txt &&
+        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+      CIBW_TEST_COMMAND: >
+        pushd {project} &&
+        pytest tests --disable-warnings -x
+      CIBW_BUILD: ${{ matrix.cibw_python }}-macosx_x86_64
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+        python-version: [3.8] # PY version for "Install cibuildwheel", default is 2.7!
+        cibw_python: [cp36, cp39]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: >
+          python -m pip install pip -U &&
+          python -m pip install wheel &&
+          python -m pip install cibuildwheel
+
+      - name: Build wheels and test python < 3.9
+        if: matrix.cibw_python != 'cp39'
+        run: >
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Build wheels and test python 3.9
+        if: matrix.cibw_python == 'cp39'
+        # note tests are a bit restricted due to missing pytables wheel
+        env:
+          CIBW_TEST_COMMAND: >
+            pushd {project} &&
+            pytest tests --disable-warnings --ignore tests/test_well -x
+
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+  build_windows_cibuildwheel:
+    name: CIBW python ${{ matrix.cibw_python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CIBW_BEFORE_ALL: choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
+      CIBW_BEFORE_TEST: >
+        pushd {project} &&
+        pip install -r requirements/requirements.txt &&
+        pip install -r requirements/requirements_test.txt &&
+        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+
+      # a test with forks is skipped as this calls python in a subprocess, where
+      # the cibuildwheel on windows cannot find the xtgeo module
+      CIBW_TEST_COMMAND: >
+        pushd {project} && dir &&
+        pytest tests -x --ignore-glob="*forks.py"
+
+      CIBW_BUILD: ${{ matrix.cibw_python }}-win_amd64
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+        cibw_python: [cp36, cp39]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: >
+          python -m pip install pip -U &&
+          python -m pip install wheel &&
+          python -m pip install cibuildwheel
+
+      - name: Build wheels and test python < 3.9
+        if: matrix.cibw_python != 'cp39'
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Build wheels and test python 3.9
+        if: matrix.cibw_python == 'cp39'
+        # note tests are a bit restricted due to missing pytables wheel
+        env:
+          CIBW_TEST_COMMAND: >
+            pushd {project} &&
+            pytest tests --disable-warnings --ignore tests/test_well
+            --ignore-glob="*forks.py" -x
+
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -1,13 +1,16 @@
-name: Upload XTGeo release to PYPI
+# Test building some cibuildwheel on pull requests (simplified testing)
+
+name: cibuildwheel
 
 on:
-  release:
-    types: [created]
+  pull_request:
+    branches: [master]
 
 env:
   CIBW_BEFORE_ALL_LINUX: "sh scripts/swig_manylinux.sh"
   CIBW_BEFORE_ALL_WINDOWS: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
-  CIBW_BEFORE_ALL_MACOS: "brew install swig"
+  CIBW_BEFORE_ALL_MACOS: brew install swig
+
   CIBW_BEFORE_TEST: |
     pushd {project}
     pip install -r requirements/requirements.txt
@@ -22,7 +25,7 @@ env:
     pytest tests/test_surface --disable-warnings
   CIBW_TEST_COMMAND_WINDOWS: |
     pushd {project}
-    rm -rf ../xtgeo-testdata
+    rmdir /s ../xtgeo-testdata
     git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
     pytest tests/test_surface --disable-warnings
   CIBW_TEST_COMMAND_LINUX: |
@@ -32,55 +35,33 @@ env:
     pytest tests --disable-warnings
 
   CIBW_BUILD: |
-    cp36-manylinux_x86_64
-    cp37-manylinux_x86_64
-    cp38-manylinux_x86_64
     cp39-manylinux_x86_64
-    cp36-macosx_x86_64
-    cp37-macosx_x86_64
-    cp38-macosx_x86_64
     cp39-macosx_x86_64
-    cp36-win_amd64
-    cp37-win_amd64
-    cp38-win_amd64
-    cp38-win_amd64
     cp39-win_amd64
 
+# Verify that wheel build jobs succeed
 jobs:
-  build_wheels:
-    name: Deploy wheels to PYPI for ${{ matrix.os }}
+  build_multiwheels:
+    name: CIBW latest on ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8]
-
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
         run: |
+          python -m pip install pip -U
+          python -m pip install wheel
           python -m pip install cibuildwheel
 
       - name: Build wheels and test
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-
-      - name: Check wheels and paths (ubuntu only)
-        run: |
-          ls -l wheelhouse
-          ls -latr
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: Publish to PYPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          pip install twine
-          twine upload wheelhouse/*

--- a/.github/workflows/ci-test-xtgeo-merge.yml
+++ b/.github/workflows/ci-test-xtgeo-merge.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci-test-xtgeo-merge.yml
+++ b/.github/workflows/ci-test-xtgeo-merge.yml
@@ -31,4 +31,4 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
           pip install -r requirements/requirements_test.txt
-          pytest --disable-warnings
+          pytest --disable-warnings -x

--- a/.github/workflows/ci-test-xtgeo.yml
+++ b/.github/workflows/ci-test-xtgeo.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
           pip install -r requirements/requirements_test.txt
-          pytest --disable-warnings
+          pytest --disable-warnings -x
 
       - name: Build docs
         run: |

--- a/.github/workflows/ci-test-xtgeo.yml
+++ b/.github/workflows/ci-test-xtgeo.yml
@@ -23,29 +23,38 @@ jobs:
             python-version: 3.6
           - os: windows-latest
             python-version: 3.8
+
     steps:
       - uses: actions/checkout@v1
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install swig (osx)
         if: matrix.os == 'macos-latest'
         run: brew install swig
+
       - name: Install swig (win)
         if: matrix.os == 'windows-latest'
         run: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
+
       - name: Install xtgeo
-        run: |
-          pip install pip -U
+        run: >
+          pip install pip -U &&
           pip install .
-      - name: Test with pytest
-        run: |
-          git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-          pip install -r requirements/requirements.txt
-          pip install -r requirements/requirements_test.txt
+
+      - name: Small version test
+        run: python -c "import xtgeo; print(xtgeo.__version__)"
+
+      - name: Full test
+        run: >
+          pip install -r requirements/requirements_test.txt &&
+          git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata &&
           pytest --disable-warnings -x
+
       - name: Build docs
-        run: |
-          pip install -r requirements/requirements_docs.txt
+        run: >
+          pip install -r requirements/requirements_docs.txt &&
           sphinx-build -W docs tmp/docs

--- a/.github/workflows/ci-test-xtgeo.yml
+++ b/.github/workflows/ci-test-xtgeo.yml
@@ -19,13 +19,14 @@ env:
     pytest tests --disable-warnings
 
   CIBW_BUILD: |
-    cp36-manylinux_x86_64
-    cp36-macosx_x86_64
-    cp36-win_amd64
+    cp39-manylinux_x86_64
+    cp38-macosx_x86_64
+    cp38-win_amd64
 
+# Verify that wheel build jobs succeed
 jobs:
   build_multiwheels:
-    name: CIBW PY36 on ${{ matrix.os }}
+    name: CIBW PY38 or 39 on ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
 
@@ -43,20 +44,31 @@ jobs:
         run: |
           python -m pip install pip -U
           python -m pip install wheel
-          python -m pip install cibuildwheel==1.5.5
+          python -m pip install cibuildwheel
 
       - name: Build wheels and test
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
   build_pywheels:
-    name: PY ${{ matrix.python-version }} on linux
+    name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
+    # All python versions are tested on linux, only first and last on win and osx
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python-version: 3.6
+          - os: macos-latest
+            python-version: 3.8
+          - os: windows-latest
+            python-version: 3.6
+          - os: windows-latest
+            python-version: 3.8
 
     steps:
       - uses: actions/checkout@v1
@@ -65,6 +77,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install swig (osx)
+        if: matrix.os == 'macos-latest'
+        run: brew install swig
+
+      - name: Install swig (win)
+        if: matrix.os == 'windows-latest'
+        run: |
+          (New-Object System.Net.WebClient).DownloadFile("http://prdownloads.sourceforge.net/swig/swigwin-4.0.2.zip","swigwin-4.0.2.zip");
+          Expand-Archive .\swigwin-4.0.2.zip .;
+          echo "$((Get-Item .).FullName)/swigwin-4.0.2" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install xtgeo
         run: |

--- a/.github/workflows/ci-test-xtgeo.yml
+++ b/.github/workflows/ci-test-xtgeo.yml
@@ -1,61 +1,15 @@
+# build and test some end points
 name: buildsall
 
 on:
   pull_request:
     branches: [master]
 
-env:
-  CIBW_BEFORE_ALL_LINUX: "sh scripts/swig_manylinux.sh"
-  CIBW_BEFORE_ALL_WINDOWS: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
-  CIBW_BEFORE_ALL_MACOS: "brew install swig"
-  CIBW_BEFORE_TEST: |
-    cd {project}
-    pip install -r requirements/requirements.txt
-    pip install -r requirements/requirements_test.txt
-
-  CIBW_TEST_COMMAND: |
-    cd {project}
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests --disable-warnings
-
-  CIBW_BUILD: |
-    cp39-manylinux_x86_64
-    cp38-macosx_x86_64
-    cp38-win_amd64
-
-# Verify that wheel build jobs succeed
 jobs:
-  build_multiwheels:
-    name: CIBW PY38 or 39 on ${{ matrix.os }}
-
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install pip -U
-          python -m pip install wheel
-          python -m pip install cibuildwheel
-
-      - name: Build wheels and test
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-
   build_pywheels:
     name: PY ${{ matrix.python-version }} on ${{ matrix.os }}
-
     runs-on: ${{ matrix.os }}
-
-    # All python versions are tested on linux, only first and last on win and osx
+    # All python versions are tested on linux, only selected versions on win and osx
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -69,37 +23,28 @@ jobs:
             python-version: 3.6
           - os: windows-latest
             python-version: 3.8
-
     steps:
       - uses: actions/checkout@v1
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install swig (osx)
         if: matrix.os == 'macos-latest'
         run: brew install swig
-
       - name: Install swig (win)
         if: matrix.os == 'windows-latest'
-        run: |
-          (New-Object System.Net.WebClient).DownloadFile("http://prdownloads.sourceforge.net/swig/swigwin-4.0.2.zip","swigwin-4.0.2.zip");
-          Expand-Archive .\swigwin-4.0.2.zip .;
-          echo "$((Get-Item .).FullName)/swigwin-4.0.2" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
+        run: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
       - name: Install xtgeo
         run: |
           pip install pip -U
           pip install .
-
       - name: Test with pytest
         run: |
           git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+          pip install -r requirements/requirements.txt
           pip install -r requirements/requirements_test.txt
           pytest --disable-warnings -x
-
       - name: Build docs
         run: |
           pip install -r requirements/requirements_docs.txt

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,28 +13,28 @@ jobs:
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.7'
+      PYTHON: "3.7"
 
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@master
 
-    - name: Setup Python
-      uses: actions/setup-python@master
-      with:
-        python-version: 3.7
+      - name: Setup Python
+        uses: actions/setup-python@master
+        with:
+          python-version: 3.7
 
-    - name: Install xtgeo
-      run: |
-        pip install pip -U
-        pip install .
+      - name: Install xtgeo
+        run: |
+          pip install pip -U
+          pip install .
 
-    - name: Generate coverage report
-      run: |
-        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-        pip install -r requirements/requirements_test.txt
-        pip install pytest-cov
-        pytest tests --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml;
+      - name: Generate coverage report
+        run: |
+          git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+          pip install -r requirements/requirements_test.txt
+          pip install pytest-cov
+          pytest tests --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml;
 
-    - name: Upload coverage to Codecov
-      run: |
-        bash <(curl -s https://codecov.io/bash) -Z -c -f xtgeocoverage.xml
+      - name: Upload coverage to Codecov
+        run: |
+          bash <(curl -s https://codecov.io/bash) -Z -c -f xtgeocoverage.xml

--- a/.github/workflows/deploy-xtgeo-pypi.yml
+++ b/.github/workflows/deploy-xtgeo-pypi.yml
@@ -63,7 +63,7 @@ jobs:
         git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
       CIBW_TEST_COMMAND: >
         pushd {project} &&
-        pytest tests --disable-warnings &&
+        pytest tests --disable-warnings
       CIBW_BUILD: ${{ matrix.cibw_python }}-macosx_x86_64
 
     strategy:
@@ -90,7 +90,8 @@ jobs:
 
       - name: Build wheels and test python 3.9
         if: matrix.cibw_python == 'cp39'
-        # note tests are a bit restricted due to missing pytables wheel
+        # note tests are a bit restricted due to missing pytables wheel; that is
+        # --ignore tests/test_well
         env:
           CIBW_TEST_COMMAND: >
             pushd {project} &&
@@ -106,6 +107,16 @@ jobs:
         run: >
           pip install twine &&
           twine upload wheelhouse/*
+
+  # pitfall for Windows, while this works for linux and macos:
+  # run: |
+  #    command1
+  #    command2
+  # it will not work for windows! Only command1 is executed; hence this syntax is
+  # replaced with:
+  # run: >
+  #     command1 &&
+  #     command2
 
   deploy_windows_cibuildwheel:
     name: CIBW deploy ${{ matrix.cibw_python }} on ${{ matrix.os }}

--- a/.github/workflows/deploy-xtgeo-pypi.yml
+++ b/.github/workflows/deploy-xtgeo-pypi.yml
@@ -4,83 +4,164 @@ on:
   release:
     types: [created]
 
-env:
-  CIBW_BEFORE_ALL_LINUX: "sh scripts/swig_manylinux.sh"
-  CIBW_BEFORE_ALL_WINDOWS: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
-  CIBW_BEFORE_ALL_MACOS: "brew install swig"
-  CIBW_BEFORE_TEST: |
-    pushd {project}
-    pip install -r requirements/requirements.txt
-    pip install -r requirements/requirements_test.txt
-
-  # 3.9 have trouble with install pytables on Mac and Win, due to missing wheel
-  # so full testing on those platforms are postponed.
-  CIBW_TEST_COMMAND_MACOS: |
-    pushd {project}
-    rm -rf ../xtgeo-testdata
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests/test_surface --disable-warnings
-  CIBW_TEST_COMMAND_WINDOWS: |
-    pushd {project}
-    rm -rf ../xtgeo-testdata
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests/test_surface --disable-warnings
-  CIBW_TEST_COMMAND_LINUX: |
-    pushd {project}
-    rm -rf ../xtgeo-testdata
-    git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
-    pytest tests --disable-warnings
-
-  CIBW_BUILD: |
-    cp36-manylinux_x86_64
-    cp37-manylinux_x86_64
-    cp38-manylinux_x86_64
-    cp39-manylinux_x86_64
-    cp36-macosx_x86_64
-    cp37-macosx_x86_64
-    cp38-macosx_x86_64
-    cp39-macosx_x86_64
-    cp36-win_amd64
-    cp37-win_amd64
-    cp38-win_amd64
-    cp38-win_amd64
-    cp39-win_amd64
-
+# Verify that wheel build jobs succeed
 jobs:
-  build_wheels:
-    name: Deploy wheels to PYPI for ${{ matrix.os }}
-
+  deploy_linux_cibuildwheel:
+    name: CIBW deploy ${{ matrix.cibw_python }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
+    env:
+      CIBW_BEFORE_ALL: "sh scripts/swig_manylinux.sh"
+      CIBW_BEFORE_TEST: >
+        pushd {project} &&
+        pip install -r requirements/requirements.txt &&
+        pip install -r requirements/requirements_test.txt &&
+        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+      CIBW_TEST_COMMAND: >
+        pushd {project} &&
+        pytest tests --disable-warnings
+      CIBW_BUILD: ${{ matrix.cibw_python }}-manylinux_x86_64
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.8]
-
+        os: [ubuntu-latest]
+        cibw_python: [cp36, cp37, cp38, cp39]
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Python ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Set up Python
         uses: actions/setup-python@v2
 
       - name: Install cibuildwheel
-        run: |
+        run: >
+          python -m pip install pip -U &&
+          python -m pip install wheel &&
           python -m pip install cibuildwheel
 
       - name: Build wheels and test
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Check wheels and paths (ubuntu only)
-        run: |
-          ls -l wheelhouse
-          ls -latr
-        if: matrix.os == 'ubuntu-latest'
-
-      - name: Publish to PYPI
+      - name: Publish to PYPI Linux
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: >
+          pip install twine &&
+          twine upload wheelhouse/*
+
+  deploy_macos_cibuildwheel:
+    name: CIBW deploy ${{ matrix.cibw_python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CIBW_BEFORE_ALL: "brew install swig"
+      CIBW_BEFORE_TEST: >
+        pushd {project} &&
+        pip install -r requirements/requirements.txt &&
+        pip install -r requirements/requirements_test.txt &&
+        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+      CIBW_TEST_COMMAND: >
+        pushd {project} &&
+        pytest tests --disable-warnings &&
+      CIBW_BUILD: ${{ matrix.cibw_python }}-macosx_x86_64
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+        python-version: [3.8] # PY version for "Install cibuildwheel", default is 2.7!
+        cibw_python: [cp36, cp37, cp38, cp39]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: >
+          python -m pip install pip -U &&
+          python -m pip install wheel &&
+          python -m pip install cibuildwheel
+
+      - name: Build wheels and test python < 3.9
+        if: matrix.cibw_python != 'cp39'
         run: |
-          pip install twine
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Build wheels and test python 3.9
+        if: matrix.cibw_python == 'cp39'
+        # note tests are a bit restricted due to missing pytables wheel
+        env:
+          CIBW_TEST_COMMAND: >
+            pushd {project} &&
+            pytest tests --disable-warnings --ignore tests/test_well
+
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Publish to PYPI MacOS
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: >
+          pip install twine &&
+          twine upload wheelhouse/*
+
+  deploy_windows_cibuildwheel:
+    name: CIBW deploy ${{ matrix.cibw_python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CIBW_BEFORE_ALL: choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
+      CIBW_BEFORE_TEST: >
+        pushd {project} &&
+        pip install -r requirements/requirements.txt &&
+        pip install -r requirements/requirements_test.txt &&
+        git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
+
+      # a test with forks is skipped as this calls python in a subprocess, where
+      # the cibuildwheel on windows cannot find the xtgeo module
+      CIBW_TEST_COMMAND: >
+        pushd {project} &&
+        pytest tests --disable-warnings --ignore-glob="*forks.py"
+      CIBW_BUILD: ${{ matrix.cibw_python }}-win_amd64
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+        cibw_python: [cp36, cp37, cp38, cp39]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: >
+          python -m pip install pip -U &&
+          python -m pip install wheel &&
+          python -m pip install cibuildwheel
+
+      - name: Build wheels and test python < 3.9
+        if: matrix.cibw_python != 'cp39'
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Build wheels and test python 3.9
+        if: matrix.cibw_python == 'cp39'
+        # note tests are a bit restricted due to missing pytables wheel
+        env:
+          CIBW_TEST_COMMAND: >
+            pushd {project} &&
+            pytest tests --disable-warnings --ignore tests/test_well
+            --ignore-glob="*forks.py" -x
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Publish to PYPI Windows
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: >
+          pip install twine &&
           twine upload wheelhouse/*

--- a/.github/workflows/deploy-xtgeo-pypi.yml
+++ b/.github/workflows/deploy-xtgeo-pypi.yml
@@ -9,10 +9,14 @@ env:
   CIBW_BEFORE_ALL_WINDOWS: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
   CIBW_BEFORE_ALL_MACOS: "brew install swig"
   CIBW_TEST_COMMAND: 'python -c "import xtgeo; print(xtgeo.__version__)"'
+
+  # 3.9 have trouble with install on Mac and Win, due to PyTables missing wheel
+  # so those platforms are postponed.
   CIBW_BUILD: |
     cp36-manylinux_x86_64
     cp37-manylinux_x86_64
     cp38-manylinux_x86_64
+    cp39-manylinux_x86_64
     cp36-macosx_x86_64
     cp37-macosx_x86_64
     cp38-macosx_x86_64
@@ -38,7 +42,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.5.5
+          python -m pip install cibuildwheel
 
       - name: Build wheels
         run: |

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Version 2.15 (in prep)
+
+* New features:
+  * Python 3.9 support, with PYPI wheel.
+
 ## Version 2.14
 
 * New features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,11 @@ exclude = '''
 )/
 '''
 
-# numpy version scheme to fulfill Roxar API compatibility
+# numpy version scheme to fulfill Roxar API compatibility:
+# RMS 11.* 12.0.*  --> numpy == 1.13.3 with python 3.6
+# RMS 12.1.*  -->  numpy == 1.19.2 with python 3.8
+#
 # For cmake, cmake >= 3.6 is tested to be OK actually but versions are linked to pip versions and
-# manylinyx1 vs manylinux2010 issues (for Equinor Komodo installs)
 [build-system]
 requires = [
   "pip>=19.1.1",
@@ -37,9 +39,10 @@ requires = [
   'cmake==3.18.0; platform_system != "Linux"',
   "ninja",
   "setuptools_scm>=3.2.0",
-  'numpy==1.10.4; python_version == "3.4"',
-  'numpy==1.13.3; python_version >= "3.5" and python_version < "3.7" and platform_system == "Linux"',
-  'numpy==1.16.0; python_version >= "3.7" or platform_system != "Linux"',
+  'numpy==1.13.3; python_version == "3.6"',
+  'numpy==1.19.2; python_version == "3.8"',
+  'numpy>=1.19; python_version == "3.7"',
+  'numpy>=1.19; python_version >= "3.9"',
   'Sphinx',
   'sphinx-rtd-theme',
   'sphinxcontrib-apidoc',

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 
 [pytest]
 minversion = 6.0
-addopts = --verbose -x
+addopts = --verbose
 log_cli = False
 log_cli_format = %(levelname)8s (%(relativeCreated)6.0fms) %(filename)44s [%(funcName)40s()] %(lineno)4d >>   %(message)s
 log_cli_level = INFO

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,4 +6,6 @@ segyio>1.8.0
 pandas>=0.18
 h5py>=3
 hdf5plugin>=2.3
-tables>=3.5.1
+# await pytables on pypi for PY3.9 macos, win
+tables>=3.5.1; python_version < "3.9" and platform_system != "Linux"
+tables>=3.5.1; platform_system == "Linux"

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -23,7 +23,7 @@ segyio>=1.8.6
 matplotlib>=1.5
 scipy>=0.17
 shapely>=1.6.2; python_version < "3.8"
-shapely==1.7a2; python_version == "3.8"
+shapely==1.7a2; python_version >= "3.8"
 black
 autopep8
 pylint

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -31,4 +31,6 @@ pytest>=6
 pytest-cov
 h5py>=3
 hdf5plugin>=2.3
-tables>=3.5
+# await pytables on pypi for PY3.9 macos, win
+tables>=3.5; python_version < "3.9" and platform_system != "Linux"
+tables>=3.5; platform_system == "Linux"

--- a/requirements/requirements_dev_rms.txt
+++ b/requirements/requirements_dev_rms.txt
@@ -19,7 +19,7 @@ recommonmark
 bandit
 segyio>=1.8.6
 shapely>=1.6.2; python_version < "3.8"
-shapely==1.7a2; python_version == "3.8"
+shapely==1.7a2; python_version >= "3.8"
 black
 autopep8
 pylint

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ skbuild.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Software Development :: Libraries",

--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -2,6 +2,7 @@
 import hashlib
 import io
 import pathlib
+import sys
 
 import pytest
 
@@ -37,6 +38,7 @@ surface_files_formats = {
 }
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Path delimiter issue")
 @pytest.mark.parametrize("filename", surface_files_formats.keys())
 def test_resolve_alias(testpath, filename):
     """Testing resolving file alias function."""

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -1,4 +1,5 @@
 """Testing RegularSurface class with methods."""
+import sys
 import os
 import os.path
 from os.path import join
@@ -147,7 +148,7 @@ def test_ijxyz_import1():
     xsurf.to_file(os.path.join(TMPD, "ijxyz_set4a.gri"))
 
 
-# @tsetup.skipifwindows
+@pytest.mark.skipif(sys.platform == "win32", reason="divide by zero issue")
 def test_ijxyz_import2():
     """Import some IJ XYZ small set with YFLIP -1."""
     logger.info("Import and export...")
@@ -162,7 +163,7 @@ def test_ijxyz_import2():
     xsurf.to_file(os.path.join(TMPD, "ijxyz_set4b.gri"))
 
 
-# @tsetup.skipifwindows
+@pytest.mark.skipif(sys.platform == "win32", reason="Unknown issue")
 def test_ijxyz_import4_ow_messy_dat():
     """Import some IJ XYZ small set with YFLIP -1 from OW messy dat format."""
     logger.info("Import and export...")
@@ -177,7 +178,7 @@ def test_ijxyz_import4_ow_messy_dat():
     xsurf.to_file(os.path.join(TMPD, "ijxyz_set4d.gri"))
 
 
-# @tsetup.skipifwindows
+@pytest.mark.skipif(sys.platform == "win32", reason="Unknown issue")
 def test_ijxyz_import3():
     """Import some IJ XYZ small set yet again."""
     logger.info("Import and export...")


### PR DESCRIPTION
Refers to issue #530. Python 3.9 support for PYPI is limited to Linux only, as the dependency pytables seems to miss wheels for Windows and MacOS for this python version. 

EDIT(1): pytables is not a build dependency, still I have trouble with running a multibuild install for Python 3.9 for MacOS and Windows

EDIT(2): The pytables package is currently not important (just for some code that has a "experimental" flag, i,.e wells export to HDF5 via pandas) so a fix is to make pypi for all platforms, and limit the tests for MacOS and Win until pytables is ready for Python 3.9 in PYPI. See also issue #539.