### PR TITLE
BUG: fix bound for zcorn in grd3d_translate

### DIFF
--- a/src/clib/xtg/grd3d_translate.c
+++ b/src/clib/xtg/grd3d_translate.c
@@ -50,7 +50,7 @@ grd3d_translate(int nx,
 
 {
     /* locals */
-    int i, j, ic, ib, nzcorn, iok = 0;
+    int i, j, ic, ib, iok = 0;
 
     logger_info(LI, FI, FU, "Do translation or pure flipping");
 
@@ -80,8 +80,7 @@ grd3d_translate(int nx,
     }
 
     /* zcorn section     */
-    nzcorn = 4 * nx * ny * (nz + 1);
-    for (ic = 0; ic <= nzcorn; ic++) {
+    for (ic = 0; ic < nzcornin; ic++) {
         zcornsv[ic] = zflip * (zcornsv[ic] + zshift);
     }
 


### PR DESCRIPTION
In `grd3d_translate` the loop goes beyond the bound of zcorn. The function should probably use the given size of the vector anyways.