### PR TITLE
Minor code cleaning

### DIFF
--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -505,7 +505,7 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
         zname: str = "Z_TVDSS",
         attributes: Optional[dict] = None,
         filesrc: str = None,
-    ):
+    ):  # pylint: disable=arguments-differ
         """Used in deprecated methods."""
         super()._reset(xname, yname, zname)
 
@@ -923,7 +923,6 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
             pfilter,
             realisation,
             attributes,
-            False,
         )
 
     def copy(self):

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -326,7 +326,7 @@ class Polygons(XYZ):  # pylint: disable=too-many-public-methods
         dtname: str = "T_DELTALEN",
         name: str = "poly",
         attributes: Optional[dict] = None,
-    ):
+    ):  # pylint: disable=arguments-differ
         """Used in deprecated methods."""
 
         super()._reset(xname, yname, zname)

--- a/tests/test_grid3d/test_deprecations.py
+++ b/tests/test_grid3d/test_deprecations.py
@@ -35,34 +35,34 @@ def test_gridproperties_init_deprecations(any_gridprop):
         GridProperties(nlay=10, props=[any_gridprop])
 
 
-def test_grid_from_file_warns(any_grid):
+def test_grid_from_file_warns(tmp_path, any_grid):
     if version.parse(xtgeo_version) < version.parse("2.16"):
         pytest.skip()
 
-    any_grid.to_file("grid.roff", fformat="roff")
+    any_grid.to_file(tmp_path / "grid.roff", fformat="roff")
 
     with pytest.warns(DeprecationWarning, match="from_file is deprecated"):
-        any_grid.from_file("grid.roff", fformat="roff")
+        any_grid.from_file(tmp_path / "grid.roff", fformat="roff")
 
 
-def test_grid_from_hdf_warns(any_grid):
+def test_grid_from_hdf_warns(tmp_path, any_grid):
     if version.parse(xtgeo_version) < version.parse("2.16"):
         pytest.skip()
 
-    any_grid.to_hdf("grid.hdf")
+    any_grid.to_hdf(tmp_path / "grid.hdf")
 
     with pytest.warns(DeprecationWarning, match="from_hdf is deprecated"):
-        any_grid.from_hdf("grid.hdf")
+        any_grid.from_hdf(tmp_path / "grid.hdf")
 
 
-def test_grid_from_xtgf_warns(any_grid):
+def test_grid_from_xtgf_warns(tmp_path, any_grid):
     if version.parse(xtgeo_version) < version.parse("2.16"):
         pytest.skip()
 
-    any_grid.to_xtgf("grid.xtg")
+    any_grid.to_xtgf(tmp_path / "grid.xtg")
 
     with pytest.warns(DeprecationWarning, match="from_xtgf is deprecated"):
-        any_grid.from_xtgf("grid.xtg")
+        any_grid.from_xtgf(tmp_path / "grid.xtg")
 
 
 def test_grid_numpify_warns(any_grid):

--- a/tests/test_grid3d/test_deprecations.py
+++ b/tests/test_grid3d/test_deprecations.py
@@ -1,26 +1,25 @@
 import pathlib
 
 import pytest
-from packaging import version
-
 import xtgeo
+from packaging import version
 from xtgeo import GridProperties, GridProperty
 from xtgeo import version as xtgeo_version
 
 
-@pytest.fixture
-def any_grid():
+@pytest.fixture(name="any_grid")
+def fixture_any_grid():
     grd = xtgeo.create_box_grid((5, 5, 5))
     return grd
 
 
-@pytest.fixture
-def any_gridprop(any_grid):
+@pytest.fixture(name="any_gridprop")
+def fixture_any_gridprop(any_grid):
     return any_grid.get_dz()
 
 
-@pytest.fixture
-def any_gridproperties(any_gridprop):
+@pytest.fixture(name="any_gridproperties")
+def fixture_any_gridproperties(any_gridprop):
     return GridProperties(props=[any_gridprop])
 
 


### PR DESCRIPTION
Minor issues:
* Tests runs (pytest) now give 3 temporary "grid.*" files at the top folder; move these to tmp path
* _reset() methods in Polygons and Points overrrides super _reset(); so rename
* redefine a few fixture names so avoid "outer scope" linting warnings
* Minor reorder of import statements in top of files (automatic from isort/black)