### PR TITLE
FIX: change error to warning for ZCORN splits/overlaps

### DIFF
--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         cibw_python: [cp36, cp37, cp38, cp39, cp310]
         os:
-          - runs_on: ubuntu-latest
+          - runs_on: ubuntu-20.04  # upgrade to u-latest when 3.6 is deprecated in xtgeo
             cibw_image: manylinux_x86_64
           - runs_on: windows-latest
             cibw_image: win_amd64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,11 @@ jobs:
   fast:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest]
         include:
+          - os: ubuntu-20.04
+            python-version: 3.6
           - os: macos-latest
             python-version: 3.6
           - os: macos-latest

--- a/src/xtgeo/grid3d/_ecl_grid.py
+++ b/src/xtgeo/grid3d/_ecl_grid.py
@@ -617,7 +617,15 @@ class EclGrid(ABC):
             zcorn[:, :, :, :, 1, : nz - 1], zcorn[:, :, :, :, 0, 1:], atol=1e-2
         ):
 
-            raise ValueError("xtgeo does not support grids with horizontal split.")
+            warnings.warn(
+                "An Eclipse style grid with vertical ZCORN splits "
+                "or overlaps between vertical neighbouring cells is detected. XTGeo "
+                "will import the grid as if the cell layers are connected, "
+                "hence check result carefully. "
+                "(Note also that this check both active and inactive cells!)",
+                UserWarning,
+            )
+
         result = np.zeros((nx + 1, ny + 1, nz + 1, 4), dtype=np.float32)
 
         # xtgeo uses 4 z values per i,j,k to mean the 4 z values of


### PR DESCRIPTION
This is triggered by cases where OPM-Flow seems to output EGRID with splits in inactive cells.