### PR TITLE
TST: Reduce disk usage of export/import benchmarks

### DIFF
--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest
 hypothesis
+pytest-benchmark

--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -121,7 +121,7 @@ files_formats = {
 
 
 @pytest.mark.parametrize("filename", files_formats.keys())
-def xtgeo_file_properties(testpath, filename):
+def test_xtgeo_file_properties(testpath, filename):
     gfile = xtgeo._XTGeoFile(testpath / filename)
 
     assert isinstance(gfile, xtgeo._XTGeoFile)
@@ -130,7 +130,7 @@ def xtgeo_file_properties(testpath, filename):
     assert gfile._memstream is False
     assert gfile._mode == "rb"
     assert gfile._delete_after is False
-    assert gfile.name == (testpath / filename).absolute()
+    assert pathlib.Path(gfile.name) == (testpath / filename).absolute().resolve()
 
     assert "Swig" in str(gfile.get_cfhandle())
     assert gfile.cfclose() is True

--- a/tests/test_common/test_system.py
+++ b/tests/test_common/test_system.py
@@ -120,6 +120,28 @@ files_formats = {
 }
 
 
+def test_xtgeo_file_reinstance(tmp_path):
+    gfile = xtgeo._XTGeoFile(tmp_path / "test.txt")
+
+    with pytest.raises(RuntimeError, match="Reinstancing"):
+        xtgeo._XTGeoFile(gfile)
+
+
+def test_xtgeo_file_bad_input():
+    with pytest.raises(RuntimeError, match="input"):
+        xtgeo._XTGeoFile(1.0)
+
+
+def test_xtgeo_file_bad_alias(tmp_path):
+    grd = xtgeo.Grid()
+    with pytest.raises(ValueError, match="not a valid alias"):
+        xtgeo._XTGeoFile(tmp_path / "$NO_ALIAS").resolve_alias(grd)
+
+
+def test_xtgeo_file_memstream_check_ok():
+    assert xtgeo._XTGeoFile(io.StringIO()).check_file()
+
+
 @pytest.mark.parametrize("filename", files_formats.keys())
 def test_xtgeo_file_properties(testpath, filename):
     gfile = xtgeo._XTGeoFile(testpath / filename)

--- a/tests/test_grid3d/test_grid_property_roff.py
+++ b/tests/test_grid3d/test_grid_property_roff.py
@@ -155,6 +155,11 @@ def test_eq_transitivity(roff_param1, roff_param2, roff_param3):
         assert roff_param1 == roff_param3
 
 
+@given(roff_parameters())
+def test_eq_typing(roff_param):
+    assert roff_param != ""
+
+
 @pytest.mark.parametrize(
     "param, expected_undef",
     [
@@ -281,4 +286,34 @@ def test_from_file_no_filedata(simple_roff_parameter_contents):
     buff.seek(0)
 
     with pytest.raises(ValueError, match="issing non-optional keyword"):
+        RoffParameter.from_file(buff, "b")
+
+
+def test_from_file_double_dimensions(simple_roff_parameter_contents):
+    buff = io.BytesIO()
+    simple_roff_parameter_contents.append(("dimensions", {"nX": 2, "nY": 2, "nZ": 2}))
+    roffio.write(buff, simple_roff_parameter_contents)
+    buff.seek(0)
+
+    with pytest.raises(ValueError, match="Multiple tag"):
+        RoffParameter.from_file(buff, "b")
+
+
+def test_from_file_missing_parameter(simple_roff_parameter_contents):
+    buff = io.BytesIO()
+    simple_roff_parameter_contents[0][1]
+    roffio.write(buff, simple_roff_parameter_contents)
+    buff.seek(0)
+
+    with pytest.raises(ValueError, match="Did not find parameter"):
+        RoffParameter.from_file(buff, "c")
+
+
+def test_from_file_wrong_filetype(simple_roff_parameter_contents):
+    buff = io.BytesIO()
+    simple_roff_parameter_contents[0][1]["filetype"] = "unknown"
+    roffio.write(buff, simple_roff_parameter_contents)
+    buff.seek(0)
+
+    with pytest.raises(ValueError, match="did not have filetype"):
         RoffParameter.from_file(buff, "b")

--- a/tests/test_grid3d/test_grid_property_roff.py
+++ b/tests/test_grid3d/test_grid_property_roff.py
@@ -110,6 +110,7 @@ def grid_properties(draw):
             name,
             discrete=is_discrete,
             codes=dict(zip(code_values, code_names)),
+            values=values,
         )
     else:
         values = draw(arrays(shape=dims, dtype=np.float32, elements=finites))


### PR DESCRIPTION
Several tests were used to benchmark reading/writing. Unfortunately that setup would use a lot of disk space which ends up being problematic on some Jenkins.

The tests were changed to use pytest-benchmark.

Refactoring the benchmarks reduced the test coverage of `_XTGeoFile` so additional unit-tests were added.
roff grid parameters coverage seems dependent on data generation so additional unit tests were added.