### PR TITLE
Resolve `generate_hash()` collisions in regular surfaces (#677)

### DIFF
--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -39,7 +39,6 @@ import io
 import math
 import numbers
 import pathlib
-import sys
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
@@ -898,15 +897,13 @@ class RegularSurface:
             "yinc",
             "yflip",
             "rotation",
-            "values",
         )
-        opt = np.get_printoptions()
-        np.set_printoptions(threshold=sys.maxsize)
         gid = ""
         for req in required:
             gid += f"{getattr(self, '_' + req)}"
+        # Ignore the mask
+        gid += self._values.data.tobytes().hex()
 
-        np.set_printoptions(**opt)
         hash_ = xtgeosys.generic_hash(gid, hashmethod=hashmethod)
         return hash_
 

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -34,6 +34,8 @@ TESTSET5 = TPATH / "surfaces/reek/2/02_midreek_rota.gri"
 TESTSET6A = TPATH / "surfaces/etc/seabed_p.pmd"
 TESTSET6B = TPATH / "surfaces/etc/seabed_p.gri"
 TESTSET6C = TPATH / "surfaces/etc/seabed_p_v2.pmd"
+TESTSET7A = TPATH / "surfaces/etc/topvolantis_genhash.gri"
+TESTSET7B = TPATH / "surfaces/etc/toptherys_genhash.gri"
 
 FENCE1 = TPATH / "polygons/reek/1/fence.pol"
 
@@ -1187,3 +1189,28 @@ def test_loadvalues_after_remove(default_surface):
         ValueError, match="Can only load values into object initialised from file"
     ):
         srf.load_values()
+
+
+def test_genhash_deterministic():
+    """Check that generate_hash() is deterministic"""
+    xsurf = xtgeo.surface_from_file(TESTSET7A)
+    ysurf = xtgeo.surface_from_file(TESTSET7A)
+
+    xhash = xsurf.generate_hash()
+    yhash = ysurf.generate_hash()
+
+    assert xhash == yhash
+
+
+def test_genhash_same_mask():
+    """
+    Check if generate_hash() returns the same hash when properties are the
+    same, actual values differ, but the masked values are equivalent.
+    """
+    xsurf = xtgeo.surface_from_file(TESTSET7A)
+    ysurf = xtgeo.surface_from_file(TESTSET7B)
+
+    xhash = xsurf.generate_hash()
+    yhash = ysurf.generate_hash()
+
+    assert xhash != yhash

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -1209,8 +1209,12 @@ def test_genhash_same_mask():
     """
     xsurf = xtgeo.surface_from_file(TESTSET7A)
     ysurf = xtgeo.surface_from_file(TESTSET7B)
+    zsurf = xtgeo.surface_from_file(TESTSET6A)
 
     xhash = xsurf.generate_hash()
     yhash = ysurf.generate_hash()
+    zhash = zsurf.generate_hash()
 
     assert xhash != yhash
+    assert xhash != zhash
+    assert yhash != zhash


### PR DESCRIPTION
When regular surfaces are imported via `_import_irap_binary_purepy()` their string representations show as masked in their entirety despite having unmasked values. As discovered in (#677) this can cause hash collisions. It's not clear to me why numpy represents arrays like this in this particular case.

The solution in this PR is to ignore the mask and concatenate the non-masked bytes-as-hex to the hashed string. Simply converting the non-masked array to a string was significantly slower, hence the tobytes-hex. This avoids the problematic behavior while staying accurate to the underlying data in the file.

Some simple tests are included. They require the files referenced in the original issue to be added to xtgeo-testdata.