### PR TITLE
Fail gracefully when GridProperties `scan_dates()`/`scan_keywords()` are given a non-existent file

### DIFF
--- a/src/clib/xtg/grd3d_ecl_tsteps.c
+++ b/src/clib/xtg/grd3d_ecl_tsteps.c
@@ -61,6 +61,11 @@ grd3d_ecl_tsteps(FILE *fc, int *seqnums, int *day, int *mon, int *year, int nmax
 
     int maxkw = MAXKEYWORDS;
 
+    if (fc == NULL) {
+        throw_exception("NULL file descriptor received");
+        return EXIT_FAILURE;
+    }
+
     keywords = (char *)calloc(maxkw * 10, sizeof(char));
     rectypes = (int *)calloc(maxkw, sizeof(int));
     reclengths = (long *)calloc(maxkw, sizeof(long));

--- a/src/clib/xtg/grd3d_ecl_tsteps.c
+++ b/src/clib/xtg/grd3d_ecl_tsteps.c
@@ -62,7 +62,8 @@ grd3d_ecl_tsteps(FILE *fc, int *seqnums, int *day, int *mon, int *year, int nmax
     int maxkw = MAXKEYWORDS;
 
     if (fc == NULL) {
-        throw_exception("NULL file descriptor received");
+        throw_exception("Unrecoverable error, NULL file pointer received "
+                        "(grd3d_ecl_tsteps)");
         return EXIT_FAILURE;
     }
 

--- a/src/clib/xtg/grd3d_scan_eclbinary.c
+++ b/src/clib/xtg/grd3d_scan_eclbinary.c
@@ -194,6 +194,12 @@ grd3d_scan_eclbinary(FILE *fc,
     const int FAIL = -99;
     const int _FAIL = -88;
 
+    if (fc == NULL) {
+        throw_exception("Unrecoverable error, NULL file pointer received "
+                        "(grd3d_scan_eclbinary)");
+        return EXIT_FAILURE;
+    }
+
     if (nkeywords_x_letters > INT_MAX) {
         throw_exception("Unrecoverable error, number of requested keyword letters "
                         "exceeds system limit (grd3d_scan_eclbinary)");

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -766,8 +766,11 @@ class GridProperties(_Grid3D):
             >>> dlist = GridProperties.scan_keywords(reek_dir + "/REEK.UNRST")
 
         """
+        pfile = xtgeo._XTGeoFile(pfile)
+        pfile.check_file(raiseerror=ValueError)
+
         return utils.scan_keywords(
-            xtgeo._XTGeoFile(pfile),
+            pfile,
             fformat=fformat,
             maxkeys=maxkeys,
             dataframe=dataframe,
@@ -803,9 +806,10 @@ class GridProperties(_Grid3D):
         """
         logger.info("Format supported as default is %s", fformat)
 
-        dlist = utils.scan_dates(
-            xtgeo._XTGeoFile(pfile), maxdates=maxdates, dataframe=dataframe
-        )
+        pfile = xtgeo._XTGeoFile(pfile)
+        pfile.check_file(raiseerror=ValueError)
+
+        dlist = utils.scan_dates(pfile, maxdates=maxdates, dataframe=dataframe)
 
         if datesonly and dataframe:
             dlist.drop("SEQNUM", axis=1, inplace=True)

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -138,6 +138,12 @@ def test_scan_dates():
     assert dl[2][1] == 20000201
 
 
+def test_scan_dates_invalid_file():
+    """Raise an error before trying to scan a non-existent file."""
+    with pytest.raises(ValueError, match="does not exist"):
+        GridProperties.scan_dates(TPATH / "notafile.UNRST")
+
+
 def test_dates_from_restart():
     """A simpler static method to scan dates in a RESTART file"""
     t1 = xtg.timer()
@@ -159,6 +165,12 @@ def test_scan_keywords():
     assert df.loc[12, "KEYWORD"] == "SWAT"  # pylint: disable=no-member
 
 
+def test_scan_keywords_invalid_file():
+    """Raise an error before trying to scan a non-existent file."""
+    with pytest.raises(ValueError, match="does not exist"):
+        GridProperties.scan_keywords(TPATH / "notafile.UNRST")
+
+
 def test_scan_keywords_roff():
     """A static method to scan quickly keywords in a ROFF file"""
     t1 = xtg.timer()
@@ -166,9 +178,6 @@ def test_scan_keywords_roff():
     t2 = xtg.timer(t1)
     logger.info("Dates scanned in {} seconds".format(t2))
     logger.info(df)
-
-
-#    assert df.loc[12, 'KEYWORD'] == 'SWAT'
 
 
 def test_get_dataframe():


### PR DESCRIPTION
As noted in (#714), when given a non-existent file, `scan_dates()` and `scan_keywords()` segfault. The segfault is a result of calling `rewind()` on the `NULL` `FILE *` pointer passed to the C-layer functions.

This PR resolves the problem at both the Python and C side by checking the existence of the file in Python, but still failing more gracefully in C as a fail-back if a `NULL` pointer somehow makes it there besides. A more robust solution to this genera of problem might be a reasonably placed call to `check_file()` on the instantiation of an `_XTGeoFile` object.

Simple tests included.