### PR TITLE
FIX: Reduce size of generated test grid for limit

### DIFF
--- a/tests/test_grid3d/grid_generator.py
+++ b/tests/test_grid3d/grid_generator.py
@@ -1,7 +1,7 @@
 import hypothesis.strategies as st
 from xtgeo.grid3d import Grid
 
-indecies = st.integers(min_value=4, max_value=10)
+indecies = st.integers(min_value=4, max_value=9)
 coordinates = st.floats(min_value=-100.0, max_value=100.0)
 increments = st.floats(min_value=1.0, max_value=100.0)
 dimensions = st.tuples(indecies, indecies, indecies)


### PR DESCRIPTION
The test data generated before made the test flaky on some hardware
setups