### PR TITLE
Adjust build and add support for python 3.11

### DIFF
--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -26,7 +26,6 @@ jobs:
       # pillow < 8.4 required for CIBW build
       CIBW_BEFORE_TEST: >
         pushd {project} &&
-        pip install "pillow<8.4.0"
         pip install -r requirements/requirements_test.txt &&
         git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
       # Ignore forking tests as they do not work well with CIBW

--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -38,7 +38,7 @@ jobs:
       # Need to skip testing for 3.10 on linux and macosx due to technical trouble with one or more
       # requirements (notably h5py) in the machine setup. But all tests w/ req. works in general
       # testing; cf. test.yml
-      CIBW_TEST_SKIP: "cp310*linux* cp310*macos*"
+      CIBW_TEST_SKIP: "cp312*linux* cp312*macos*"
       CIBW_BEFORE_BUILD: python -m pip install "pip<=22.0.4"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ${{ matrix.os.runs_on }}
     strategy:
       matrix:
-        cibw_python: [cp36, cp37, cp38, cp39, cp310]
+        cibw_python: [cp36, cp37, cp38, cp39, cp310, cp311]
         os:
-          - runs_on: ubuntu-20.04  # upgrade to u-latest when 3.6 is deprecated in xtgeo
+          - runs_on: ubuntu-20.04 # upgrade to u-latest when 3.6 is deprecated in xtgeo
             cibw_image: manylinux_x86_64
           - runs_on: windows-latest
             cibw_image: win_amd64
@@ -30,15 +30,11 @@ jobs:
         pip install -r requirements/requirements_test.txt &&
         git clone --depth 1 https://github.com/equinor/xtgeo-testdata ../xtgeo-testdata
       # Ignore forking tests as they do not work well with CIBW
-      # ignore tests/test_well due to missing pytables wheel
       CIBW_TEST_COMMAND: >
         pushd {project} &&
         pytest  --disable-warnings -x -m "not hypothesis" --ignore tests/test_well --ignore-glob="*forks.py"
       CIBW_BUILD: ${{ matrix.cibw_python }}-${{ matrix.os.cibw_image }}
-      # Need to skip testing for 3.10 on linux and macosx due to technical trouble with one or more
-      # requirements (notably h5py) in the machine setup. But all tests w/ req. works in general
-      # testing; cf. test.yml
-      CIBW_TEST_SKIP: "cp312*linux* cp312*macos*"
+      # CIBW_TEST_SKIP: "cp312*linux* cp312*macos*"
       CIBW_BEFORE_BUILD: python -m pip install "pip<=22.0.4"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,9 +8,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
       - name: Check black style and linting
         run: |
           pip install black
-          black --check *.py src tests --exclude tests/**/snapshots
+          pip freeze
+          black --check *.py src tests --extend-exclude tests/**/snapshots --extend-exclude src/xtgeo/grid3d/grid_properties.py
           pip install flake8
           flake8 src tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,19 @@ jobs:
   fast:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
         os: [ubuntu-latest]
         include:
           - os: ubuntu-20.04
             python-version: 3.6
           - os: macos-latest
-            python-version: 3.6
+            python-version: 3.8
           - os: macos-latest
-            python-version: 3.8
-          - os: windows-latest
-            python-version: 3.6
+            python-version: 3.11
           - os: windows-latest
             python-version: 3.8
+          - os: windows-latest
+            python-version: 3.11
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,9 +7,7 @@ segyio>1.8.0
 pandas>=0.18
 h5py>=3
 hdf5plugin>=2.3
-# await pytables on pypi for PY3.9 macos, win
-tables>=3.5.1; python_version < "3.9" and platform_system != "Linux"
-tables>=3.5.1; platform_system == "Linux"
+tables>=3.5.1
 roffio
 ecl-data-io>=1.0
 typing-extensions

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -23,7 +23,7 @@ segyio>=1.8.6
 matplotlib>=1.5
 scipy>=0.17
 shapely>=1.6.2
-black
+black>=23.1
 autopep8
 pylint
 pytest>=6

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -30,6 +30,4 @@ pytest>=6
 pytest-cov
 h5py>=3
 hdf5plugin>=2.3
-# await pytables on pypi for PY3.9 macos, win
-tables>=3.5; python_version < "3.9" and platform_system != "Linux"
-tables>=3.5; platform_system == "Linux"
+tables>=3.5

--- a/requirements/requirements_dev_rms.txt
+++ b/requirements/requirements_dev_rms.txt
@@ -19,7 +19,7 @@ myst-parser
 bandit
 segyio>=1.8.6
 shapely>=1.6.2
-black
+black>=23.1
 autopep8
 pylint
 pytest>=2.9.2

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -37,7 +37,6 @@ if os.environ.get("XTG_DEBUG_DEV") is None:
 
 
 def _xprint(msg):
-
     difftime = _timer(TIME0)
 
     if DEBUG:
@@ -66,7 +65,6 @@ if not ROXAR:
     ertbool = "LSB_JOBID" in os.environ
 
     if display == "" or "grid" in dhost or "lgc" in dhost or ertbool:
-
         _xprint("")
         _xprint("=" * 79)
 

--- a/src/xtgeo/common/sys.py
+++ b/src/xtgeo/common/sys.py
@@ -136,7 +136,6 @@ class _XTGeoFile(object):
     """
 
     def __init__(self, fobj, mode="rb", obj=None):
-
         self._file = None  # Path instance or BytesIO memory stream
         self._tmpfile = None
         self._delete_after = False  # delete file (e.g. tmp) afterwards
@@ -402,7 +401,6 @@ class _XTGeoFile(object):
             return self._cfhandle
 
         if isinstance(self._file, io.BytesIO) and self._mode == "rb" and islinux:
-
             fobj = self._file.getvalue()  # bytes type in Python3, str in Python2
 
             # note that the typemap in swig computes the length for the buf/fobj!

--- a/src/xtgeo/common/xtgeo_dialog.py
+++ b/src/xtgeo/common/xtgeo_dialog.py
@@ -194,7 +194,6 @@ class _Formatter(logging.Formatter):
     # https://stackoverflow.com/questions/14429724/
     # python-logging-how-do-i-truncate-the-pathname-to-just-the-last-few-characters
     def format(self, record):
-
         filename = "unset_filename"
 
         if "pathname" in record.__dict__.keys():
@@ -257,7 +256,6 @@ class XTGeoDialog(object):  # pylint: disable=too-many-public-methods
 
     @testpath.setter
     def testpath(self, newtestpath):
-
         if not os.path.isdir(newtestpath):
             raise RuntimeError(
                 "Proposed test path is not valid: {}".format(newtestpath)
@@ -584,7 +582,6 @@ class XTGeoDialog(object):  # pylint: disable=too-many-public-methods
         return None
 
     def _output(self, idx, level, string):
-
         prefix = ""
         endfix = ""
 

--- a/src/xtgeo/cube/_cube_export.py
+++ b/src/xtgeo/cube/_cube_export.py
@@ -61,7 +61,6 @@ def _export_segy_segyio(self, sfile, template=None, pristine=False):
     cvalues = self.values
 
     if template is not None and not pristine:
-
         try:
             shutil.copyfile(self._segyfile, sfile)
         except Exception as errormsg:
@@ -71,7 +70,6 @@ def _export_segy_segyio(self, sfile, template=None, pristine=False):
         logger.debug("Input segy file copied ...")
 
         with segyio.open(sfile, "r+") as segyfile:
-
             logger.debug("Output segy file is now open...")
 
             if segyfile.sorting == 1:
@@ -103,7 +101,6 @@ def _export_segy_segyio(self, sfile, template=None, pristine=False):
         spec.xlines = np.arange(self.nrow)
 
         with segyio.create(sfile, spec) as fseg:
-
             # write the line itself to the file and the inline number
             # in all this line's headers
             for ill, ilno in enumerate(spec.ilines):

--- a/src/xtgeo/cube/_cube_import.py
+++ b/src/xtgeo/cube/_cube_import.py
@@ -378,7 +378,6 @@ def _get_coordinate(
 
 
 def _scan_segy_header(sfile, outfile):
-
     ptr_gn_bitsheader = _cxtgeo.new_intpointer()
     ptr_gn_formatcode = _cxtgeo.new_intpointer()
     ptr_gf_segyformat = _cxtgeo.new_floatpointer()
@@ -400,7 +399,6 @@ def _scan_segy_header(sfile, outfile):
 
 
 def _scan_segy_trace(sfile, outfile):
-
     ptr_gn_bitsheader = _cxtgeo.new_intpointer()
     ptr_gn_formatcode = _cxtgeo.new_intpointer()
     ptr_gf_segyformat = _cxtgeo.new_floatpointer()
@@ -496,7 +494,6 @@ def import_stormcube(
     # Scan the header with Python; then use CLIB for the binary data
     sfile = str(sfile.file)
     with open(sfile, "rb") as stf:
-
         iline = 0
 
         ncol = nrow = nlay = nlines = 1

--- a/src/xtgeo/cube/_cube_roxapi.py
+++ b/src/xtgeo/cube/_cube_roxapi.py
@@ -138,7 +138,6 @@ def export_cube_roxapi(
 def _roxapi_export_cube(
     self, proj, rox, name, folder=None, domain="time", compression=("wavelet", 5)
 ):  # type: ignore # pragma: no cover
-
     roxar = None
     try:
         import roxar  # type: ignore

--- a/src/xtgeo/cube/_cube_utils.py
+++ b/src/xtgeo/cube/_cube_utils.py
@@ -31,7 +31,6 @@ def swapaxes(self):
 
 
 def thinning(self, icol, jrow, klay):
-
     inputs = [icol, jrow, klay]
     ranges = [self.nrow, self.ncol, self.nlay]
 
@@ -176,7 +175,6 @@ def get_xy_value_from_ij(self, iloc, jloc, ixline=False, zerobased=False):
         juse = jlst.index(jloc) + 1
 
     if 1 <= iuse <= self.ncol and 1 <= juse <= self.nrow:
-
         ier, xval, yval = _cxtgeo.cube_xy_from_ij(
             iuse,
             juse,

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -241,7 +241,6 @@ class Cube:  # pylint: disable=too-many-public-methods
         segyfile=None,
         filesrc=None,
     ):
-
         self._filesrc = filesrc
         self._xori = xori
         self._yori = yori

--- a/src/xtgeo/grid3d/_ecl_grid.py
+++ b/src/xtgeo/grid3d/_ecl_grid.py
@@ -616,7 +616,6 @@ class EclGrid(ABC):
         if not np.allclose(
             zcorn[:, :, :, :, 1, : nz - 1], zcorn[:, :, :, :, 0, 1:], atol=1e-2
         ):
-
             warnings.warn(
                 "An Eclipse style grid with vertical ZCORN splits "
                 "or overlaps between vertical neighbouring cells is detected. XTGeo "

--- a/src/xtgeo/grid3d/_grid3d.py
+++ b/src/xtgeo/grid3d/_grid3d.py
@@ -11,7 +11,6 @@ class _Grid3D(object):
     """Abstract base class for Grid3D."""
 
     def __init__(self, ncol=4, nrow=3, nlay=5):
-
         self._ncol = ncol
         self._nrow = nrow
         self._nlay = nlay

--- a/src/xtgeo/grid3d/_grid3d_fence.py
+++ b/src/xtgeo/grid3d/_grid3d_fence.py
@@ -143,7 +143,6 @@ def _update_tmpvars(self, force=False):
 def _get_randomline_fence(self, fencespec, hincrement, atleast, nextend):
     """Compute a resampled fence from a Polygons instance."""
     if hincrement is None:
-
         geom = self.get_geometrics()
 
         avgdxdy = 0.5 * (geom[10] + geom[11])

--- a/src/xtgeo/grid3d/_grid3d_utils.py
+++ b/src/xtgeo/grid3d/_grid3d_utils.py
@@ -158,7 +158,6 @@ def _scan_ecl_keywords_w_dates(pfile, maxkeys=MAXKEYWORDS, dataframe=False):
 
 
 def _scan_roff_keywords(pfile, maxkeys=MAXKEYWORDS, dataframe=False):
-
     rectypes = _cxtgeo.new_intarray(maxkeys)
     reclens = _cxtgeo.new_longarray(maxkeys)
     recstarts = _cxtgeo.new_longarray(maxkeys)

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -555,7 +555,6 @@ def get_xyz_corners(self, names=("X_UTME", "Y_UTMN", "Z_TVDSS")):
     )
 
     for i in range(0, 24, 3):
-
         _gridprop_lowlevel.update_values_from_carray(
             grid_props[i], ptr_coord[i], np.float64, delete=True
         )
@@ -742,7 +741,6 @@ def get_geometrics(self, allcells=False, cellcenter=True, return_dict=False, _ve
 
 
 def _get_geometrics_v1(self, allcells=False, cellcenter=True, return_dict=False):
-
     ptr_x = []
     for i in range(13):
         ptr_x.append(_cxtgeo.new_doublepointer())
@@ -1021,7 +1019,6 @@ def crop(self, spec, props=None):  # pylint: disable=too-many-locals
         or kc1 < 1
         or kc2 > self.nlay
     ):
-
         raise ValueError("Boundary for tuples not matching grid" "NCOL, NROW, NLAY")
 
     oldnlay = self._nlay

--- a/src/xtgeo/grid3d/_grid_export.py
+++ b/src/xtgeo/grid3d/_grid_export.py
@@ -117,7 +117,6 @@ def export_hdf5_cpgeom(self, gfile, compression=None, chunks=False, subformat=84
     jmeta = json.dumps(meta).encode()
 
     with h5py.File(gfile.name, "w") as fh5:
-
         grp = fh5.create_group("CornerPointGeometry")
         grp.create_dataset(
             "coord",
@@ -172,7 +171,6 @@ def _define_dtypes(self, fmt, meta):
 
 
 def _transform_vectors(self, meta, dtypecoo, dtypezco, dtypeact):
-
     logger.debug("Transform vectors...")
 
     xshift = meta["_required_"]["xshift"]

--- a/src/xtgeo/grid3d/_grid_import_xtgcpgeom.py
+++ b/src/xtgeo/grid3d/_grid_import_xtgcpgeom.py
@@ -44,7 +44,6 @@ def convert_subgrids(sdict):
 
 
 def handle_metadata(result, meta, ncol, nrow, nlay):
-
     # meta _optional_ *may* contain xshift, xscale etc which in case must be taken
     # into account
     coordsv = result["coordsv"]
@@ -137,7 +136,6 @@ def import_hdf5_cpgeom(mfile, ijkrange=None, zerobased=False):
     """Experimental grid geometry import using hdf5."""
     #
     with h5py.File(mfile.name, "r") as h5h:
-
         grp = h5h["CornerPointGeometry"]
 
         idcode = grp.attrs["format-idcode"]

--- a/src/xtgeo/grid3d/_grid_roxapi.py
+++ b/src/xtgeo/grid3d/_grid_roxapi.py
@@ -199,7 +199,6 @@ def _convert_to_xtgeo_grid_v1(rox, roxgrid, corners, gname):  # pragma: no cover
         logger.debug("Zonation length (N subzones) is %s", len(indexer.zonation))
         subz = OrderedDict()
         for inum, zrange in indexer.zonation.items():
-
             logger.debug("inum: %s, zrange: %s", inum, zrange)
             zname = roxgrid.zone_names[inum]
             logger.debug("zname is: %s", zname)
@@ -293,7 +292,6 @@ def _convert_to_xtgeo_grid_v2(roxgrid, gname):
         logger.debug("Zonation length (N subzones) is %s", len(indexer.zonation))
         subz = OrderedDict()
         for inum, zrange in indexer.zonation.items():
-
             logger.debug("inum: %s, zrange: %s", inum, zrange)
             zname = roxgrid.zone_names[inum]
             logger.debug("zname is: %s", zname)

--- a/src/xtgeo/grid3d/_gridprop_export.py
+++ b/src/xtgeo/grid3d/_gridprop_export.py
@@ -28,7 +28,6 @@ def to_file(self, pfile, fformat="roff", name=None, append=False, dtype=None, fm
         name = self.name
 
     if "roff" in fformat:
-
         binary = True
         if "asc" in fformat:
             binary = False
@@ -59,7 +58,6 @@ def to_file(self, pfile, fformat="roff", name=None, append=False, dtype=None, fm
 
 
 def export_roff(self, pfile, name, binary=True):
-
     logger.info("Export roff to %s", pfile)
     roff_param = RoffParameter.from_xtgeo_grid_property(self)
     roff_param.name = name

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -49,6 +49,7 @@ logger = xtg.functionlogger(__name__)
 # For functions with mask=... ,they should be replaced with asmasked=...
 # --------------------------------------------------------------------------------------
 
+
 # METHODS as wrappers to class init + import
 def _handle_import(grid_constructor, gfile, fformat=None, **kwargs):
     """Handles the import given a constructor.
@@ -314,7 +315,6 @@ class Grid(_Grid3D):
         roxgrid=None,
         roxindexer=None,
     ):
-
         coordsv = np.asarray(coordsv)
         zcornsv = np.asarray(zcornsv)
         actnumsv = np.asarray(actnumsv)
@@ -559,7 +559,6 @@ class Grid(_Grid3D):
 
     @subgrids.setter
     def subgrids(self, sgrids):
-
         if sgrids is None:
             self._subgrids = None
             return
@@ -646,7 +645,6 @@ class Grid(_Grid3D):
 
     @gridprops.setter
     def gridprops(self, gprops):
-
         if not isinstance(gprops, GridProperties):
             raise ValueError("Input must be a GridProperties instance")
 
@@ -678,7 +676,6 @@ class Grid(_Grid3D):
 
     @props.setter
     def props(self, plist):
-
         if not isinstance(plist, list):
             raise ValueError("Input to props must be a list")
 

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import deprecation
 import numpy as np
 import pandas as pd
+
 import xtgeo
 from xtgeo.common import XTGDescription, XTGeoDialog
 from xtgeo.common.constants import MAXDATES, MAXKEYWORDS

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -542,7 +542,6 @@ class GridProperty(_Grid3D):
 
     @geometry.setter
     def geometry(self, geom):
-
         if geom is None:
             self._geometry = None
         elif isinstance(geom, xtgeo.grid3d.Grid) and geom.dimensions == self.dimensions:
@@ -574,7 +573,6 @@ class GridProperty(_Grid3D):
 
     @isdiscrete.setter
     def isdiscrete(self, flag):
-
         if not isinstance(flag, bool):
             raise ValueError("Input to {__name__} must be a bool")
 
@@ -691,7 +689,6 @@ class GridProperty(_Grid3D):
 
     @values.setter
     def values(self, values):
-
         values = self.ensure_correct_values(self.ncol, self.nrow, self.nlay, values)
 
         self._values = values

--- a/src/xtgeo/plot/baseplot.py
+++ b/src/xtgeo/plot/baseplot.py
@@ -58,7 +58,6 @@ class BasePlot(object):
 
     @colormap.setter
     def colormap(self, cmap):
-
         if isinstance(cmap, LinearSegmentedColormap):
             self._colormap = cmap
         elif isinstance(cmap, str):

--- a/src/xtgeo/plot/grid3d_slice.py
+++ b/src/xtgeo/plot/grid3d_slice.py
@@ -152,7 +152,6 @@ class Grid3DSlice(BasePlot):
     #     # plt.gca().set_aspect("equal", adjustable="box")
 
     def _plot_layer(self):
-
         xyc, ibn = self._grid.get_layer_slice(self._index, activeonly=self._active)
 
         xval = xyc[:, :, 0]

--- a/src/xtgeo/plot/xsection.py
+++ b/src/xtgeo/plot/xsection.py
@@ -784,7 +784,6 @@ class XSection(BasePlot):
         )
 
     def _drawlegend(self, ax, bba, title=None):
-
         leg = ax.legend(
             loc="upper left",
             bbox_to_anchor=bba,
@@ -1151,7 +1150,6 @@ class XSection(BasePlot):
         ax = self._ax2
 
         if self.fence is not None:
-
             xwellarray = self._well.dataframe["X_UTME"].values
             ywellarray = self._well.dataframe["Y_UTMN"].values
 
@@ -1194,7 +1192,6 @@ class XSection(BasePlot):
 
         ax = self._ax3
         if self.fence is not None:
-
             xp = self._outline.dataframe["X_UTME"].values
             yp = self._outline.dataframe["Y_UTMN"].values
             ip = self._outline.dataframe["POLY_ID"].values

--- a/src/xtgeo/plot/xtmap.py
+++ b/src/xtgeo/plot/xtmap.py
@@ -179,7 +179,6 @@ class Map(BasePlot):
         aff = fpoly.dataframe.groupby(idname)
 
         for name, _group in aff:
-
             # make a dataframe sorted on faults (groupname)
             myfault = aff.get_group(name)
 
@@ -207,7 +206,6 @@ class Map(BasePlot):
         aff = fpoly.dataframe.groupby(idname)
 
         for _name, group in aff:
-
             # make a dataframe sorted on groupname
             pname = fpoly.name
 

--- a/src/xtgeo/surface/_regsurf_cube_window.py
+++ b/src/xtgeo/surface/_regsurf_cube_window.py
@@ -49,7 +49,6 @@ def slice_cube_window(
     algorithm=1,
 ):
     if algorithm == 1:
-
         if sampling == "cube":
             sampling = "nearest"
 
@@ -106,7 +105,6 @@ def _slice_cube_window_v1(
     showprogress=False,
     deadtraces=True,
 ):
-
     """Slice Cube with a window and extract attribute(s)
 
     This is legacy version algorithm 1 and will removed later.
@@ -279,7 +277,6 @@ def _slice_between_surfaces(
     showprogress=False,
     deadtraces=True,
 ):
-
     """Slice and find values between two surfaces."""
 
     npcollect = []

--- a/src/xtgeo/surface/_regsurf_cube_window_v2.py
+++ b/src/xtgeo/surface/_regsurf_cube_window_v2.py
@@ -46,7 +46,6 @@ def slice_cube_window(
     showprogress=False,
     deadtraces=True,
 ):
-
     if not snapxy:
         attrs = _slice_cube_window_resample(
             self,
@@ -65,7 +64,6 @@ def slice_cube_window(
         )
 
     else:
-
         attrs = _slice_cube_window(
             self,
             cube,
@@ -85,7 +83,6 @@ def slice_cube_window(
     # if attribute is str, self shall be updated and None returned, otherwise a dict
     # of attributes objects shall be returned
     if isinstance(attrs, dict) and len(attrs) == 1 and isinstance(attribute, str):
-
         self.values = attrs[attribute].values
         return None
 
@@ -107,7 +104,6 @@ def _slice_cube_window(
     showprogress,
     deadtraces,
 ):  # pylint: disable=too-many-branches, too-many-statements
-
     """Slice Cube between surfaces to find attributes
 
     New from May 2020, to provide a much faster algorithm and correct some issues

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -68,7 +68,6 @@ def avgsum_from_3dprops_gridding(
     zone_avg=False,
     mask_outside=False,
 ):
-
     """Get surface average from a 3D grid prop."""
     # NOTE:
     # This do _either_ averaging _or_ sum gridding (if summing is True)
@@ -121,7 +120,6 @@ def avgsum_from_3dprops_gridding(
     zoneprop = ma.masked_greater(zoneprop, zone_minmax[1])
 
     for klay0 in range(gnlay):
-
         k1lay = klay0 + 1
 
         if k1lay == 1:
@@ -212,7 +210,6 @@ def avgsum_from_3dprops_gridding(
 def _zone_averaging(
     xprop, yprop, zoneprop, zone_minmax, coarsen, zone_avg, dzprop, mprop, summing=False
 ):
-
     # General preprocessing, and...
     # Change the 3D numpy array so they get layers by
     # averaging across zones. This may speed up a lot,
@@ -318,7 +315,6 @@ def surf_fill(self, fill_value=None):
         else:
             raise ValueError("Keyword fill_value must be int or float")
     else:
-
         invalid = ma.getmaskarray(self.values)
 
         ind = scipy.ndimage.distance_transform_edt(

--- a/src/xtgeo/surface/_regsurf_import.py
+++ b/src/xtgeo/surface/_regsurf_import.py
@@ -100,7 +100,6 @@ def _import_irap_binary_purepy(mfile, values=True):
 
 
 def _import_irap_binary(mfile, values=True):
-
     logger.info("Enter function %s", __name__)
 
     cfhandle = mfile.get_cfhandle()
@@ -507,7 +506,6 @@ def import_hdf5_regsurf(mfile, values=True, **_):
 
     invalues = None
     with h5py.File(mfile.name, "r") as h5h:
-
         grp = h5h["RegularSurface"]
         idcode = grp.attrs["format-idcode"]
         provider = grp.attrs["provider"]

--- a/src/xtgeo/surface/_regsurf_oper.py
+++ b/src/xtgeo/surface/_regsurf_oper.py
@@ -434,7 +434,6 @@ def _get_randomline_fence(self, fencespec, hincrement, atleast, nextend):
     """Compute a resampled fence from a Polygons instance"""
 
     if hincrement is None:
-
         avgdxdy = 0.5 * (self.xinc + self.yinc)
         distance = 0.5 * avgdxdy
     else:

--- a/src/xtgeo/surface/_regsurf_roxapi.py
+++ b/src/xtgeo/surface/_regsurf_roxapi.py
@@ -99,7 +99,6 @@ def _roxapi_import_surface(
         args.update(_roxapi_horizon_to_xtgeo(roxsurf))
 
     elif stype == "trends":
-
         if name not in proj.trends.surfaces:
             logger.info("Name %s is not present in trends", name)
             raise ValueError(f"Name {name} is not within Trends")

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -1117,7 +1117,6 @@ class RegularSurface:
         """
 
         if not self._isloaded:
-
             if self.filesrc is None:
                 raise ValueError(
                     "Can only load values into object initialised from file"

--- a/src/xtgeo/surface/surfaces.py
+++ b/src/xtgeo/surface/surfaces.py
@@ -219,7 +219,6 @@ class Surfaces:
         result["std"] = template.copy()
 
         if percentiles is not None:
-
             # nan on a axis tends to give warnings that are not a worry; suppress:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")

--- a/src/xtgeo/well/_well_roxapi.py
+++ b/src/xtgeo/well/_well_roxapi.py
@@ -179,7 +179,6 @@ def export_well_roxapi(
 
 
 def _roxapi_export_well(xwell1, rox, wname, lognames, logrun, trajectory, realisation):
-
     if wname in rox.project.wells:
         _roxapi_update_well(
             xwell1, rox, wname, lognames, logrun, trajectory, realisation
@@ -210,7 +209,6 @@ def _roxapi_update_well(xwell1, rox, wname, lognames, logrun, trajectory, realis
         uselognames = lognames
 
     for lname in uselognames:
-
         isdiscrete = False
         xtglimit = xtgeo.UNDEF_LIMIT
         if xwell1._wlogtypes[lname] == "DISC":

--- a/src/xtgeo/well/_wellmarkers.py
+++ b/src/xtgeo/well/_wellmarkers.py
@@ -157,7 +157,6 @@ def _extract_ztops(
         pzone = usezonerange[0] - 1
 
     for ind, zone in np.ndenumerate(zlog):
-
         ino = ind[0]  # since ind is a tuple...
 
         if pzone != zone and pzone < iundeflimit and zone < iundeflimit:
@@ -299,7 +298,6 @@ def get_fraction_per_zone(
     count_limit=3,
     zonelogname=None,
 ):  # pylint: disable=too-many-branches, too-many-statements
-
     """Fraction of e.g. a facies in a zone segment.
 
         X_UTME       Y_UTMN    Z_TVDSS  Zonelog  Facies  M_INCL

--- a/src/xtgeo/well/_wells_utils.py
+++ b/src/xtgeo/well/_wells_utils.py
@@ -38,7 +38,6 @@ def wellintersections(
     progress = XTGShowProgress(wlen, show=showprogress, leadtext="progress: ", skip=5)
 
     for iwell, well in enumerate(self.wells):
-
         progress.flush(iwell)
 
         logger.info("Work with %s", well.name)
@@ -64,7 +63,6 @@ def wellintersections(
         nox[well.name] = list()
         # loop over other wells
         for other in self.wells:
-
             if other.name == well.name:
                 continue  # same well
 

--- a/src/xtgeo/well/blocked_well.py
+++ b/src/xtgeo/well/blocked_well.py
@@ -46,7 +46,6 @@ def blockedwell_from_file(
 
 
 def blockedwell_from_roxar(project, gname, bwname, wname, lognames=None, ijk=True):
-
     """This makes an instance of a BlockedWell directly from Roxar RMS.
 
     For arguments, see :meth:`BlockedWell.from_roxar`.
@@ -128,7 +127,6 @@ class BlockedWell(Well):
     VALID_LOGTYPES = {"DISC", "CONT"}
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
 
         self._gridname = None
@@ -144,7 +142,6 @@ class BlockedWell(Well):
         self._gridname = newname
 
     def copy(self):
-
         newbw = super().copy()
 
         newbw._gridname = self._gridname

--- a/src/xtgeo/well/blocked_wells.py
+++ b/src/xtgeo/well/blocked_wells.py
@@ -23,7 +23,6 @@ def blockedwells_from_files(
     zonelogname=None,
     strict=True,
 ):
-
     """Import blocked wells from a list of files (filelist).
 
     Args:
@@ -59,7 +58,6 @@ def blockedwells_from_files(
 def blockedwells_from_roxar(
     project, gname, bwname, lognames=None, ijk=True
 ):  # pragma: no cover
-
     """This makes an instance of a BlockedWells directly from Roxar RMS.
 
     For arguments, see :meth:`BlockedWells.from_roxar`.
@@ -115,7 +113,6 @@ class BlockedWells(Wells):
         strict=True,
         append=True,
     ):
-
         """Import blocked wells from a list of files (filelist).
 
         Args:

--- a/src/xtgeo/well/wells.py
+++ b/src/xtgeo/well/wells.py
@@ -21,7 +21,6 @@ logger = xtg.functionlogger(__name__)
 
 
 def wells_from_files(filelist, *args, **kwargs):
-
     """Import wells from a list of files (filelist).
 
     Creates a Wells object from a list of filenames. Remaining arguments are
@@ -103,7 +102,6 @@ class Wells:
 
     @wells.setter
     def wells(self, well_list):
-
         for well in well_list:
             if not isinstance(well, xtgeo.well.Well):
                 raise ValueError("Well in list not valid Well object")
@@ -157,7 +155,6 @@ class Wells:
         strict=True,
         append=True,
     ):
-
         """Deprecated see :func:`wells_from_files`"""
 
         if not append:

--- a/src/xtgeo/xyz/_xyz_oper.py
+++ b/src/xtgeo/xyz/_xyz_oper.py
@@ -104,7 +104,6 @@ def _rescale_v1(self, distance, addlen, mode2d):
 
     dfrlist = []
     for idx, grp in idgroups:
-
         if len(grp.index) < 2:
             logger.warning("Cannot rescale polygons with less than two points. Skip")
             continue
@@ -166,7 +165,6 @@ def _handle_vertical_input(self, inframe):
     pseudo = self.copy()
 
     if inframe[self.dhname].max() < tolerance:
-
         result.at[0, self.xname] -= edit
         result.at[result.index[-1], self.xname] += edit
         pseudo.dataframe = result
@@ -178,7 +176,6 @@ def _handle_vertical_input(self, inframe):
 
 
 def _rescale_v2(self, distance, addlen, kind="slinear", mode2d=True):
-
     # Rescaling to constant increment is perhaps impossible, but this is
     # perhaps quite close
 
@@ -189,7 +186,6 @@ def _rescale_v2(self, distance, addlen, kind="slinear", mode2d=True):
 
     dfrlist = []
     for idx, grp in idgroups:
-
         grp = _handle_vertical_input(self, grp)
 
         # avoid duplicates when *_DELTALEN are 0.0 (makes scipy interp1d() fail
@@ -468,7 +464,6 @@ def extend(self, distance, nsamples, addhlen=True):
         raise ValueError("Input object of wrong data type, must be Polygons")
 
     for _ in range(nsamples):
-
         # beginning of poly
         row0 = self.dataframe.iloc[0]
         row1 = self.dataframe.iloc[1]

--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -309,7 +309,6 @@ def _roxapi_export_xyz_viafile(
 def _roxapi_export_xyz(
     self, rox, name, category, stype, pfilter, realisation, attributes
 ):  # pragma: no cover
-
     logger.warning("Realisation %s not in use", realisation)
 
     proj = rox.project
@@ -392,7 +391,6 @@ def _cast_dataframe_attrs_to_numeric(dfr):
 def _check_category_etc(
     proj, name, category, stype, realisation, mode="get"
 ):  # pylint: disable=too-many-branches  # pragma: no cover
-
     """Helper to check if valid placeholder' whithin RMS."""
 
     logger.warning("Realisation %s not in use", realisation)
@@ -477,7 +475,6 @@ def _get_roxitem(self, proj, name, category, stype, mode="set"):  # pragma: no c
             roxxyz = roxxyz[name]
 
         elif mode == "set":
-
             # clipboard folders will be created if not present, and overwritten else
             if isinstance(self, xtgeo.Polygons):
                 roxxyz = roxxyz.create_polylines(name, folders)

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -131,7 +131,6 @@ def _wells_dfrac_importer(
     zonelist: list = None,
     zonelogname: str = None,
 ) -> Dict:
-
     """General function, get fraction of discrete code(s) e.g. facies per zone."""
 
     dflist = []
@@ -267,7 +266,6 @@ def points_from_wells(
     zonelist: Optional[list] = None,
     use_undef: bool = False,
 ):
-
     """Get tops or zone points data from a list of wells.
 
     Args:
@@ -316,7 +314,6 @@ def points_from_wells_dfrac(
     zonelist: Optional[list] = None,
     zonelogname: Optional[str] = None,
 ):
-
     """Get fraction of discrete code(s) e.g. facies per zone.
 
     Args:
@@ -777,7 +774,6 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
         zonelist=None,
         use_undef=False,
     ):
-
         """Get tops or zone points data from a list of wells.
 
         Args:
@@ -811,7 +807,6 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
         details="Use direct Points() initialisation instead",
     )
     def from_list(self, plist):
-
         self._reset(_xyz_io._from_list_like(plist, "Z_TVDSS", None, False))
 
     @deprecation.deprecated(
@@ -830,7 +825,6 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
         zonelist=None,
         zonelogname=None,
     ):
-
         """Get fraction of discrete code(s) (e.g. facies) per zone.
 
         Args:

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -172,7 +172,6 @@ def polygons_from_wells(
     zone: Optional[int] = 1,
     resample: Optional[int] = 1,
 ):
-
     """Get polygons from wells and a single zone number.
 
     Args:
@@ -586,7 +585,6 @@ class Polygons(XYZ):  # pylint: disable=too-many-public-methods
         details="Use direct Polygons() initialisation instead",
     )
     def from_list(self, plist):
-
         kwargs = {}
         kwargs["values"] = _xyz_io._from_list_like(plist, "Z_TVDSS", None, True)
         self._reset(**kwargs)

--- a/tests/test_common/test_cxtgeo_lowlevel.py
+++ b/tests/test_common/test_cxtgeo_lowlevel.py
@@ -142,7 +142,6 @@ def test_well_mask_shoulder(depth, logseries, distance, expected):
     ],
 )
 def test_x_interp_map_nodes(xcoords, ycoords, zcoords, xval, yval, method, zexpected):
-
     xv = _cxtgeo.new_doublearray(4)
     yv = _cxtgeo.new_doublearray(4)
     zv = _cxtgeo.new_doublearray(4)

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -157,7 +157,6 @@ def test_emerald_grid_values(emerald_grid):
 
 
 def test_roffbin_get_dataframe_for_grid(emerald_grid):
-
     df = emerald_grid.get_dataframe()
 
     assert len(df) == emerald_grid.nactive

--- a/tests/test_grid3d/test_grid_dual_index.py
+++ b/tests/test_grid3d/test_grid_dual_index.py
@@ -106,7 +106,6 @@ def rsg_grid_mock():
 
 def test_simbox_index():
     with patch("xtgeo.grid3d._grid_roxapi.RoxUtils") as mock_rox_utils:
-
         mock_grid_getter = MagicMock()
         mock_grid_getter.get_grid.return_value = rsg_grid_mock()
         mock_rox_utils.return_value.project.grid_models = {

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -614,7 +614,6 @@ def test_gridprop_grid_and_dim_init(dim, grid, discrete):
 
 @pytest.mark.parametrize("discrete", [True, False])
 def test_gridprop_default(discrete):
-
     default_values = np.ma.MaskedArray(np.full((4, 3, 5), 99), False)
     default_values[0:4, 0, 0:2] = np.ma.masked
 

--- a/tests/test_grid3d/test_grid_xtgformats_io.py
+++ b/tests/test_grid3d/test_grid_xtgformats_io.py
@@ -317,7 +317,6 @@ def benchmark_gridprop_fixture(request, testpath):
 
 @pytest.mark.benchmark(group="import/export grid property")
 def test_benchmark_gridprop_export(benchmark, tmp_path, benchmark_gridprop):
-
     fname = tmp_path / "benchmark.xtgcpprop"
 
     def write():

--- a/tests/test_surface/test_surface_cube_attrs.py
+++ b/tests/test_surface/test_surface_cube_attrs.py
@@ -98,7 +98,6 @@ def test_single_slice_yflip_positive_snapxy(loadsfile1):
     samplings = ["nearest", "trilinear"]
 
     for sampling in samplings:
-
         surf1 = xtgeo.surface_from_cube(cube1, 1000.0)
 
         surf1.slice_cube(cube1, sampling=sampling, snapxy=True, algorithm=2)
@@ -265,7 +264,6 @@ def test_avg_surface_large_cube_algorithm1(benchmark, algorithm):
 
 @pytest.mark.bigtest
 def test_attrs_reek(tmpdir, loadsfile2):
-
     logger.info("Make cube...")
     cube2 = loadsfile2
 

--- a/tests/test_well/test_well.py
+++ b/tests/test_well/test_well.py
@@ -1217,7 +1217,7 @@ def test_get_polygons(string_to_well):
         1
         Zonelog DISC 1 zone1 2 zone2 3 zone3"""
 
-    for (x, y, z) in zip(
+    for x, y, z in zip(
         np.random.random(10), np.random.random(10), np.random.random(10)
     ):
         well_definition += f"\n        {x} {y} {z} 1"

--- a/tests/test_well/test_well_deprecations.py
+++ b/tests/test_well/test_well_deprecations.py
@@ -42,7 +42,6 @@ def test_blockedwell_init_from_file_warns(any_well_file):
 
 
 def test_wells_init_warns(any_well_file):
-
     with pytest.warns(DeprecationWarning, match="directly from file"):
         xtgeo.Wells([any_well_file])
 

--- a/tests/test_well/test_well_to_points.py
+++ b/tests/test_well/test_well_to_points.py
@@ -166,7 +166,6 @@ def test_simple_points(well_spec, expected_result, string_to_well, zonelist, use
 
 
 def test_simple_points_two(string_to_well):
-
     wellstring = """1.01
 Unknown
 name 0 0 0

--- a/tests/test_xyz/test_polygon.py
+++ b/tests/test_xyz/test_polygon.py
@@ -27,7 +27,6 @@ POINTSET2 = pathlib.Path("points/reek/1/pointset2.poi")
     ],
 )
 def test_polygons_from_file_alternatives(testpath, filename, fformat):
-
     polygons1 = xtgeo.polygons_from_file(testpath / filename, fformat=fformat)
     polygons2 = xtgeo.polygons_from_file(testpath / filename)
 

--- a/tests/test_xyz/test_xyz_deprecated.py
+++ b/tests/test_xyz/test_xyz_deprecated.py
@@ -69,7 +69,6 @@ def test_import_from_dataframe_deprecated(testpath):
     ],
 )
 def test_polygons_from_file_alternatives_with_deprecated(testpath, filename, fformat):
-
     if version.parse(xtgeo_version) < version.parse("2.21"):
         # to avoid test failure before tag is actually set
         pytest.skip()


### PR DESCRIPTION
The main issue was to be able to make a `python 3.11` build (a request from a customer). While doing that some reveiw and tuning of other CI settings were done. Support for `python 3.6` is still present in CIBW builds but will be terminated quite soon.

Linting:
A new version of black made some line changes in a number of files. In one particular file, the same `black` command and version in the console made a difference with the `black` check in GH actions, so as a resrt the file `grid_properties.py` is excluded...

