### PR TITLE
Bump numpy dependency.

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 deprecation
-numpy>=1.13
+numpy>=1.20
 shapely>=1.6.2
 matplotlib>=1.5
 scipy>=0.17


### PR DESCRIPTION
Prevent this failure on import of xtgeo after installing from pip:

```RuntimeError: module compiled against API version 0xe but this version of numpy is 0xd```