### PR TITLE
ENH: Use abstract interface for grid geometry

### DIFF
--- a/src/xtgeo/corner_point_geometry/__init__.py
+++ b/src/xtgeo/corner_point_geometry/__init__.py
@@ -1,0 +1,6 @@
+"""
+This module regards the general defintion of grid geometry used in most
+petroleum reservoir modelling tools. See
+:class:`xtgeo.corner_point_geometry.CornerPointGeometry` for general interface
+and definition of concepts
+"""

--- a/src/xtgeo/corner_point_geometry/corner_point_geometry.py
+++ b/src/xtgeo/corner_point_geometry/corner_point_geometry.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+from typing import Callable
+
+import numpy as np
+from np.typing import ArrayLike
+
+
+class CornerPointGeometry(ABC):
+    """
+    A CornerPointGeometry describes cells layed out in three dimensions by
+    giving 1) linear corner point lines with a non-zero projection in z
+    direction and 2) set of z-values on each line describing the location of
+    cell corners. The cells are hexagons formed by the corners on 4 adjacent
+    corner lines.
+
+    The corner lines are usually layed out in rows and columns, so one references
+    the corner line by a tuple of indecies (i,j) giving the row (i) and column (j)
+    number of that line.
+
+    The corners are likewise usually layed out in layers: there are 8 corners
+    for each (i,j,k) index (i=row, j=column, k=layer). The reason for there being
+    8 values is due to there being a cell in 8 directions from that position (planar
+    directions north-west, north-east, south-west, south-east and above and below given
+    corner).
+
+    """
+
+    @abstractmethod
+    @property
+    def number_of_rows(self) -> np.integer:
+        ...
+
+    @abstractmethod
+    @property
+    def number_of_columns(self) -> np.integer:
+        ...
+
+    @abstractmethod
+    @property
+    def number_of_layers(self) -> np.integer:
+        ...
+
+    def dimensions(self):
+        return self.number_of_rows, self.number_of_columns, self.number_of_layers
+
+    @abstractmethod
+    @property
+    def coordinates(self) -> ArrayLike[np.number]:
+        """
+        An array with shape (nx, ny, 2, 3) giving the
+        upper and lower corner line points.
+        """
+        ...
+
+    def planar_function(self, i: np.integer, j: np.integer) -> Callable:
+        """
+        Returns:
+            The planar function of the (i,j)th corner point line. Ie. returns
+            x, y coordinates of the line for a given z value:
+
+            # (x,y,z) is a point along the i=0, j=1 corner line
+            x, y = cpg.planar_function(0,1)(z)
+
+        """
+        lower_point = self.coordinates[i, j, 0, :]
+        upper_point = self.coordinates[i, j, 1, :]
+        diff = upper_point - lower_point
+
+        lower_z = lower_point[2]
+        lower_plane = lower_point[(0, 1)]
+        xy_slope = diff[(0, 1)] / diff[2]
+
+        return lambda z: (z - lower_z) * xy_slope + lower_plane
+
+    @abstractmethod
+    def layer_heights(
+        self, i: np.integer, j: np.integer
+    ) -> ArrayLike[(np.integer, np.integer, np.integer, 4, 2), np.number]:
+        """
+        Returns:
+            Array of k heights (z-values) of the intersection between the kth layer
+            and the (i,j)th corner line. First dimension
+            is in the order (nw, ne, sw, se), the second in lower then upper.
+        """
+        ...

--- a/src/xtgeo/corner_point_geometry/operations.py
+++ b/src/xtgeo/corner_point_geometry/operations.py
@@ -1,0 +1,91 @@
+from typing import Callable, List
+
+import numpy as np
+from enums import Enum, auto, unique
+from numpy.typing import ArrayLike, NDArray
+
+from .corner_point_geometry import CornerPointGeometry
+
+
+@unique
+class Handedness(Enum):
+    LEFT = auto()
+    Right = auto()
+
+
+def estimate_handedness(cpg: CornerPointGeometry) -> Handedness:
+    """
+    Estimates the handedness of a corner point geometry
+    """
+    ...
+
+
+@unique
+class LayerDesign(Enum):
+    PROPORTIONAL = auto()
+    TOPCONFORM = auto()
+    BASECONFORM = auto()
+    MIXED = auto()
+
+
+def estimate_design(
+    cpg: CornerPointGeometry, layers: ArrayLike[np.integer]
+) -> LayerDesign:
+    """
+    Estimates the design of a layer, returns None if no design can
+    be determined.
+    """
+    ...
+
+
+def cell_heights(
+    cpg: CornerPointGeometry, i: np.integer, j: np.integer, k: np.integer
+) -> ArrayLike[(4, 2), np.number]:
+    """
+    Returns:
+        Array of the 8 corner heights for the i,j,kth cell
+    """
+    ...
+
+
+def cell_volumes(
+    planar_functions: ArrayLike[4, Callable],
+    corner_heights: ArrayLike[(4, 2), np.number],
+) -> NDArray[np.floating]:
+    """Calculates the bulk volume of one cell"""
+    ...
+
+
+def pillar_heights(
+    cpg: CornerPointGeometry, i: np.integer, j: np.integer, k: np.integer
+) -> ArrayLike[(np.integer, 4, 2), np.number]:
+    """
+    Returns:
+        Array of the 8 corner heights for the i,jth pillar.
+    """
+    ...
+
+
+def pillar_planar_functions(
+    cpg: CornerPointGeometry, i: np.integer, j: np.integer
+) -> List[Callable]:
+    """
+    Returns:
+        The four planar functions for the i,jth pillar.
+    """
+    ...
+
+
+def pillar_volumes(
+    planar_functions: ArrayLike[4, Callable],
+    corner_heights: ArrayLike[(np.integer, np.integer, np.integer), np.number],
+) -> NDArray[np.floating]:
+    """Calculates the bulk volume of the cells in a pillar."""
+    ...
+
+
+def grid_volumes(
+    cpg: CornerPointGeometry,
+) -> NDArray[(np.integer, np.integer, np.integer), np.floating]:
+    """Calculates the bulk volume of all cells in a corner point geometry."""
+    ...


### PR DESCRIPTION
This PR only details a design idea for replacing the corner point geometry calculations of grid with a public facing abstract interface. See #641.

The general idea would be that Grid would contain a `CornerPointGeometry` provided by the importing module (e.g. `RoffGrid`) with a mixin that provides conversion to the legacy format.
