### PR TITLE
BUG: Fix missing GRIDHEAD giving ungraceful fail

### DIFF
--- a/src/xtgeo/grid3d/_egrid.py
+++ b/src/xtgeo/grid3d/_egrid.py
@@ -856,7 +856,7 @@ class EGridReader:
                 "GRIDUNIT": GridUnit.from_bgrdecl,
                 "GDORIENT": GdOrient.from_bgrdecl,
             },
-            required_keywords={"FILEHEAD"},
+            required_keywords={"FILEHEAD", "GRIDUNIT"},
             stop_keywords=["GRIDHEAD"],
         )
         return EGridHead(**params)

--- a/tests/test_grid3d/test_grid_egrid.py
+++ b/tests/test_grid3d/test_grid_egrid.py
@@ -184,6 +184,22 @@ from .grid_generator import xtgeo_grids
             ],
             "ENDLGR",
         ),
+        (
+            [
+                ("FILEHEAD", np.zeros((100,), dtype=np.int32)),
+                ("GRIDHEAD", np.ones((100,), dtype=np.int32)),
+                ("COORD   ", []),
+                ("ZCORN   ", []),
+                ("ACTNUM  ", []),
+                ("ENDGRID ", []),
+                ("LGR     ", ["name"]),
+                ("GRIDHEAD", np.ones((100,), dtype=np.int32)),
+                ("COORD   ", []),
+                ("ZCORN   ", []),
+                ("HOSTNUM ", []),
+            ],
+            "ENDLGR",
+        ),
     ],
 )
 def test_bad_keywords_raises(file_contents, bad_keyword):


### PR DESCRIPTION
`GRIDUNIT` is marked as a required keyword by the eclipse documentation. If it is missing then the map coordinates conversion will fail with an AttributeError. This is now changed to give an EGridFileFormatError.


We are not sure if this is the correct choice yet. It might be that eclipse chooses a default value for such files and we can reuse that default.