### PR TITLE
BUG: Fix roff subgrids export when values are list

### DIFF
--- a/src/xtgeo/grid3d/_roff_grid.py
+++ b/src/xtgeo/grid3d/_roff_grid.py
@@ -314,7 +314,7 @@ class RoffGrid:
                     "Cannot convert non-consecutive subgrids to roff format."
                 )
             else:
-                subgrids.append(value[-1] - value[0])
+                subgrids.append(value[-1] + 1 - value[0])
         return np.array(subgrids, dtype=np.int32)
 
     @staticmethod

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -985,3 +985,25 @@ def test_grid_get_dxdydz_bad_metric():
         grd.get_dy(metric="foo")
     with pytest.raises(ValueError, match="Unknown metric"):
         grd.get_dz(metric="foo")
+
+
+def test_grid_roff_subgrids_import_regression(tmp_path):
+    grid = Grid()
+    grid.create_box(dimension=(5, 5, 67))
+    grid.subgrids = OrderedDict(
+        [
+            ("subgrid_0", list(range(1, 21))),
+            ("subgrid_1", list(range(21, 53))),
+            ("subgrid_2", list(range(53, 68))),
+        ]
+    )
+    grid.to_file(tmp_path / "grid.roff")
+
+    grid2 = xtgeo.grid_from_file(tmp_path / "grid.roff")
+    assert grid2.subgrids == OrderedDict(
+        [
+            ("subgrid_0", range(1, 21)),
+            ("subgrid_1", range(21, 53)),
+            ("subgrid_2", range(53, 68)),
+        ]
+    )

--- a/tests/test_grid3d/test_grid_roff.py
+++ b/tests/test_grid3d/test_grid_roff.py
@@ -1,4 +1,5 @@
 import io
+from collections import OrderedDict
 from itertools import product
 
 import hypothesis.strategies as st
@@ -301,3 +302,21 @@ def test_eq_symmetry(roff_grid1, roff_grid2):
 def test_eq_transitivity(roff_grid1, roff_grid2, roff_grid3):
     if roff_grid1 == roff_grid2 and roff_grid2 == roff_grid3:
         assert roff_grid1 == roff_grid3
+
+
+def test_from_xtgeo_subgrids():
+    assert list(RoffGrid._from_xtgeo_subgrids(OrderedDict())) == []
+    assert list(
+        RoffGrid._from_xtgeo_subgrids(OrderedDict([("subgrid_0", range(1, 2))]))
+    ) == [1]
+    assert list(RoffGrid._from_xtgeo_subgrids(OrderedDict([("subgrid_0", [1])]))) == [1]
+    assert list(
+        RoffGrid._from_xtgeo_subgrids(
+            OrderedDict([("subgrid_0", [1, 2, 3]), ("subgrid_1", [4])])
+        )
+    ) == [3, 1]
+    assert list(
+        RoffGrid._from_xtgeo_subgrids(
+            OrderedDict([("subgrid_0", range(1, 4)), ("subgrid_1", range(4, 5))])
+        )
+    ) == [3, 1]


### PR DESCRIPTION
When a grid was exported to roff, if the elements of the subgrids dictionary was list, the result would have an off-by-one error.