### PR TITLE
BUG: correct threshold on dataframe length wrt attrs

### DIFF
--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -353,7 +353,7 @@ def _roxapi_export_xyz(
 
     roxxyz.set_values(arrxyz)
 
-    if attributes and isinstance(self, xtgeo.Points) and len(self.dataframe) > 3:
+    if attributes and isinstance(self, xtgeo.Points) and len(self.dataframe) >= 1:
         dfr = _cast_dataframe_attrs_to_numeric(dfrcopy)
         for name in dfr.columns[3:]:
             values = dfr[name].values
@@ -378,7 +378,7 @@ def _cast_dataframe_attrs_to_numeric(dfr):
     function is applied per attribute column, and will do a conversion if possible;
     otherwise the 'object' dtype will be preserved.
     """
-    if len(dfr) <= 3:
+    if len(dfr) < 1:
         return dfr
 
     newdfr = dfr.copy()


### PR DESCRIPTION
For writing a Points (dataframe) to RMS with attributes, more than 3 wells were required; otherwise no attributes were written back. This is now corrected.