### PR TITLE
Fix egrid nnc amalgamation

### DIFF
--- a/src/xtgeo/grid3d/_ecl_grid.py
+++ b/src/xtgeo/grid3d/_ecl_grid.py
@@ -554,9 +554,8 @@ class EclGrid(ABC):
 
         if has_mapaxes and not has_axis_units:
             warnings.warn(
-                "Conversion between map and grid axes necessary,"
-                " but axis units is missing, assuming"
-                " no unit conversion necessary"
+                "Axis units specification is missing in input, assuming that no "
+                "unit conversion is necessary"
             )
 
         if relative_to == GridRelative.MAP and not self.is_map_relative:

--- a/src/xtgeo/grid3d/_egrid.py
+++ b/src/xtgeo/grid3d/_egrid.py
@@ -671,9 +671,9 @@ class EGrid(EclGrid):
         self.global_grid._check_xtgeo_compatible()
         if self.lgr_sections:
             warnings.warn(
-                "egrid file given with local grid refinements."
-                "LGR's are not directly supported,"
-                "Instead unrefined grid is imported."
+                "UserWarning: egrid file contains local grid refinements (LGR). "
+                "LGR's are not directly supported, only the global grid is "
+                "imported."
             )
 
     @property

--- a/tests/test_grid3d/egrid_generator.py
+++ b/tests/test_grid3d/egrid_generator.py
@@ -130,16 +130,21 @@ def lgr_sections(draw, nx=st.just(2), ny=st.just(2), nz=st.just(2), zcorn=zcorns
 
 nnc_heads = st.builds(xtge.NNCHead, indices, indices)
 
-nnc_sections = st.builds(
-    xtge.NNCSection,
-    nnc_heads,
-    arrays(elements=indices, dtype="int32", shape=st.just(2)),
-    arrays(elements=indices, dtype="int32", shape=st.just(2)),
-    arrays(elements=indices, dtype="int32", shape=st.just(2)),
-    arrays(elements=indices, dtype="int32", shape=st.just(2)),
-    st.tuples(indices, indices),
-    arrays(elements=indices, dtype="int32", shape=st.just(2)),
-    arrays(elements=indices, dtype="int32", shape=st.just(2)),
+nnc_sections = st.one_of(
+    st.builds(
+        xtge.NNCSection,
+        nnc_heads,
+        arrays(elements=indices, dtype="int32", shape=st.just(2)),
+        arrays(elements=indices, dtype="int32", shape=st.just(2)),
+        arrays(elements=indices, dtype="int32", shape=st.just(2)),
+        arrays(elements=indices, dtype="int32", shape=st.just(2)),
+    ),
+    st.builds(
+        xtge.AmalgamationSection,
+        st.tuples(indices, indices),
+        arrays(elements=indices, dtype="int32", shape=st.just(2)),
+        arrays(elements=indices, dtype="int32", shape=st.just(2)),
+    ),
 )
 
 

--- a/tests/test_grid3d/test_grid_ecl_grid.py
+++ b/tests/test_grid3d/test_grid_ecl_grid.py
@@ -151,11 +151,9 @@ def test_conversion_warning(egrid):
     with pytest.warns(None) as warnlog:
         egrid.xtgeo_coord(relative_to=xtgeo.GridRelative.MAP)
 
+    axis_unit_warnings = [w for w in warnlog if "Axis units" in str(w.message)]
+
     if egrid.mapaxes is not None and egrid.map_axis_units is None:
-        assert (
-            len([w for w in warnlog if "axis units is missing" in str(w.message)]) == 1
-        )
+        assert len(axis_unit_warnings) == 1
     else:
-        assert (
-            len([w for w in warnlog if "axis units is missing" in str(w.message)]) == 0
-        )
+        assert len(axis_unit_warnings) == 0

--- a/tests/test_grid3d/test_grid_egrid.py
+++ b/tests/test_grid3d/test_grid_egrid.py
@@ -363,6 +363,31 @@ def test_read_unexpected_section():
         reader.read()
 
 
+def test_read_multiple_amalgamations():
+    buf = io.BytesIO()
+    eclio.write(
+        buf,
+        [
+            ("FILEHEAD", np.zeros((100,), dtype=np.int32)),
+            ("GRIDUNIT", ["METRES  ", "MAP     "]),
+            ("GRIDHEAD", np.ones((100,), dtype=np.int32)),
+            ("ZCORN   ", np.ones((8,), dtype=np.int32)),
+            ("COORD   ", np.ones((4,), dtype=np.int32)),
+            ("ENDGRID ", []),
+            ("NNCHEADA", [1, 2]),
+            ("NNA1    ", []),
+            ("NNA2    ", []),
+            ("NNCHEADA", [1, 3]),
+            ("NNA1    ", []),
+            ("NNA2    ", []),
+        ],
+    )
+    buf.seek(0)
+    reader = xtge.EGridReader(buf)
+    egrid = reader.read()
+    assert len(egrid.nnc_sections) == 2
+
+
 @settings(max_examples=5)
 @given(xtgeo_compatible_egrids())
 def test_coarsening_warning(egrid):


### PR DESCRIPTION
Fixes #727 

The assumption before was that at most one NNCHEADA would follow a NNCHEAD keyword in a EGRID file.

This assumption was incorrect. The code has changed so that the number of NNCHEAD is independent from the number of NNCHEADA and they might come interspersed in any order.

It seems that libraries and simulators implementing LGR's output these sections with NNCHEAD before NNCHEADA, ordered in some way by LGR index. The current implementation is oblivious to this detail, but does preserve the order of these sections.