### PR TITLE
BLD: Enable CMP0074 NEW to allow SWIG_ROOT

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 
 # These policies are related to SWIG python libraries naming
 if (CMAKE_VERSION VERSION_GREATER 3.12)
+  cmake_policy(SET CMP0074 NEW)
   if (POLICY CMP0078)
     cmake_policy(SET CMP0078 OLD)
   endif()


### PR DESCRIPTION
CMP0074 NEW allows new ways of specifying search paths for
find_program. SWIG_ROOT will be required to to build xtgeo in case
HOSTNAME is empty, but there is no newer SWIG on standard paths.

Testing this on equinor machines can be achieved by executing

```bash
HOSTNAME= pip install . # Fails: Could NOT find SWIG: Found unsuitable version "2.0.10"
SWIG_ROOT=/prog/res/opt/rhel7/swig_4.0.2 HOSTNAME= pip install . # Works
```