### PR TITLE
BUG: change datatype for counters, related to #537

### DIFF
--- a/src/clib/xtg/grd3d_scan_roffbinary.c
+++ b/src/clib/xtg/grd3d_scan_roffbinary.c
@@ -110,7 +110,8 @@ _scan_roff_bin_record(FILE *fc,
      */
 
     /* int swap = 0; */
-    int ndat, nrec, i, n, ic;
+    int nrec, ndat;
+    int i, n, ic;
     int bsize = 0;
     const int FAIL = -88;
     char tmpname[ROFFSTRLEN] = "";
@@ -296,7 +297,7 @@ _scan_roff_bin_record(FILE *fc,
                             ncum += _roffbinstring(fc, cname[nrec]);
                         }
                     } else {
-                        ncum += bsize * ndat;
+                        ncum += (long)bsize * (long)ndat;
                         if (fseek(fc, ncum, SEEK_SET) != 0)
                             return FAIL;
                     }


### PR DESCRIPTION
This is a quite small commit, awaiting a rewrite of the ROFF scan (#536), but it fix an urgent issue. It solves reading very large ROFF files described in #537.