### PR TITLE
Fix issue #767  scanning ECL binary files

### DIFF
--- a/.github/actions/build-xtgeo/action.yml
+++ b/.github/actions/build-xtgeo/action.yml
@@ -15,7 +15,7 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Upgrade pip
-      run: python -m pip install pip -U
+      run: python -m pip install pip "pip<=22.0.4"
       shell: bash
 
     - name: install xtgeo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,17 +62,3 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           files: xtgeocoverage.xml
-  integration:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: "./.github/actions/test_setup"
-        with:
-          python-version: 3.9
-      - name: Set up OPM
-        run: |
-          sudo apt install software-properties-common &&
-          sudo apt-add-repository ppa:opm/ppa &&
-          sudo apt install mpi-default-bin libopm-simulators-bin
-      - name: Integration test
-        run: HAS_OPM=1 python -m pytest -m requires_opm --disable-warnings -x --hypothesis-profile ci

--- a/src/clib/cxtgeo.i
+++ b/src/clib/cxtgeo.i
@@ -34,6 +34,7 @@ typedef uint8_t mbool;
 %cstring_bounded_output(char *swig_bnd_char_10k, 10000);
 %cstring_bounded_output(char *swig_bnd_char_100k, 100000);
 %cstring_bounded_output(char *swig_bnd_char_1m, 1000000);
+%cstring_output_maxsize(char *swig_out_char_msize, int nswig_out_char_msize);
 
 
 /* Create some functions for working with "int *" etc */
@@ -250,6 +251,9 @@ PyDict_SetItemString(d, "XTGeoCLibError", PY_XTGeoCLibError);
 // ARGOUT long no 1
 %apply (long* ARGOUT_ARRAY1, long DIM1) {(long *swig_np_lng_aout_v1,
                                           long n_swig_np_lng_aout_v1)};
+// ARGOUT long no 2
+%apply (long* ARGOUT_ARRAY1, long DIM1) {(long *swig_np_lng_aout_v2,
+                                          long n_swig_np_lng_aout_v2)};
 
 //======================================================================================
 // Inline tranforms

--- a/src/clib/xtg/grd3d_ecl_tsteps.c
+++ b/src/clib/xtg/grd3d_ecl_tsteps.c
@@ -59,7 +59,7 @@ grd3d_ecl_tsteps(FILE *fc, int *seqnums, int *day, int *mon, int *year, int nmax
     float *xfloat = NULL;
     double *xdouble = NULL;
 
-    int maxkw = 1000000;
+    int maxkw = MAXKEYWORDS;
 
     keywords = (char *)calloc(maxkw * 10, sizeof(char));
     rectypes = (int *)calloc(maxkw, sizeof(int));
@@ -69,7 +69,8 @@ grd3d_ecl_tsteps(FILE *fc, int *seqnums, int *day, int *mon, int *year, int nmax
     rewind(fc);
 
     /* do scan */
-    nkeys = grd3d_scan_eclbinary(fc, keywords, rectypes, reclengths, recstarts, maxkw);
+    nkeys = grd3d_scan_eclbinary(fc, keywords, 10 * maxkw, rectypes, maxkw, reclengths,
+                                 maxkw, recstarts, maxkw);
 
     if (nkeys <= 0) {
         throw_exception("No keys received");

--- a/src/clib/xtg/libxtg.h
+++ b/src/clib/xtg/libxtg.h
@@ -80,6 +80,10 @@
 #define UNDEF_ECLINT 0
 #define UNDEF_ECLFLOAT 0
 
+/* eclipse and roff binary read max keywords and dates */
+#define MAXKEYWORDS 1000000
+#define MAXDATES 1000
+
 /*
  *======================================================================================
  * GENERAL XTGEO
@@ -1181,8 +1185,9 @@ grd3d_calc_xyz(int nx,
 
 long
 grd3d_scan_roffbinary(FILE *fc,
-                      int *swig_int_out_p1,    // *swap,
-                      char *swig_bnd_char_1m,  // *tags,
+                      int *swig_int_out_p1,       // *swap,
+                      char *swig_out_char_msize,  // tagletters
+                      int nswig_out_char_msize,
                       int *rectypes,
                       long *reclengths,
                       long *recstarts,
@@ -1209,11 +1214,14 @@ grd3d_conv_roxapi_grid(int nx,
 
 long
 grd3d_scan_eclbinary(FILE *fc,
-                     char *swig_bnd_char_1m,  // *keywords,
-                     int *rectype,
-                     long *reclengths,
-                     long *recstarts,
-                     long maxkw);
+                     char *swig_out_char_msize,  // keywords (as one long string)
+                     int nswig_out_char_msize,
+                     int *swig_np_int_aout_v1,  // rectype
+                     long n_swig_np_int_aout_v1,
+                     long *swig_np_lng_aout_v1,  // reclengths
+                     long n_swig_np_lng_aout_v1,
+                     long *swig_np_lng_aout_v2,  // recstarts
+                     long n_swig_np_lng_aout_v2);
 
 int
 grd3d_read_eclrecord(FILE *fc,

--- a/src/xtgeo/common/constants.py
+++ b/src/xtgeo/common/constants.py
@@ -2,6 +2,7 @@
 """Module for basic XTGeo constants"""
 
 # align with cxtgeo libxtg.h!
+import xtgeo.cxtgeo._cxtgeo as cx
 
 M_PI = 3.14159265358979323846
 PI = M_PI
@@ -17,3 +18,6 @@ VERYLARGENEGATIVE = -10e30
 
 UNDEF_MAP_IRAPB = 1e30
 UNDEF_MAP_IRAPA = 9999900.0000
+
+MAXKEYWORDS = cx.MAXKEYWORDS  # maximum keywords for ECL and ROFF scanning
+MAXDATES = cx.MAXDATES  # maximum keywords for ECL scanning

--- a/src/xtgeo/grid3d/_gridprops_import_eclrun.py
+++ b/src/xtgeo/grid3d/_gridprops_import_eclrun.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from typing import List, Tuple, Union
 
-from typing_extensions import Literal
-
 import xtgeo
+from typing_extensions import Literal
+from xtgeo.common.constants import MAXKEYWORDS
 
 from . import _grid3d_utils as utils
 from ._find_gridprop_in_eclrun import (
@@ -71,6 +71,7 @@ def import_ecl_init_gridproperties(
     names: Union[List[str], Literal["all"]],
     grid,
     strict=True,
+    maxkeys: int = MAXKEYWORDS,
 ) -> List[GridProperty]:
     """Imports list of properties from an init file.
 
@@ -83,6 +84,7 @@ def import_ecl_init_gridproperties(
         names: List of names to fetch, can also be "all" to fetch all properties.
         grid: The grid used by the simulator to produce the restart file.
         strict: If strict=True, will raise error if key is not found.
+        maxkeys: Maximum number of keywords allocated
     Returns:
         List of GridProperty objects fetched from the init file.
     """
@@ -97,7 +99,11 @@ def import_ecl_init_gridproperties(
 
     # scan valid keywords
     kwlist = utils.scan_keywords(
-        pfile, fformat="xecl", maxkeys=100000, dataframe=True, dates=True
+        pfile,
+        fformat="xecl",
+        dataframe=True,
+        dates=True,
+        maxkeys=maxkeys,
     )
 
     validnames = list()
@@ -149,6 +155,7 @@ def import_ecl_restart_gridproperties(
     grid,
     strict: Tuple[bool, bool],
     namestyle: Literal[0, 1],
+    maxkeys: int = MAXKEYWORDS,
 ) -> List[GridProperty]:
     """Imports list of gridproperties from a restart file.
 
@@ -173,6 +180,7 @@ def import_ecl_restart_gridproperties(
             are missing an exception will be raised
         namestyle : 0 (default) for style SWAT_20110223,
             1 for SWAT--2011_02_23 (applies to restart only)
+        maxkeys: Maximum number of keywords allocated
     Returns:
         List of GridProperty objects fetched from the restart file.
     """
@@ -188,7 +196,11 @@ def import_ecl_restart_gridproperties(
 
     # scan valid keywords with dates
     kwlist = utils.scan_keywords(
-        pfile, fformat="xecl", maxkeys=100000, dataframe=True, dates=True
+        pfile,
+        fformat="xecl",
+        dataframe=True,
+        dates=True,
+        maxkeys=maxkeys,
     )
 
     validnamedatepairs, validdates = _process_valid_namesdates(kwlist, grid)

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -8,9 +8,9 @@ from typing import List, Optional
 import deprecation
 import numpy as np
 import pandas as pd
-
 import xtgeo
 from xtgeo.common import XTGDescription, XTGeoDialog
+from xtgeo.common.constants import MAXDATES, MAXKEYWORDS
 
 from . import _grid3d_utils as utils
 from . import _grid_etc1, _gridprops_import_eclrun
@@ -86,6 +86,7 @@ def gridproperties_from_file(
                 grid=grid,
                 names=names,
                 strict=strict[0],
+                maxkeys=MAXKEYWORDS,
             )
         )
     elif fformat.lower() == "unrst":
@@ -97,6 +98,7 @@ def gridproperties_from_file(
                 names=names,
                 namestyle=namestyle,
                 strict=strict,
+                maxkeys=MAXKEYWORDS,
             )
         )
     else:
@@ -731,7 +733,7 @@ class GridProperties(_Grid3D):
 
     @staticmethod
     def scan_keywords(
-        pfile, fformat="xecl", maxkeys=100000, dataframe=False, dates=False
+        pfile, fformat="xecl", maxkeys=MAXKEYWORDS, dataframe=False, dates=False
     ):
         """Quick scan of keywords in Eclipse binary files, or ROFF binary files.
 
@@ -774,7 +776,7 @@ class GridProperties(_Grid3D):
 
     @staticmethod
     def scan_dates(
-        pfile, fformat="unrst", maxdates=1000, dataframe=False, datesonly=False
+        pfile, fformat="unrst", maxdates=MAXDATES, dataframe=False, datesonly=False
     ):
         """Quick scan dates in a simulation restart file.
 


### PR DESCRIPTION
This relates to issue #767  and two issues have been identified and solved:

* Maximum number of keywords need an increase and is now 1 million (was 100 k)
* In case of LGR's the scanning for dates went wrong; this is now fixed

In addition, MAXKEYWORDS and MAXDATES are now centralized, and some other internal fixes (SWIG technical) was done