### PR TITLE
add new supported file format for regsurf for docs

### DIFF
--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -79,7 +79,7 @@ def surface_from_file(mfile, fformat=None, template=None, values=True, engine="c
 
     Args:
         mfile (str): Name of file
-        fformat: File format, None/guess/irap_binary/irap_ascii/ijxyz is currently
+        fformat: File format, None/guess/irap_binary/irap_ascii/ijxyz/petromod/zmap_ascii/xtg/hdf is currently
             supported. If None or guess, the file 'signature' is used to guess format
             first, then file extension.
         template: Only valid if ``ijxyz`` format, where an existing Cube or

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -79,9 +79,9 @@ def surface_from_file(mfile, fformat=None, template=None, values=True, engine="c
 
     Args:
         mfile (str): Name of file
-        fformat: File format, None/guess/irap_binary/irap_ascii/ijxyz/petromod/zmap_ascii/xtg/hdf is currently
-            supported. If None or guess, the file 'signature' is used to guess format
-            first, then file extension.
+        fformat: File format, None/guess/irap_binary/irap_ascii/ijxyz/petromod/
+            zmap_ascii/xtg/hdf is currently supported. If None or guess, the file
+            'signature' is used to guess format first, then file extension.
         template: Only valid if ``ijxyz`` format, where an existing Cube or
             RegularSurface instance is applied to get correct topology.
         values (bool): If True (default), surface values will be read (Irap binary only)


### PR DESCRIPTION
Supported file format for creating regsurf from file has not been updated for a while. This adds all supported format to docs based on https://github.com/equinor/xtgeo/blob/629c61b5c680d6ed66c3a270231bb1d589bcfdf5/src/xtgeo/surface/regular_surface.py#L184