### PR TITLE
BUG: handle not found file in surface_from_file

### DIFF
--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -1082,6 +1082,7 @@ class RegularSurface:
 
         """
         mfile = xtgeosys._XTGeoFile(mfile)
+        mfile.check_file(raiseerror=ValueError)
         if fformat is None or fformat == "guess":
             fformat = mfile.detect_fformat()
         else:

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -39,6 +39,11 @@ TESTSET6C = TPATH / "surfaces/etc/seabed_p_v2.pmd"
 FENCE1 = TPATH / "polygons/reek/1/fence.pol"
 
 
+def test_surface_from_file_missing(tmp_path):
+    with pytest.raises(ValueError, match="missing"):
+        xtgeo.surface_from_file(tmp_path / "nosuchfile", fformat="irap_binary")
+
+
 @pytest.mark.filterwarnings("ignore:Default values*")
 def test_values(default_surface):
     """Test behaviour of values attribute."""


### PR DESCRIPTION
surface_from_file would throw a segfault when file is missing, fixed with a check on the python side.