### PR TITLE
TST: Use default deadline for surface io tests

### DIFF
--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -18,7 +18,7 @@ jobs:
         git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
       CIBW_TEST_COMMAND: >
         pushd {project} &&
-        pytest tests/test_common --disable-warnings -x --generate-plots
+        pytest tests/test_common --disable-warnings -x --hypothesis-profile ci --generate-plots
       CIBW_BUILD: ${{ matrix.cibw_python }}-manylinux_x86_64
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
 
@@ -114,7 +114,7 @@ jobs:
       # the cibuildwheel on windows cannot find the xtgeo module
       CIBW_TEST_COMMAND: >
         pushd {project} && dir &&
-        pytest tests -x --ignore-glob="*forks.py"
+        pytest tests -x --hypothesis-profile ci --ignore-glob="*forks.py"
 
       CIBW_BUILD: ${{ matrix.cibw_python }}-win_amd64
 
@@ -145,7 +145,7 @@ jobs:
         env:
           CIBW_TEST_COMMAND: >
             pushd {project} &&
-            pytest tests --disable-warnings --ignore tests/test_well
+            pytest tests --disable-warnings --hypothesis-profile ci --ignore tests/test_well
             --ignore-glob="*forks.py" -x
 
         run: |

--- a/.github/workflows/ci-test-xtgeo-merge.yml
+++ b/.github/workflows/ci-test-xtgeo-merge.yml
@@ -31,4 +31,4 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
           pip install -r requirements/requirements_test.txt
-          pytest --disable-warnings -x --generate-plots
+          pytest --disable-warnings -x --hypothesis-profile ci --generate-plots

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,7 +33,7 @@ jobs:
           git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
           pip install -r requirements/requirements_test.txt
           pip install pytest-cov
-          pytest tests --generate-plots --disable-warnings --cov=xtgeo --hypothesis-profile ci --cov-report=xml:xtgeocoverage.xml;
+          pytest tests --generate-plots --disable-warnings --cov=xtgeo --hypothesis-profile ci-fast --cov-report=xml:xtgeocoverage.xml;
 
       - name: Upload coverage to Codecov
         run: |

--- a/.github/workflows/deploy-xtgeo-pypi.yml
+++ b/.github/workflows/deploy-xtgeo-pypi.yml
@@ -61,7 +61,7 @@ jobs:
         git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
       CIBW_TEST_COMMAND: >
         pushd {project} &&
-        pytest tests --disable-warnings
+        pytest tests --disable-warnings --hypothesis-profile ci
       CIBW_BUILD: ${{ matrix.cibw_python }}-macosx_x86_64
 
     strategy:
@@ -93,7 +93,7 @@ jobs:
         env:
           CIBW_TEST_COMMAND: >
             pushd {project} &&
-            pytest tests --disable-warnings --ignore tests/test_well
+            pytest tests --disable-warnings --hypothesis-profile ci --ignore tests/test_well
 
         run: |
           python -m cibuildwheel --output-dir wheelhouse
@@ -131,7 +131,7 @@ jobs:
       # the cibuildwheel on windows cannot find the xtgeo module
       CIBW_TEST_COMMAND: >
         pushd {project} &&
-        pytest tests --disable-warnings --ignore-glob="*forks.py"
+        pytest tests --disable-warnings --hypothesis-profile ci --ignore-glob="*forks.py"
       CIBW_BUILD: ${{ matrix.cibw_python }}-win_amd64
 
     strategy:
@@ -161,7 +161,7 @@ jobs:
         env:
           CIBW_TEST_COMMAND: >
             pushd {project} &&
-            pytest tests --disable-warnings --ignore tests/test_well
+            pytest tests --disable-warnings --hypothesis-profile ci --ignore tests/test_well
             --ignore-glob="*forks.py" -x
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/tests/test_surface/test_file_io.py
+++ b/tests/test_surface/test_file_io.py
@@ -132,7 +132,6 @@ def test_complex_io(surf, fformat, output_engine, input_engine):
 
 @deprecation.fail_if_not_removed
 @pytest.mark.usefixtures("setup_tmpdir")
-@settings(deadline=400)
 @given(surfaces())
 def test_complex_io_hdf(surf):
     surf.to_hdf("my_file")


### PR DESCRIPTION
Default deadlines have changed and are now sufficient for these tests.