### PR TITLE
FIX: change error to warning

### DIFF
--- a/src/clib/xtg/x_ijk2ib.c
+++ b/src/clib/xtg/x_ijk2ib.c
@@ -9,11 +9,8 @@ x_ijk2ib(long i, long j, long k, long nx, long ny, long nz, int ia_start)
 {
 
     if (i > nx || j > ny || k > nz) {
-        logger_error(LI, FI, FU, "i: %ld, nx: %ld, j: %ld, ny: %ld, k: %ld, nz: %ld\n",
-                     i, nx, j, ny, k, nz);
         return -2;
     } else if (i < 1 || j < 1 || k < 1) {
-        logger_error(LI, FI, FU, "i: %ld, j: %ld, k: %ld\n", i, j, k);
         return -2;
     }
 
@@ -33,11 +30,8 @@ x_ijk2ic(long i, long j, long k, long nx, long ny, long nz, int ia_start)
 {
 
     if (i > nx || j > ny || k > nz) {
-        logger_error(LI, FI, FU, "i: %ld, nx: %ld, j: %ld, ny: %ld, k: %ld, nz: %ld\n",
-                     i, nx, j, ny, k, nz);
         return -2;
     } else if (i < 1 || j < 1 || k < 1) {
-        logger_error(LI, FI, FU, "i: %ld, j: %ld, k: %ld\n", i, j, k);
         return -2;
     }
 


### PR DESCRIPTION
It is perhaps a bit drastic to log an error if we go outside the grid. I have changed it to warning here, but maybe it should be removed altogether?