### PR TITLE
BUG: ensure raising a ValueError if return -1

### DIFF
--- a/src/clib/xtg/surf_import_ijxyz_tmpl.c
+++ b/src/clib/xtg/surf_import_ijxyz_tmpl.c
@@ -114,8 +114,7 @@ surf_import_ijxyz_tmpl(FILE *fd,
         /* some sanity tests first */
         if (iline < ilines[0] || iline > ilines[nncol - 1] || xline < xlines[0] ||
             xline > xlines[nnrow - 1]) {
-            logger_error(LI, FI, FU, "ILINE or XLINE in file outside template ranges");
-            return -1;
+            return -1;  // handle this code as error in client
         }
 
         found = 0;

--- a/src/xtgeo/surface/_regsurf_import.py
+++ b/src/xtgeo/surface/_regsurf_import.py
@@ -342,7 +342,7 @@ def _import_ijxyz_tmpl(mfile, template):
         )
 
     elif ier != 0:
-        raise RuntimeError(f"Unknown error when trying to import the IJXYZ based file!")
+        raise RuntimeError("Unknown error when trying to import the IJXYZ based file!")
 
     val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
 


### PR DESCRIPTION
The C function surf_import_ijxyz_tmpl may return -1 which means that using a template fails. Earlier this was not handled; now a ValueError is raised in the receiving python code. Context: Auto4D bug report.

This Exception is then used in the auto4D code to make a workaround.
