### PR TITLE
TST: Suppress ci hypothesis healthcheck too_slow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,17 @@ import os
 import platform
 
 import pytest
-from hypothesis import settings
+from hypothesis import HealthCheck, settings
 
-settings.register_profile("ci", max_examples=1000, deadline=None)
-settings.register_profile("ci-fast", max_examples=10, deadline=None)
+settings.register_profile(
+    "ci", max_examples=1000, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+settings.register_profile(
+    "ci-fast",
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
 
 ALLPLATF = set("darwin linux windows".split())
 SKIPPED = set("skipdarwin skiplinux skipwindows".split())


### PR DESCRIPTION
Our CI timings might be unreliable so sometimes hypothesis will report a slow test while the problem is a hiccup on the CI side.