### PR TITLE
BUG: Less warnings about missing mapaxes and unit

### DIFF
--- a/src/xtgeo/grid3d/_ecl_grid.py
+++ b/src/xtgeo/grid3d/_ecl_grid.py
@@ -530,17 +530,23 @@ class EclGrid(ABC):
     def _relative_to_transform(self, xtgeo_coord, relative_to=GridRelative.MAP):
         """Handle relative transform of xtgeo_coord()."""
         mapaxes = self.mapaxes
+        has_mapaxes = True
         if self.mapaxes is None:
             mapaxes = MapAxes()
+            has_mapaxes = False
         axis_units = self.map_axis_units
 
+        has_axis_units = True
         if axis_units is None:
+            axis_units = self.grid_units
+            has_axis_units = False
+
+        if has_mapaxes and not has_axis_units:
             warnings.warn(
                 "Conversion between map and grid axes necessary,"
                 " but axis units is missing, assuming"
                 " no unit conversion necessary"
             )
-            axis_units = self.grid_units
 
         if relative_to == GridRelative.MAP and not self.is_map_relative:
             xtgeo_coord *= self.grid_units.conversion_factor(axis_units)
@@ -638,11 +644,6 @@ class EclGrid(ABC):
 
         axis_units = self.map_axis_units
         if axis_units is None:
-            warnings.warn(
-                "Conversion between map and grid axes necessary,"
-                " but axis units is missing, assuming"
-                " no unit conversion necessary"
-            )
             axis_units = self.grid_units
         if relative_to == GridRelative.MAP and not self.is_map_relative:
             result *= self.grid_units.conversion_factor(self.map_axis_units)

--- a/tests/test_grid3d/test_grid_ecl_grid.py
+++ b/tests/test_grid3d/test_grid_ecl_grid.py
@@ -144,3 +144,18 @@ def test_transform_map_relative_no_double(egrid):
     coord2 = egrid.xtgeo_coord(relative_to=xtgeo.GridRelative.ORIGIN)
 
     assert_allclose(coord1, coord2)
+
+
+@given(xtgeo_compatible_egrids())
+def test_conversion_warning(egrid):
+    with pytest.warns(None) as warnlog:
+        egrid.xtgeo_coord(relative_to=xtgeo.GridRelative.MAP)
+
+    if egrid.mapaxes is not None and egrid.map_axis_units is None:
+        assert (
+            len([w for w in warnlog if "axis units is missing" in str(w.message)]) == 1
+        )
+    else:
+        assert (
+            len([w for w in warnlog if "axis units is missing" in str(w.message)]) == 0
+        )


### PR DESCRIPTION
Before warning would be given if any of map axis and map units were missing, and a conversion was required. However, we only need to warn if map axes are given but no units.