### PR TITLE
DOC: Fix docstring of _export_segy_segyio

### DIFF
--- a/src/xtgeo/cube/_cube_export.py
+++ b/src/xtgeo/cube/_cube_export.py
@@ -46,7 +46,6 @@ def _export_segy_segyio(self, sfile, template=None, pristine=False):
         template (str): Use an existing file a template.
         pristine (bool): Make SEGY from scrtach if True; otherwise use an
             existing SEGY file.
-        engine (str): Use 'xtgeo' or (later?) 'segyio'
     """
     logger.debug("Export segy format using segyio...")
 


### PR DESCRIPTION
Docstring had additional argument engine which was not present in function signature.

closes #612 