### PR TITLE
Roxar api add new features

### DIFF
--- a/src/xtgeo/grid3d/_grid_roxapi.py
+++ b/src/xtgeo/grid3d/_grid_roxapi.py
@@ -5,12 +5,10 @@ import tempfile
 from collections import OrderedDict
 
 import numpy as np
-
 import xtgeo
 import xtgeo.cxtgeo._cxtgeo as _cxtgeo
-
-from xtgeo.common import XTGeoDialog
 from xtgeo import RoxUtils
+from xtgeo.common import XTGeoDialog
 
 xtg = XTGeoDialog()
 

--- a/src/xtgeo/surface/_regsurf_roxapi.py
+++ b/src/xtgeo/surface/_regsurf_roxapi.py
@@ -1,24 +1,54 @@
 # coding: utf-8
 """Roxar API functions for XTGeo RegularSurface."""
-from xtgeo.common import XTGeoDialog
+import os
+import tempfile
+
 from xtgeo import RoxUtils
+from xtgeo.common import XTGeoDialog
 
 xtg = XTGeoDialog()
 
 logger = xtg.functionlogger(__name__)
 
+VALID_STYPES = ["horizons", "zones", "clipboard", "general2d_data", "trends"]
+
+
+def _check_stypes_names_category(roxutils, stype, name, category):
+    """General check of some input values."""
+    stype = stype.lower()
+
+    if stype not in VALID_STYPES:
+        raise ValueError(
+            f"Given stype {stype} is not supported, legal stypes are: {VALID_STYPES}"
+        )
+
+    if not name:
+        raise ValueError("The name is missing or empty.")
+
+    if stype in ("horizons", "zones") and (name is None or not category):
+        raise ValueError(
+            "Need to spesify both name and category for horizons and zones"
+        )
+
+    if stype == "general2d_data" and not roxutils.version_required("1.6"):
+        raise NotImplementedError(
+            "API Support for general2d_data is missing in this RMS version"
+            f"(current API version is {roxutils.roxversion} - required is 1.6"
+        )
+
 
 def import_horizon_roxapi(
     project, name, category, stype, realisation
 ):  # pragma: no cover
-    """Import a Horizon surface via ROXAR API spec."""
-    rox = RoxUtils(project, readonly=True)
+    """Import a Horizon surface via ROXAR API spec. to xtgeo."""
+    roxutils = RoxUtils(project, readonly=True)
 
-    proj = rox.project
+    _check_stypes_names_category(roxutils, stype, name, category)
 
+    proj = roxutils.project
     args = _roxapi_import_surface(proj, name, category, stype, realisation)
 
-    rox.safe_close()
+    roxutils.safe_close()
     return args
 
 
@@ -54,20 +84,32 @@ def _roxapi_import_surface(
         except KeyError as kwe:
             logger.error(kwe)
 
-    elif stype == "clipboard":
+    elif stype in ("clipboard", "general2d_data"):
+        styperef = getattr(proj, stype)
         if category:
             if "|" in category:
                 folders = category.split("|")
             else:
                 folders = category.split("/")
-            rox = proj.clipboard.folders[folders]
+            rox = styperef.folders[folders]
         else:
-            rox = proj.clipboard
+            rox = styperef
+
         roxsurf = rox[name].get_grid(realisation)
         args.update(_roxapi_horizon_to_xtgeo(roxsurf))
 
+    elif stype == "trends":
+
+        if name not in proj.trends.surfaces:
+            logger.info("Name %s is not present in trends", name)
+            raise ValueError(f"Name {name} is not within Trends")
+        rox = proj.trends.surfaces[name]
+
+        roxsurf = rox.get_grid(realisation)
+        args.update(_roxapi_horizon_to_xtgeo(roxsurf))
+
     else:
-        raise ValueError("Invalid stype")
+        raise ValueError(f"Invalid stype given: {stype}")  # should never reach here
     return args
 
 
@@ -90,16 +132,18 @@ def export_horizon_roxapi(
     self, project, name, category, stype, realisation
 ):  # pragma: no cover
     """Export (store) a Horizon surface to RMS via ROXAR API spec."""
-    rox = RoxUtils(project, readonly=False)
+    roxutils = RoxUtils(project, readonly=False)
+
+    _check_stypes_names_category(roxutils, stype, name, category)
 
     logger.info("Surface from xtgeo to roxapi...")
-    _roxapi_export_surface(self, rox.project, name, category, stype, realisation)
+    _roxapi_export_surface(self, roxutils.project, name, category, stype, realisation)
 
-    if rox._roxexternal:
-        rox.project.save()
+    if roxutils._roxexternal:
+        roxutils.project.save()
 
     logger.info("Surface from xtgeo to roxapi... DONE")
-    rox.safe_close()
+    roxutils.safe_close()
 
 
 def _roxapi_export_surface(
@@ -135,22 +179,46 @@ def _roxapi_export_surface(
         except KeyError as kwe:
             logger.error(kwe)
 
-    elif stype == "clipboard":
+    elif stype in ("clipboard", "general2d_data"):
         folders = []
         if category:
             if "|" in category:
                 folders = category.split("|")
             else:
                 folders = category.split("/")
+        styperef = getattr(proj, stype)
         if folders:
-            proj.clipboard.folders.create(folders)
+            styperef.folders.create(folders)
 
-        roxroot = proj.clipboard.create_surface(name, folders)
+        roxroot = styperef.create_surface(name, folders)
         roxg = _xtgeo_to_roxapi_grid(self)
         roxg.set_values(self.values)
         roxroot.set_grid(roxg)
+
+    elif stype == "trends":
+        if name not in proj.trends.surfaces:
+            logger.info("Name %s is not present in trends", name)
+            raise ValueError(
+                f"Name {name} is not within Trends (it must exist in advance!)"
+            )
+        # here a workound; trends.surfaces are read-only in Roxar API, but is seems
+        # that load() in RMS is an (undocumented?) workaround...
+        try:
+            import roxar  # pylint: disable=import-outside-toplevel
+        except ImportError as err:
+            raise ImportError(
+                "roxar not available, this functionality is not available"
+            ) from err
+
+        roxsurf = proj.trends.surfaces[name]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            logger.info("Made a tmp folder: %s", tmpdir)
+            self.to_file(os.path.join(tmpdir, "gxx.gri"), fformat="irap_binary")
+
+            roxsurf.load(os.path.join(tmpdir, "gxx.gri"), roxar.FileFormat.ROXAR_BINARY)
+
     else:
-        raise ValueError("Invalid stype")
+        raise ValueError(f"Invalid stype given: {stype}")  # should never reach here
 
 
 def _xtgeo_to_roxapi_grid(self):  # pragma: no cover

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -34,39 +34,37 @@ or::
 
 # pylint: disable=too-many-public-methods
 
-import sys
-import pathlib
-import io
-from typing import Tuple, Union, Optional, List
 import functools
-
-import numbers
-from copy import deepcopy
+import io
 import math
-from types import FunctionType
+import numbers
+import pathlib
+import sys
 import warnings
-
 from collections import OrderedDict
+from copy import deepcopy
+from types import FunctionType
+from typing import List, Optional, Tuple, Union
 
 import deprecation
 import numpy as np
 import numpy.ma as ma
-
 import pandas as pd
-
 import xtgeo
-from xtgeo.common.constants import VERYLARGENEGATIVE, VERYLARGEPOSITIVE
 import xtgeo.common.sys as xtgeosys
+from xtgeo.common.constants import VERYLARGENEGATIVE, VERYLARGEPOSITIVE
 
-from . import _regsurf_import
-from . import _regsurf_export
-from . import _regsurf_cube
-from . import _regsurf_cube_window
-from . import _regsurf_grid3d
-from . import _regsurf_roxapi
-from . import _regsurf_gridding
-from . import _regsurf_oper
-from . import _regsurf_utils
+from . import (
+    _regsurf_cube,
+    _regsurf_cube_window,
+    _regsurf_export,
+    _regsurf_grid3d,
+    _regsurf_gridding,
+    _regsurf_import,
+    _regsurf_oper,
+    _regsurf_roxapi,
+    _regsurf_utils,
+)
 
 xtg = xtgeo.common.XTGeoDialog()
 logger = xtg.functionlogger(__name__)

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -111,8 +111,12 @@ def surface_from_roxar(project, name, category, stype="horizons", realisation=0)
         project (str or special): Name of project (as folder) if
             outside RMS, og just use the magic project word if within RMS.
         name (str): Name of surface/map
-        category (str): For horizons/zones or clipboard: for example 'DS_extracted'
-        stype (str): RMS folder type, 'horizons' (default), 'zones' or 'clipboard'
+        category (str): For horizons/zones or clipboard/general2d_data:
+            for example 'DS_extracted'. For clipboard/general2d_data this can
+            be empty or None, or use '/' for multiple folder levels (e.g. 'fld/subfld').
+            For 'trends', the category is not applied.
+        stype (str): RMS folder type, 'horizons' (default), 'zones', 'clipboard',
+            'general2d_data' or 'trends'
         realisation (int): Realisation number, default is 0
 
     Example::
@@ -120,6 +124,14 @@ def surface_from_roxar(project, name, category, stype="horizons", realisation=0)
         # inside RMS:
         import xtgeo
         mysurf = xtgeo.surface_from_roxar(project, 'TopEtive', 'DepthSurface')
+
+    Note::
+
+        When dealing with surfaces to and from ``stype="trends"``, the surface must
+        exist in advance, i.e. the Roxar API do not allow creating new surfaces.
+        Actually trends are read only, but a workaround using ``load()`` in Roxar
+        API makes it possible to overwrite existing surface trends. In addition,
+        ``realisation`` is not applied in trends.
 
     """
 
@@ -1320,19 +1332,12 @@ class RegularSurface:
             project (str or special): Name of project (as folder) if
                 outside RMS, og just use the magic project word if within RMS.
             name (str): Name of surface/map
-            category (str): For horizons/zones or clipboard: for example 'DS_extracted'
+            category (str): For horizons/zones or clipboard/general2d_data: for
+                example 'DS_extracted'
             stype (str): RMS folder type, 'horizons' (default), 'zones' or 'clipboard'
             realisation (int): Realisation number, default is 0
 
         """
-        stype = stype.lower()
-        valid_stypes = ["horizons", "zones", "clipboard"]
-
-        if stype not in valid_stypes:
-            raise ValueError(
-                "Invalid stype, only {} stypes is supported.".format(valid_stypes)
-            )
-
         kwargs = _regsurf_roxapi.import_horizon_roxapi(
             project, name, category, stype, realisation
         )
@@ -1371,8 +1376,10 @@ class RegularSurface:
             project (str or special): Name of project (as folder) if
                 outside RMS, og just use the magic project word if within RMS.
             name (str): Name of surface/map
-            category (str): For horizons/zones or clipboard: for example 'DS_extracted'
-            stype (str): RMS folder type, 'horizons' (default), 'zones' or 'clipboard'
+            category (str): For horizons/zones or clipboard/general2d_data: for
+                example 'DS_extracted'
+            stype (str): RMS folder type, 'horizons' (default), 'zones', 'clipboard'
+                or 'general2d_data'
             realisation (int): Realisation number, default is 0
 
         Returns:
@@ -1390,13 +1397,6 @@ class RegularSurface:
 
 
         """
-        valid_stypes = ["horizons", "zones", "clipboard"]
-
-        if stype.lower() not in valid_stypes:
-            raise ValueError(
-                "Invalid stype, only {} stypes is supported.".format(valid_stypes)
-            )
-
         kwargs = _regsurf_roxapi.import_horizon_roxapi(
             project, name, category, stype, realisation
         )
@@ -1425,8 +1425,13 @@ class RegularSurface:
             project (str or special): Name of project (as folder) if
                 outside RMS, og just use the magic project word if within RMS.
             name (str): Name of surface/map
-            category (str): For horizons/zones only: e.g. 'DS_extracted'.
-            stype (str): RMS folder type, 'horizons' (default), 'zones' or 'clipboard'
+            category (str): Required for horizons/zones: e.g. 'DS_extracted'. For
+                clipboard/general2d_data is reperesent the folder(s), where "" or None
+                means no folder, while e.g. "myfolder/subfolder" means that folders
+                myfolder/subfolder will be created if not already present. For
+                stype = 'trends', the category will not be applied
+            stype (str): RMS folder type, 'horizons' (default), 'zones', 'clipboard'
+                'general2d_data', 'trends'
             realisation (int): Realisation number, default is 0
 
         Raises:
@@ -1447,17 +1452,19 @@ class RegularSurface:
               # store in project
               topupperreek.to_roxar(project, 'TopUpperReek', 'DS_something')
 
+        Note::
+
+            When dealing with surfaces to and from ``stype="trends"``, the surface must
+            exist in advance, i.e. the Roxar API do not allow creating new surfaces.
+            Actually trends are read only, but a workaround using ``load()`` in Roxar
+            API makes it possible to overwrite existing surface trends. In addition,
+            ``realisation`` is not applied in trends.
+
+
         .. versionadded:: 2.1 clipboard support
+        .. versionadded:: 2.19 general2d_data and trends support
 
         """
-        stype = stype.lower()
-        valid_stypes = ["horizons", "zones", "clipboard"]
-
-        if stype in valid_stypes and name is None or category is None:
-            logger.error("Need to spesify name and category for " "horizon")
-        elif stype not in valid_stypes:
-            raise ValueError("Only {} stype is supported per now".format(valid_stypes))
-
         _regsurf_roxapi.export_horizon_roxapi(
             self, project, name, category, stype, realisation
         )

--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -164,6 +164,8 @@ def import_rms_attr(pfile, zname="Z_TVDSS"):
                 dfr[col].replace("UNDEF", xtgeo.UNDEF, inplace=True)
             elif _attrs[col] == "int":
                 dfr[col].replace("UNDEF", xtgeo.UNDEF_INT, inplace=True)
+            # cast to numerical if possible
+        dfr[col] = pd.to_numeric(dfr[col], errors="ignore")
 
     kwargs["values"] = dfr
     kwargs["attributes"] = _attrs
@@ -314,9 +316,7 @@ def export_rms_attr(self, pfile, attributes=True, pfilter=None, ispolygons=False
                         df[col].replace(xtgeo.UNDEF, "UNDEF", inplace=True)
 
     with open(pfile, mode) as fc:
-        df.to_csv(
-            fc, sep=" ", header=None, columns=columns, index=False, float_format="%.3f"
-        )
+        df.to_csv(fc, sep=" ", header=None, columns=columns, index=False)
 
     return len(df.index)
 

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -79,12 +79,6 @@ def _roxar_importer(
     realisation: int = 0,
     attributes: bool = False,
 ):
-    stype = stype.lower()
-    valid_stypes = ["horizons", "zones", "faults", "clipboard"]
-
-    if stype not in valid_stypes:
-        raise ValueError(f"Invalid stype, only {valid_stypes} stypes is supported.")
-
     return _xyz_roxapi.import_xyz_roxapi(
         project, name, category, stype, realisation, attributes, False
     )
@@ -219,8 +213,9 @@ def points_from_roxar(
             magic `project` word if within RMS.
         name: Name of points item
         category: For horizons/zones/faults: for example 'DL_depth'
-            or use a folder notation on clipboard.
-        stype: RMS folder type, 'horizons' (default), 'zones', 'clipboard', etc!
+            or use a folder notation on clipboard/general2d_data.
+        stype: RMS folder type, 'horizons' (default), 'zones', 'clipboard',
+            'general2d_data'
         realisation: Realisation number, default is 0
         attributes: If True, attributes will be preserved (from RMS 11)
 
@@ -230,6 +225,7 @@ def points_from_roxar(
         import xtgeo
         mypoints = xtgeo.points_from_roxar(project, 'TopEtive', 'DP_seismic')
 
+    .. versionadded:: 2.19 general2d_data support is added
     """
 
     return Points(
@@ -645,7 +641,7 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
                 outside RMS, og just use the magic project word if within RMS.
             name (str): Name of polygons item
             category (str): For horizons/zones/faults: for example 'DL_depth'
-                or use a folder notation on clipboard.
+                or use a folder notation on clipboard/general2d_data.
 
             stype (str): RMS folder type, 'horizons' (default) or 'zones' etc!
             realisation (int): Realisation number, default is 0
@@ -895,7 +891,7 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
             pfilter (dict): Filter on e.g. top name(s) with keys TopName
                 or ZoneName as {'TopName': ['Top1', 'Top2']}
             stype (str): RMS folder type, 'horizons' (default), 'zones'
-                or 'faults' or 'clipboard'  (in prep: well picks)
+                or 'faults' or 'clipboard', general2d_data (in prep: well picks)
             realisation (int): Realisation number, default is 0
             attributes (bool): If True, attributes will be preserved (from RMS 11)
 
@@ -907,9 +903,17 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
             ValueError: Various types of invalid inputs.
             NotImplementedError: Not supported in this ROXAPI version
 
+        .. versionadded:: 2.19 general2d_data support is added
         """
 
-        valid_stypes = ["horizons", "zones", "faults", "clipboard", "horizon_picks"]
+        valid_stypes = [
+            "horizons",
+            "zones",
+            "faults",
+            "clipboard",
+            "general2d_data",
+            "horizon_picks",
+        ]
 
         if stype.lower() not in valid_stypes:
             raise ValueError(f"Invalid stype, only {valid_stypes} stypes is supported.")
@@ -919,7 +923,7 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
             project,
             name,
             category,
-            stype.lower(),
+            stype,
             pfilter,
             realisation,
             attributes,

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -63,12 +63,6 @@ def _roxar_importer(
     stype: Optional[str] = "horizons",
     realisation: Optional[int] = 0,
 ):  # pragma: no cover
-    stype = stype.lower()
-    valid_stypes = ["horizons", "zones", "faults", "clipboard"]
-
-    if stype not in valid_stypes:
-        raise ValueError(f"Invalid stype, only {valid_stypes} stypes is supported.")
-
     kwargs = _xyz_roxapi.import_xyz_roxapi(
         project, name, category, stype, realisation, None, True
     )
@@ -147,15 +141,17 @@ def polygons_from_roxar(
             `project` word if within RMS.
         name: Name of polygons item
         category: For horizons/zones/faults: for example 'DL_depth'
-            or use a folder notation on clipboard.
+            or use a folder notation on clipboard/general2d_data.
         stype: RMS folder type, 'horizons' (default), 'zones', 'clipboard',
-            'faults', ...
+            'faults', 'general2d_data'
         realisation: Realisation number, default is 0
 
     Example::
 
         import xtgeo
         mysurf = xtgeo.polygons_from_roxar(project, 'TopAare', 'DepthPolys')
+
+    .. versionadded:: 2.19 general2d_data support is added
     """
 
     return Polygons(
@@ -528,7 +524,8 @@ class Polygons(XYZ):  # pylint: disable=too-many-public-methods
             project (str or special): Name of project (as folder) if
                 outside RMS, og just use the magic project word if within RMS.
             name (str): Name of polygons item
-            category (str): For horizons/zones/faults: for example 'DL_depth'
+            category (str): For horizons/zones/faults: for example 'DL_depth' and use
+                a folder notation for clipboard/general2d_data
             stype (str): RMS folder type, 'horizons' (default), 'zones'
                 or 'faults' or 'clipboard'  (in prep: well picks)
             realisation (int): Realisation number, default is 0
@@ -541,19 +538,15 @@ class Polygons(XYZ):  # pylint: disable=too-many-public-methods
             ValueError: Various types of invalid inputs.
             NotImplementedError: Not supported in this ROXAPI version
 
+        .. versionadded:: 2.19 general2d_data support is added
         """
-
-        valid_stypes = ["horizons", "zones", "faults", "clipboard"]
-
-        if stype.lower() not in valid_stypes:
-            raise ValueError(f"Invalid stype, only {valid_stypes} stypes is supported.")
 
         _xyz_roxapi.export_xyz_roxapi(
             self,
             project,
             name,
             category,
-            stype.lower(),
+            stype,
             None,
             realisation,
             None,

--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -8,6 +8,7 @@ Then run tests in Roxar API which focus on IO.
 
 This requires a ROXAPI license, and to be ran in a "roxenvbash" environment if Equinor.
 """
+from collections import OrderedDict
 from os.path import join
 
 import numpy as np
@@ -15,6 +16,7 @@ import pytest
 import xtgeo
 
 try:
+    import _roxar
     import roxar
 except ImportError:
     pass
@@ -181,7 +183,7 @@ def test_rox_wells(roxar_project):
 @pytest.mark.requires_roxar
 def test_rox_get_gridproperty(roxar_project):
     """Get a grid property from a RMS project."""
-    print("Project is {}".format(roxar_project))
+    logger.info("Project is %s", roxar_project)
 
     poro = xtgeo.gridproperty_from_roxar(roxar_project, GRIDNAME1, PORONAME1)
 

--- a/tests/test_xyz/test_points.py
+++ b/tests/test_xyz/test_points.py
@@ -161,11 +161,17 @@ def test_import_rmsattr_format(testpath, tmp_path):
 def test_export_points_rmsattr(testpath, tmp_path):
     """Export XYZ points to file, as rmsattr."""
 
-    mypoints = Points(testpath / POINTSET4)  # should guess based on extesion
+    mypoints = xtgeo.points_from_file(
+        testpath / POINTSET4
+    )  # should guess based on extesion
     output_path = tmp_path / "poi_export.rmsattr"
 
     mypoints.to_file(output_path, fformat="rms_attr")
-    mypoints2 = Points(output_path)
+    mypoints2 = xtgeo.points_from_file(output_path)
 
     assert mypoints.dataframe["Seg"].equals(mypoints2.dataframe["Seg"])
-    assert mypoints.dataframe["MyNum"].equals(mypoints2.dataframe["MyNum"])
+
+    np.testing.assert_array_almost_equal(
+        mypoints.dataframe["MyNum"].values,
+        mypoints2.dataframe["MyNum"].values,
+    )


### PR DESCRIPTION
This PR has several commits targeted to Roxar API:
* General improvements/refactor in RMS integration tests
* Add support for "General 2D" in RMS GUI tree (Roxar API >= 1.6) for both `RegularSurface()` and `_XYZ()` based classes
* Add support for Trend Surfaces in RMS GUI
* Add support for writing subzones/subgrids for Roxar API >= 1.6
* From Roxar API 1.6, setting and getting point attributes via the API is possible and now implemented. Earlier a workaround using tmp files and `save()` + `load() `have been implemented, which should still work for Roxar  API < 1.6. Polygons support is postponed.