### PR TITLE
TST: Solve compatibility with pytest 7.1

### DIFF
--- a/tests/test_surface/test_file_io.py
+++ b/tests/test_surface/test_file_io.py
@@ -167,7 +167,9 @@ def test_read_cube(data):
     }
     cube = Cube(**cube_input)
     surf_from_cube = RegularSurface._read_cube(cube, data)
-    assert set(surf_from_cube.values.data.flatten().tolist()) == pytest.approx({data})
+    assert list(set(surf_from_cube.values.data.flatten().tolist())) == pytest.approx(
+        [data]
+    )
 
     cube_input.pop("zinc")
     cube_input.pop("nlay")

--- a/tests/test_surface/test_new_surface.py
+++ b/tests/test_surface/test_new_surface.py
@@ -88,7 +88,7 @@ def test_wrong_size_input_lists(data):
 @given(data=st.one_of(st.floats(allow_nan=False), st.integers()))
 def test_input_numbers(data):
     surf = RegularSurface(10, 10, 0.0, 0.0, values=data)
-    assert set(surf.values.data.flatten().tolist()) == pytest.approx({data})
+    assert list(set(surf.values.data.flatten().tolist())) == pytest.approx([data])
 
 
 def test_read_grid3d():


### PR DESCRIPTION
pytest.approx no longer wants to work with unordered sequences