### PR TITLE
BUG: reading ROFF multiple gridproperties, "all"

### DIFF
--- a/src/xtgeo/grid3d/_gridprops_import_roff.py
+++ b/src/xtgeo/grid3d/_gridprops_import_roff.py
@@ -1,0 +1,65 @@
+from typing import List, Union
+
+from typing_extensions import Literal
+
+import xtgeo
+from xtgeo.common.sys import _XTGeoFile
+
+from . import _grid3d_utils as utils
+from .grid_property import GridProperty
+
+xtg = xtgeo.common.XTGeoDialog()
+
+logger = xtg.functionlogger(__name__)
+
+
+def import_roff_gridproperties(
+    pfile: _XTGeoFile,
+    names: Union[List[str], Literal["all"]],
+    strict: bool = True,
+) -> List[GridProperty]:
+    """Imports list of properties from a roff file.
+
+    Args:
+        pfile: Reference to the file
+        names: List of names to fetch, can also be "all" to fetch all properties.
+        strict: If strict=True, will raise error if key is not found.
+    Returns:
+        List of GridProperty objects fetched from the ROFF file.
+    """
+    print(pfile)
+    validnames = []
+
+    collectdata = utils.scan_keywords(pfile, fformat="roff")
+    for item in collectdata:
+        keyname = item[0]
+        if keyname.startswith("parameter!name!"):
+            # format is 'parameter!name!FIPNUM'
+            validnames.append(keyname.split("!").pop())
+
+    usenames = []
+    if names == "all":
+        usenames = validnames
+    else:
+        for name in names:
+            if name not in validnames:
+                if strict:
+                    raise ValueError(
+                        f"Requested keyword {name} is not in ROFF file, valid "
+                        f"entries are {validnames}, set strict=False to warn instead."
+                    )
+                else:
+                    logger.warning(
+                        "Requested keyword %s is not in ROFF file. Entry will"
+                        "not be read, set strict=True to raise Error instead.",
+                        name,
+                    )
+            else:
+                usenames.append(name)
+
+    props = [
+        xtgeo.gridproperty_from_file(pfile.file, fformat="roff", name=name)
+        for name in usenames
+    ]
+
+    return props

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -8,12 +8,13 @@ from typing import List, Optional
 import deprecation
 import numpy as np
 import pandas as pd
+
 import xtgeo
 from xtgeo.common import XTGDescription, XTGeoDialog
 from xtgeo.common.constants import MAXDATES, MAXKEYWORDS
 
 from . import _grid3d_utils as utils
-from . import _grid_etc1, _gridprops_import_eclrun
+from . import _grid_etc1, _gridprops_import_eclrun, _gridprops_import_roff
 from ._grid3d import _Grid3D
 from .grid_property import GridProperty
 
@@ -70,14 +71,11 @@ def gridproperties_from_file(
         fformat = pfile.generic_format_by_proposal(fformat)  # default
 
     if fformat.lower() in ["roff_ascii", "roff_binary"]:
-        return GridProperties(
-            props=[
-                xtgeo.gridproperty_from_file(
-                    pfile.file, fformat="roff", name=name, grid=grid
-                )
-                for name in names
-            ]
+
+        props = _gridprops_import_roff.import_roff_gridproperties(
+            pfile, names, strict=strict
         )
+        return GridProperties(props=props)
 
     elif fformat.lower() == "init":
         return GridProperties(

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -7,8 +7,9 @@ import sys
 
 import hypothesis.strategies as st
 import pytest
-import xtgeo
 from hypothesis import assume, given
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.grid3d import GridProperties
 
@@ -215,6 +216,41 @@ def test_get_dataframe_active_only():
 
     df2 = xtgeo.gridproperties_dataframe(gps, activeonly=True, ijk=True, xyz=False)
     assert (df == df2).all().all()
+
+
+def test_gridproperties_all_roff():
+    """Read all gridproperties from ROFF binary format."""
+
+    gps = xtgeo.gridproperties_from_file(
+        XFILE2,
+        fformat="roff",
+        names="all",
+    )
+
+    for name in ("PORV", "PORO", "EQLNUM", "FIPNUM"):
+        assert name in gps.names
+
+
+def test_gridproperties_read_roff_missing_name():
+    """Read gridproperties from ROFF binary format, with one key not present."""
+
+    with pytest.raises(ValueError):
+        gps = xtgeo.gridproperties_from_file(
+            XFILE2,
+            fformat="roff",
+            names=["PORO", "EQLNUM", "NOTPRESENT"],
+            strict=True,
+        )
+
+    gps = xtgeo.gridproperties_from_file(
+        XFILE2,
+        fformat="roff",
+        names=["PORO", "EQLNUM", "NOTPRESENT"],
+        strict=False,
+    )
+
+    assert "PORO" in gps.names
+    assert "NOTPRESENT" not in gps.names
 
 
 @given(gridproperties())


### PR DESCRIPTION
This fix both the `names="all"` issue as well as it checks for valid keywords.

Solves #836 