### PR TITLE
Intersect restart issues

### DIFF
--- a/src/xtgeo/grid3d/_ecl_inte_head.py
+++ b/src/xtgeo/grid3d/_ecl_inte_head.py
@@ -91,9 +91,11 @@ class InteHead:
     @property
     def phases(self):
         """The phase system used for simulation"""
-        if "300" in str(self.simulator):
+        if any([ids in str(self.simulator) for ids in ["300", "INTERSECT"]]):
             # item 14 in E300 runs is number of tracers, not IPHS; assume oil/wat/gas
+            # item 14 in INTERSECT is always(?) undef., not IPHS; assume oil/wat/gas
             return Phases.OIL_WATER_GAS
+
         return self._optional_index_lookup(14, Phases)
 
     @property

--- a/tests/test_grid3d/test_ecl_simpleb8_cases.py
+++ b/tests/test_grid3d/test_ecl_simpleb8_cases.py
@@ -1,0 +1,327 @@
+"""Test basic ecl_data_io wrt to xtgeo testdata and core ecl-data-io and xtgeo usage.
+
+Based on 'simpleb8' and ran through various simulators in 2022 by V. Kippe (Equinor):
+
+    E100_BO: Eclipse 100 blackoil (oil/wat/gas + disgas/vapoil)
+
+    E300_BO: Eclipse 300 blackoil
+
+    IX_BO: IX blackoil, EGRID genererated by ‘migrator’ (IX = InterSect)
+
+    IX_BO_GRIDREPORT: IX blackoil, with EGRID from IX itself (may differ!)
+
+    E300_COMP: Eclipse 300 compositional
+
+    IX_COMP: IX compositional, with EGRID from migrator
+
+    IX_COMP_GRIDREPORT: IX compositional, with EGRID from IX
+"""
+import ecl_data_io as eio
+import numpy as np
+import pytest
+
+import xtgeo
+
+xtg = xtgeo.XTGeoDialog()
+
+logger = xtg.basiclogger(__name__)
+
+if not xtg.testsetup():
+    raise SystemExit
+
+TPATH = xtg.testpathobj
+
+SIMPLEB8_PATH = TPATH / "3dgrids/simpleb8"
+
+
+@pytest.mark.parametrize(
+    "ecl_like_file, some_valid_kwords, some_notpresent_kwords",
+    [
+        (
+            "E100_BO.EGRID",
+            ["FILEHEAD", "MAPAXES", "ZCORN", "NNC1"],
+            [],
+        ),
+        (
+            "E100_BO.GRID",
+            ["DIMENS", "GRIDUNIT", "COORDS"],
+            ["FILEHEAD"],
+        ),
+        (
+            "E300_BO.EGRID",
+            ["FILEHEAD", "MAPAXES", "ZCORN", "NNC1"],
+            [],
+        ),
+        (
+            "E300_BO.GRID",
+            ["DIMENS", "GRIDUNIT", "COORDS"],
+            ["FILEHEAD"],
+        ),
+        (
+            "E300_COMP.EGRID",
+            ["FILEHEAD", "MAPAXES", "ZCORN", "NNC1"],
+            [],
+        ),
+        (
+            "IX_BO.EGRID",
+            ["FILEHEAD", "MAPAXES", "ZCORN", "NNC1"],
+            [],
+        ),
+        (
+            "IX_BO.GRID",
+            ["DIMENS", "GRIDUNIT", "COORDS"],
+            ["FILEHEAD"],
+        ),
+        (
+            "IX_COMP.EGRID",
+            ["FILEHEAD", "MAPAXES", "ZCORN", "NNC1"],
+            [],
+        ),
+        (
+            "IX_COMP_GRIDREPORT.EGRID",
+            ["FILEHEAD", "MAPAXES", "ZCORN"],
+            ["NNC1"],  # NNC1 is not in IX "GRIDREPORT" for some reason
+        ),
+    ],
+)
+def test_ecl_data_io_read_grids(
+    ecl_like_file, some_valid_kwords, some_notpresent_kwords
+):
+    """Read grid data, different simulators."""
+    kwords = []
+    ktypes = []
+    for item in eio.lazy_read(SIMPLEB8_PATH / ecl_like_file):
+        kwords.append(item.read_keyword().strip())
+        ktypes.append(item.read_type().strip())
+
+    for kword in some_valid_kwords:
+        assert kword in kwords
+
+    for kword in some_notpresent_kwords:
+        assert kword not in kwords
+
+
+@pytest.mark.parametrize(
+    "ecl_like_file, some_valid_kwords, some_notpresent_kwords",
+    [
+        (
+            "E100_BO.INIT",
+            ["INTEHEAD", "PORO", "PORV"],
+            [],
+        ),
+        (
+            "E300_BO.INIT",
+            ["INTEHEAD", "PORO", "PORV"],
+            [],
+        ),
+        (
+            "IX_BO.INIT",
+            ["INTEHEAD", "PORO", "PORV"],
+            [],
+        ),
+    ],
+)
+def test_ecl_data_io_read_init(
+    ecl_like_file, some_valid_kwords, some_notpresent_kwords
+):
+    """Read INIT data, different simulators."""
+    kwords = []
+    ktypes = []
+    for item in eio.lazy_read(SIMPLEB8_PATH / ecl_like_file):
+        kwords.append(item.read_keyword().strip())
+        ktypes.append(item.read_type().strip())
+
+    for kword in some_valid_kwords:
+        assert kword in kwords
+
+    for kword in some_notpresent_kwords:
+        assert kword not in kwords
+
+
+@pytest.mark.parametrize(
+    "ecl_like_file, some_valid_kwords, some_notpresent_kwords",
+    [
+        (
+            "E100_BO.UNRST",
+            ["INTEHEAD", "PRESSURE", "SWAT", "HIDDEN"],
+            ["SOIL"],
+        ),
+        (
+            "E300_BO.UNRST",
+            ["INTEHEAD", "PRESSURE", "SWAT", "SOIL", "ZPHASE"],
+            ["HIDDEN"],
+        ),
+        (
+            "E300_COMP.UNRST",
+            ["INTEHEAD", "PRESSURE", "SWAT", "SOIL", "ZPHASE"],
+            ["HIDDEN"],
+        ),
+        (
+            "IX_BO.UNRST",
+            ["INTEHEAD", "PRESSURE", "SWAT", "SOIL"],
+            ["HIDDEN", "ZPHASE"],
+        ),
+    ],
+)
+def test_ecl_data_io_read_restart(
+    ecl_like_file, some_valid_kwords, some_notpresent_kwords
+):
+    """Read UNRST data, different simulators."""
+    kwords = []
+    ktypes = []
+    for item in eio.lazy_read(SIMPLEB8_PATH / ecl_like_file):
+        kwords.append(item.read_keyword().strip())
+        ktypes.append(item.read_type().strip())
+
+    for kword in some_valid_kwords:
+        assert kword in kwords
+
+    for kword in some_notpresent_kwords:
+        assert kword not in kwords
+
+    print(kwords)
+
+
+@pytest.mark.parametrize(
+    "ecl_like_grid, ecl_like_init, keywords, expected_averages",
+    [
+        (
+            "E100_BO.EGRID",
+            "E100_BO.INIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+        (
+            "E100_BO.FEGRID",
+            "E100_BO.FINIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+        (
+            "E300_BO.EGRID",
+            "E300_BO.INIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+        (
+            "E300_COMP.EGRID",
+            "E300_COMP.INIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+        (
+            "IX_BO.EGRID",
+            "IX_BO.INIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+        (
+            "IX_COMP.EGRID",
+            "IX_COMP.INIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+        (
+            "IX_COMP_GRIDREPORT.EGRID",
+            "IX_COMP_GRIDREPORT.INIT",
+            ["PORO", "TRANZ"],
+            [0.257455, 571.378237],
+        ),
+    ],
+)
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_egrid_init_read_xtgeo(
+    ecl_like_grid,
+    ecl_like_init,
+    keywords,
+    expected_averages,
+):
+    """Test reading properties from various simulators, egrid and init.
+
+    Internally, xtgeo uses ecl_data_io for Eclipse like data
+    """
+    grid = xtgeo.grid_from_file(SIMPLEB8_PATH / ecl_like_grid)
+    actnum = grid.get_actnum_indices()
+    new_actnum = grid.get_actnum_indices()
+    assert np.array_equal(actnum, new_actnum)
+    for num, keyw in enumerate(keywords):
+        prop = xtgeo.gridproperty_from_file(
+            SIMPLEB8_PATH / ecl_like_init, name=keyw, grid=grid
+        )
+        assert prop.values.mean() == pytest.approx(expected_averages[num], rel=0.001)
+
+
+@pytest.mark.parametrize(
+    "ecl_like_grid, ecl_like_unrst, keywords, date, expected_averages",
+    [
+        (
+            "E100_BO.EGRID",
+            "E100_BO.UNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [270.0358789, 0.98801123],
+        ),
+        (
+            "E100_BO.FEGRID",
+            "E100_BO.FUNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [270.0358789, 0.98801123],
+        ),
+        (
+            "E300_BO.EGRID",
+            "E300_BO.UNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [270.0358789, 0.98801123],
+        ),
+        (
+            "E300_COMP.EGRID",
+            "E300_COMP.UNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [400.72074, 0.951075],
+        ),
+        (
+            "IX_BO.EGRID",
+            "IX_BO.UNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [270.0358789, 0.98801123],
+        ),
+        (
+            "IX_COMP.EGRID",
+            "IX_COMP.UNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [400.72074, 0.951075],
+        ),
+        (
+            "IX_COMP_GRIDREPORT.EGRID",
+            "IX_COMP_GRIDREPORT.UNRST",
+            ["PRESSURE", "SWAT"],
+            20220101,
+            [400.72074, 0.951075],
+        ),
+    ],
+)
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_egrid_unrst_read_xtgeo(
+    ecl_like_grid,
+    ecl_like_unrst,
+    keywords,
+    date,
+    expected_averages,
+):
+    """Test reading properties from various simulators, egrid and unrst
+
+    Internally, xtgeo uses ecl_data_io for Eclipse like data
+    """
+    grid = xtgeo.grid_from_file(SIMPLEB8_PATH / ecl_like_grid)
+
+    for num, keyw in enumerate(keywords):
+        prop = xtgeo.gridproperty_from_file(
+            SIMPLEB8_PATH / ecl_like_unrst, name=keyw, date=date, grid=grid
+        )
+
+        assert prop.values.mean() == pytest.approx(expected_averages[num], rel=0.001)

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -55,13 +55,9 @@ DUALROFF = TPATH / "3dgrids/etc/dual_grid_w_props.roff"
 
 BANAL7 = TPATH / "3dgrids/etc/banal7_grid_params.roff"
 
-INTERSECTGRID = TPATH / "3dgrids/simpleb8/IX_BO.EGRID"
-INTERSECTINIT = TPATH / "3dgrids/simpleb8/IX_BO.INIT"
-
 
 def test_create():
     """Create a simple property"""
-
     x = GridProperty(ncol=4, nrow=3, nlay=1, values=np.array(range(12)), discrete=True)
     assert x.ncol == 4, "NCOL"
     assert x.nrow == 3, "NROW"
@@ -388,18 +384,6 @@ def test_grdecl_import_reek(tmpdir):
         exportfile, name="PORO", fformat="bgrdecl", grid=rgrid
     )
     assert poro.values.mean() == pytest.approx(porox.values.mean(), abs=0.001)
-
-
-def test_egrid_read_intersect():
-    """
-    Test reading properties from intersect export egrid and init
-    The ACTNUM should be updated based on PORV from init file
-    """
-    grid = xtgeo.grid_from_file(INTERSECTGRID, fformat="egrid")
-    actnum = grid.get_actnum_indices()
-    xtgeo.gridproperty_from_file(INTERSECTINIT, fformat="init", name="PORO", grid=grid)
-    new_actnum = grid.get_actnum_indices()
-    assert not np.array_equal(actnum, new_actnum)
 
 
 def test_io_roff_discrete(tmpdir):


### PR DESCRIPTION
This is a follow up of closed PR #807, and is also related to former issues #812 and #814.

- Allow that UNRST produced by INTERSECT have undefined PHASES flag in INTEHEAD, ans assume that oil/wat/gas are always present 
- Fix a special INTERSECT issue/bug where the ACTNUM in the EGRID files does not match the number of properties. So, similar to #807, will now use PORV to decide on active cells. The culprit is that is assumes that a INIT file with same name is present; for practical purposes it is shall be OK in 99%.