### PR TITLE
BUG: handling of ECL keywords with spaces in scanning

### DIFF
--- a/src/xtgeo/grid3d/_grid3d_utils.py
+++ b/src/xtgeo/grid3d/_grid3d_utils.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 """Some grid utilities, file scanning etc (methods with no class)"""
+import re
+
 import pandas as pd
+
 import xtgeo
 import xtgeo.cxtgeo._cxtgeo as _cxtgeo
 from xtgeo import XTGeoCLibError
@@ -99,7 +102,7 @@ def _scan_ecl_keywords(pfile, maxkeys=MAXKEYWORDS, dataframe=False):
             "hard limit"
         )
 
-    keywords = keywords.replace(" ", "")
+    keywords = re.sub(r"\s+\|", "|", keywords)
     keywords = keywords.split("|")
 
     # record types translation (cf: grd3d_scan_eclbinary.c in cxtgeo)

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -7,8 +7,9 @@ import sys
 
 import hypothesis.strategies as st
 import pytest
-import xtgeo
 from hypothesis import assume, given
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.grid3d import GridProperties
 
@@ -28,6 +29,7 @@ logger = xtg.basiclogger(__name__)
 GFILE1 = TPATH / "3dgrids/reek/REEK.EGRID"
 IFILE1 = TPATH / "3dgrids/reek/REEK.INIT"
 RFILE1 = TPATH / "3dgrids/reek/REEK.UNRST"
+RFILE2 = TPATH / "3dgrids/simpleb8/E100_3LETTER_TRACER.UNRST"  # has kword with spaces
 
 XFILE2 = TPATH / "3dgrids/reek/reek_grd_w_props.roff"
 
@@ -163,6 +165,13 @@ def test_scan_keywords():
     logger.info(df)
 
     assert df.loc[12, "KEYWORD"] == "SWAT"  # pylint: disable=no-member
+
+
+def test_scan_ecl_keywords_with_spaces():
+    """Allow and preserve spacing in keywords from Eclipse RESTART file"""
+    df = GridProperties.scan_keywords(RFILE2, dataframe=True)
+
+    assert df.loc[12, "KEYWORD"] == "W2 F"  # pylint: disable=no-member
 
 
 def test_scan_keywords_invalid_file():


### PR DESCRIPTION
This is about eclipse keywords in INIT and UNRST files that may contain spaces, while scanning keys. One known case is usage of tracers in E100 that may provide names like "W8 F".

Solves #834 