### PR TITLE
BLD: remove swig install - comes preinstalled

### DIFF
--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: "sh scripts/swig_manylinux.sh"
       CIBW_BEFORE_TEST: >
         pushd {project} &&
         pip install -r requirements/requirements.txt &&
@@ -47,7 +46,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: "brew install swig"
       CIBW_BEFORE_TEST: >
         pushd {project} &&
         pip install -r requirements/requirements.txt &&
@@ -106,7 +104,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
       CIBW_BEFORE_TEST: >
         pushd {project} &&
         pip install -r requirements/requirements.txt &&

--- a/.github/workflows/ci-test-xtgeo.yml
+++ b/.github/workflows/ci-test-xtgeo.yml
@@ -32,14 +32,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install swig (osx)
-        if: matrix.os == 'macos-latest'
-        run: brew install swig
-
-      - name: Install swig (win)
-        if: matrix.os == 'windows-latest'
-        run: "choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
-
       - name: Install xtgeo
         run: >
           python -m pip install pip -U &&

--- a/.github/workflows/deploy-xtgeo-pypi.yml
+++ b/.github/workflows/deploy-xtgeo-pypi.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: "sh scripts/swig_manylinux.sh"
       CIBW_BEFORE_TEST: >
         pushd {project} &&
         pip install -r requirements/requirements.txt &&
@@ -55,7 +54,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: "brew install swig"
       CIBW_BEFORE_TEST: >
         pushd {project} &&
         pip install -r requirements/requirements.txt &&
@@ -123,7 +121,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      CIBW_BEFORE_ALL: choco install -y --no-progress --allow-empty-checksums -r swig --version=4.0.1"
       CIBW_BEFORE_TEST: >
         pushd {project} &&
         pip install -r requirements/requirements.txt &&


### PR DESCRIPTION
Github actions included swig in setup:
https://github.com/actions/virtual-environments/issues/3342

Solves: #569 