### PR TITLE
ENH: Update ACTNUM based on value of PORV in INIT file

### DIFF
--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -55,6 +55,9 @@ DUALROFF = TPATH / "3dgrids/etc/dual_grid_w_props.roff"
 
 BANAL7 = TPATH / "3dgrids/etc/banal7_grid_params.roff"
 
+INTERSECTGRID = TPATH / "3dgrids/simpleb8/IX_BO.EGRID"
+INTERSECTINIT = TPATH / "3dgrids/simpleb8/IX_BO.INIT"
+
 
 def test_create():
     """Create a simple property"""
@@ -375,6 +378,18 @@ def test_grdecl_import_reek(tmpdir):
         exportfile, name="PORO", fformat="bgrdecl", grid=rgrid
     )
     assert poro.values.mean() == pytest.approx(porox.values.mean(), abs=0.001)
+
+
+def test_egrid_read_intersect():
+    """
+    Test reading properties from intersect export egrid and init
+    The ACTNUM should be updated based on PORV from init file
+    """
+    grid = xtgeo.grid_from_file(INTERSECTGRID, fformat="egrid")
+    actnum = grid.get_actnum_indices()
+    xtgeo.gridproperty_from_file(INTERSECTINIT, fformat="init", name="PORO", grid=grid)
+    new_actnum = grid.get_actnum_indices()
+    assert not np.array_equal(actnum, new_actnum)
 
 
 def test_io_roff_discrete(tmpdir):


### PR DESCRIPTION
This PR is to address issue #753 where EGRID file reported 23 active cells from total 24 cells. But in the INIT file, the properties are reported for either 24 cells or 22 active cells.

The approach that have been done in ResInsight is to override ACTNUM when PORV is found in INIT file.
https://github.com/OPM/ResInsight/blob/6d5e303361a1aa91d0ad01ab3987e2abaaf8dab6/ApplicationLibCode/FileInterface/RifActiveCellsReader.cpp#L55-L114

