### PR TITLE
BUG: Use backwards compatible dtype in roff

### DIFF
--- a/src/xtgeo/grid3d/_roff_parameter.py
+++ b/src/xtgeo/grid3d/_roff_parameter.py
@@ -148,31 +148,22 @@ class RoffParameter:
                 list(xtgeo_grid_property.codes.keys()), dtype=np.int32
             )
 
-        values = xtgeo_grid_property.values.astype(xtgeo_grid_property.roxar_dtype)
+        values = xtgeo_grid_property.values
         if not np.ma.isMaskedArray(values):
             if xtgeo_grid_property.isdiscrete:
                 values = np.ma.masked_greater(values, UNDEF_INT_LIMIT)
             else:
                 values = np.ma.masked_greater(values, UNDEF_LIMIT)
 
-        if values.dtype == np.uint8:
-            values = values.filled(255)
-        elif values.dtype == np.uint16:
-            values = values.filled(-999)
-        elif values.dtype == np.float32:
-            values = values.filled(-999.0)
+        if xtgeo_grid_property.isdiscrete:
+            values = values.astype(np.int32).filled(-999)
         else:
-            raise ValueError(f"Unexpected roxar_dtype in parameter {values.dtype}")
+            values = values.astype(np.float64).filled(-999.0)
 
         return RoffParameter(
             *xtgeo_grid_property.dimensions,
             name=xtgeo_grid_property.name,
-            values=np.asarray(
-                np.flip(
-                    values.astype(xtgeo_grid_property.roxar_dtype),
-                    -1,
-                ).ravel()
-            ),
+            values=np.asarray(np.flip(values, -1).ravel()),
             code_names=code_names,
             code_values=code_values,
         )

--- a/tests/test_grid3d/test_grid_property_roff.py
+++ b/tests/test_grid3d/test_grid_property_roff.py
@@ -103,7 +103,7 @@ def grid_properties(draw):
                 elements=st.sampled_from(code_values),
             )
         )
-        return GridProperty(
+        gp = GridProperty(
             None,
             "guess",
             *dims,
@@ -112,8 +112,10 @@ def grid_properties(draw):
             codes=dict(zip(code_values, code_names)),
             values=values,
         )
+        gp.dtype = np.int32
+        return gp
     else:
-        values = draw(arrays(shape=dims, dtype=np.float32, elements=finites))
+        values = draw(arrays(shape=dims, dtype=np.float64, elements=finites))
         return GridProperty(
             None, "guess", *dims, name, discrete=is_discrete, values=values
         )
@@ -302,23 +304,22 @@ def test_from_file_wrong_filetype(simple_roff_parameter_contents):
 
 
 @pytest.mark.parametrize(
-    "xtgeotype, roxtype, rofftype",
+    "xtgeotype, rofftype",
     [
-        (np.float64, np.float32, "float"),
-        (np.int32, np.uint16, "int"),
-        (np.int8, np.uint8, "byte"),
+        (np.float64, "double"),
+        (np.int32, "int"),
+        (np.uint8, "int"),
     ],
 )
-def test_from_xtgeo_dtype_cast(xtgeotype, roxtype, rofftype):
+def test_from_xtgeo_dtype_cast(xtgeotype, rofftype):
     gp = GridProperty(
         ncol=1,
         nrow=1,
         nlay=1,
-        roxar_dtype=roxtype,
+        discrete=np.issubdtype(xtgeotype, np.integer),
         values=np.zeros((1, 1, 1), dtype=xtgeotype),
     )
     rp = RoffParameter.from_xtgeo_grid_property(gp)
-    assert rp.values.dtype == roxtype
 
     buf = io.StringIO()
     rp.to_file(buf, roff_format=roffio.Format.ASCII)


### PR DESCRIPTION
RoffParameter.from_xtgeo_grid would use roxar_dtype to determine what type to put in the output, but this is potentially error prone and not backwards compatible.

Revert to using isdiscrete member to either use double or int as datatype.