### PR TITLE
Version 3 part2

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,7 @@
 # Release notes
 
+For version 2.21 and later, see https://github.com/equinor/xtgeo/releases !
+
 ## Version 2.20
 
 ### Enhancements

--- a/src/xtgeo/cube/_cube_roxapi.py
+++ b/src/xtgeo/cube/_cube_roxapi.py
@@ -66,10 +66,7 @@ def _roxapi_cube_to_xtgeo(self, rox, rcube):  # pragma: no cover
     logger.info("Cube from roxapi to xtgeo...")
 
     # roxrotation is cube rotation clockwise from azimuth but not consistent
-    if rox.version_required("1.4"):
-        roxrotation = rcube.orientation
-    else:
-        roxrotation = rcube.rotation * -1
+    roxrotation = rcube.orientation
 
     roxhandedness = str(rcube.handedness)
 
@@ -176,29 +173,15 @@ def _roxapi_export_cube(
     ilincr = self.ilines[1] - self.ilines[0]
     xlincr = self.xlines[1] - self.xlines[0]
 
-    if rox.version_required("1.4"):
-        rcube.set_seismic(
-            values,
-            origin,
-            increment,
-            first_z,
-            sample_rate,
-            rotation * -1,
-            vertical_domain=vertical_domain,
-            handedness=handedness,
-            inline_crossline_start=(ilstart, xlstart),
-            inline_crossline_increment=(ilincr, xlincr),
-        )
-    else:
-        rcube.set_cube(
-            values,
-            origin,
-            increment,
-            first_z,
-            sample_rate,
-            rotation,
-            vertical_domain=vertical_domain,
-            handedness=handedness,
-            inline_crossline_start=(ilstart, xlstart),
-            inline_crossline_increment=(ilincr, xlincr),
-        )
+    rcube.set_seismic(
+        values,
+        origin,
+        increment,
+        first_z,
+        sample_rate,
+        rotation * -1,
+        vertical_domain=vertical_domain,
+        handedness=handedness,
+        inline_crossline_start=(ilstart, xlstart),
+        inline_crossline_increment=(ilincr, xlincr),
+    )

--- a/src/xtgeo/grid3d/_grid_roxapi.py
+++ b/src/xtgeo/grid3d/_grid_roxapi.py
@@ -35,7 +35,7 @@ def import_grid_roxapi(
 
     """
     rox = RoxUtils(projectname, readonly=True)
-    if dimonly or not rox.version_required("1.3"):
+    if dimonly:
         return _import_grid_roxapi_v1(rox, gname, realisation, dimonly, info)
     else:
         return _import_grid_roxapi_v2(rox, gname, realisation, info)
@@ -76,28 +76,24 @@ def _import_grid_roxapi_v1(rox, gname, realisation, dimonly, info):  # pragma: n
 
 
 def _display_roxapi_grid_info(rox, roxgrid):  # pragma: no cover
-    """Push info to screen (mostly for debugging), expermental."""
-    cpgeom = False
-    if rox.version_required("1.3"):
-        cpgeom = True
+    """Push info to screen (mostly for debugging), experimental."""
 
     indexer = roxgrid.grid_indexer
     ncol, nrow, _ = indexer.dimensions
 
-    if cpgeom:
-        xtg.say("ROXAPI with support for CornerPointGeometry")
-        geom = roxgrid.get_geometry()
-        defined_cells = geom.get_defined_cells()
-        xtg.say(f"Defined cells \n{defined_cells}")
+    xtg.say("ROXAPI with support for CornerPointGeometry")
+    geom = roxgrid.get_geometry()
+    defined_cells = geom.get_defined_cells()
+    xtg.say(f"Defined cells \n{defined_cells}")
 
-        xtg.say(f"IJK handedness: {geom.ijk_handedness}")
-        for ipi in range(ncol + 1):
-            for jpi in range(nrow + 1):
-                tpi, bpi, zco = geom.get_pillar_data(ipi, jpi)
-                xtg.say(f"For pillar {ipi}, {jpi}\n")
-                xtg.say(f"Tops\n{tpi}")
-                xtg.say(f"Bots\n{bpi}")
-                xtg.say(f"Depths\n{zco}")
+    xtg.say(f"IJK handedness: {geom.ijk_handedness}")
+    for ipi in range(ncol + 1):
+        for jpi in range(nrow + 1):
+            tpi, bpi, zco = geom.get_pillar_data(ipi, jpi)
+            xtg.say(f"For pillar {ipi}, {jpi}\n")
+            xtg.say(f"Tops\n{tpi}")
+            xtg.say(f"Bots\n{bpi}")
+            xtg.say(f"Depths\n{zco}")
 
 
 def _convert_to_xtgeo_grid_v1(rox, roxgrid, corners, gname):  # pragma: no cover
@@ -139,10 +135,7 @@ def _convert_to_xtgeo_grid_v1(rox, roxgrid, corners, gname):  # pragma: no cover
 
     actnum = mybuffer
 
-    if rox.version_required("1.3"):
-        logger.info("Handedness (new) %s", indexer.ijk_handedness)
-    else:
-        logger.info("Handedness (old) %s", indexer.handedness)
+    logger.info("Handedness (new) %s", indexer.ijk_handedness)
 
     corners = corners.ravel(order="K")
     actnum = actnum.ravel(order="K")
@@ -217,9 +210,6 @@ def _convert_to_xtgeo_grid_v1(rox, roxgrid, corners, gname):  # pragma: no cover
 def _import_grid_roxapi_v2(rox, gname, realisation, info):  # pragma: no cover
     """Import a Grid via ROXAR API spec."""
     proj = rox.project
-
-    if not rox.version_required("1.3"):
-        raise NotImplementedError("Functionality to implemented for Roxar API < 1.3")
 
     logger.info("Loading grid with realisation %s...", realisation)
     try:
@@ -326,20 +316,6 @@ def export_grid_roxapi(
 
     """
     rox = RoxUtils(projectname, readonly=False)
-
-    if method != "cpg" and not rox.version_required("1.2"):
-        minimumrms = rox.rmsversion("1.2")
-        raise NotImplementedError(
-            "Not supported in this ROXAPI version. Grid load/import requires "
-            f"RMS version {minimumrms}"
-        )
-
-    if method == "cpg" and not rox.version_required("1.3"):
-        xtg.warn(
-            "Export method=cpg is not implemented for ROXAPI "
-            f"version {rox.roxversion}. Change to workaround..."
-        )
-        method = "other"
 
     if method == "cpg":
         if self._xtgformat == 1:

--- a/src/xtgeo/grid3d/_gridprop_roxapi.py
+++ b/src/xtgeo/grid3d/_gridprop_roxapi.py
@@ -66,10 +66,7 @@ def _convert_to_xtgeo_prop(
     indexer = roxgrid.get_grid(realisation=realisation).grid_indexer
     result["ncol"], result["nrow"], result["nlay"] = indexer.dimensions
 
-    if rox.version_required("1.3"):
-        logger.info(indexer.ijk_handedness)
-    else:
-        logger.info(indexer.handedness)
+    logger.info(indexer.ijk_handedness)
 
     pvalues = roxprop.get_values(realisation=realisation)
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -1084,15 +1084,6 @@ class Grid(_Grid3D):
     # Various public methods
     # ==================================================================================
 
-    @deprecation.deprecated(
-        deprecated_in="2.7",
-        removed_in="3.0",
-        current_version=xtgeo.version,
-        details="Method numpify_carrays is deprecated and can be removed",
-    )
-    def numpify_carrays(self):
-        """Numpify pointers from C (SWIG) arrays so instance is easier to pickle."""
-
     def copy(self):
         """Copy from one existing Grid instance to a new unique instance.
 
@@ -1531,15 +1522,6 @@ class Grid(_Grid3D):
 
         return None
 
-    @deprecation.deprecated(
-        deprecated_in="2.7",
-        removed_in="3.0",
-        current_version=xtgeo.version,
-        details="Method get_cactnum is deprecated and can be removed",
-    )
-    def get_cactnum(self):
-        """Returns the C pointer object reference to the ACTNUM array (deprecated)."""
-
     def get_actnum(self, name="ACTNUM", asmasked=False, mask=None, dual=False):
         """Return an ACTNUM GridProperty object.
 
@@ -1808,30 +1790,6 @@ class Grid(_Grid3D):
         return _grid_etc1.get_bulk_volume(
             self, name=name, asmasked=asmasked, precision=precision
         )
-
-    @deprecation.deprecated(
-        deprecated_in="1.16",
-        removed_in="3.0",
-        current_version=xtgeo.version,
-        details="Use method get_ijk() instead",
-    )
-    def get_indices(self, names=("I", "J", "K")):
-        """Return 3 GridProperty objects for column, row, and layer index.
-
-        Note that the indexes starts with 1, not zero (i.e. upper
-        cell layer is K=1)
-
-        This method is deprecated, use :meth:`get_ijk()` instead.
-
-        Args:
-            names (tuple): Names of the columns (as property names)
-
-        Examples::
-
-            i_index, j_index, k_index = grd.get_indices()
-
-        """
-        return self.get_ijk(names=names, asmasked=False)
 
     def get_ijk(
         self, names=("IX", "JY", "KZ"), asmasked=True, mask=None, zerobased=False

--- a/src/xtgeo/plot/baseplot.py
+++ b/src/xtgeo/plot/baseplot.py
@@ -1,11 +1,9 @@
 """The baseplot module."""
-import deprecation
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 from packaging.version import parse as versionparse
 
-import xtgeo
 from xtgeo.common import XTGeoDialog
 
 from . import _colortables as _ctable
@@ -150,22 +148,6 @@ class BasePlot(object):
         """Returns the given color map cmap as a list of RGB tuples."""
         cmaplist = [cmap(i) for i in range(cmap.N)]
         return cmaplist
-
-    @deprecation.deprecated(
-        deprecated_in="1.16",
-        removed_in="3.0",
-        current_version=xtgeo.version,
-        details=(
-            "set_colortable is deprecated, use the colormap"
-            " property or define_colormap instead"
-        ),
-    )
-    def set_colortable(self, cname, colorlist=None):
-        """Deprecated function, use define_colormap or the colormap property instead"""
-        if colorlist is None:
-            self.colormap = cname
-        else:
-            self.define_colormap(cname, colorlist=colorlist)
 
     def get_colormap_as_table(self):
         """Get the current color map as a list of RGB tuples."""

--- a/src/xtgeo/roxutils/roxutils.py
+++ b/src/xtgeo/roxutils/roxutils.py
@@ -55,6 +55,10 @@ class RoxUtils(object):
         self._project = None
 
         self._version = roxar.__version__
+
+        if versionparse(self._version) < versionparse("1.5"):
+            raise RuntimeError("XTGeo >= 3.0 requires Roxar API >= 1.5")
+
         self._roxexternal = True
 
         self._versions = {
@@ -126,7 +130,7 @@ class RoxUtils(object):
         Example::
 
             rox = RoxUtils(project)
-            if rox.version_required('1.2'):
+            if rox.version_required('1.5'):
                 somefunction()
             else:
                 print('Not supported in this version')
@@ -147,7 +151,7 @@ class RoxUtils(object):
         Example::
 
             rox = RoxUtils(project)
-            rmsver = rox.rmsversion('1.2')
+            rmsver = rox.rmsversion('1.5')
             print('The supported RMS version are {}'.format(rmsver))
 
         """

--- a/src/xtgeo/surface/_regsurf_export.py
+++ b/src/xtgeo/surface/_regsurf_export.py
@@ -361,7 +361,7 @@ def export_storm_binary(self, mfile):
         scopy._yori,
         scopy._xinc,
         yinc,
-        scopy.get_zval(),
+        scopy.get_values1d(order="F", asmasked=False, fill_value=self.undef),
         zmin,
         zmax,
         0,

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 import deprecation
 import numpy as np
 import pandas as pd
+
 import xtgeo
 from xtgeo.common import XTGeoDialog, inherit_docstring
 from xtgeo.xyz import _xyz_io, _xyz_roxapi
@@ -453,7 +454,7 @@ class Points(XYZ):  # pylint: disable=too-many-public-methods, function-redefine
         for RMS version up to 12.0.x) do not support NaN values for Integers. The
         solution is store undefined values as large numbers, xtgeo.UNDEF_INT
         (2000000000) for integers and xtgeo.UNDEF (10e32) for float values.
-        This will change from xtgeo version 3.0 where Pandas version 1 and
+        This will change from xtgeo version 3.x where Pandas version 1 and
         above will be required, which in turn support will pandas.NA
         entries.
 

--- a/tests/test_grid3d/test_grid3d_deprecations.py
+++ b/tests/test_grid3d/test_grid3d_deprecations.py
@@ -3,9 +3,10 @@ import pathlib
 
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import given
 from packaging import version
+
+import xtgeo
 from xtgeo import GridProperties, GridProperty
 from xtgeo import version as xtgeo_version
 
@@ -69,25 +70,6 @@ def test_grid_from_xtgf_warns(tmp_path, any_grid):
 
     with pytest.warns(DeprecationWarning, match="from_xtgf is deprecated"):
         any_grid.from_xtgf(tmp_path / "grid.xtg")
-
-
-def test_grid_numpify_warns(any_grid):
-    if version.parse(xtgeo_version) < version.parse("2.7"):
-        pytest.skip()
-
-    with pytest.warns(DeprecationWarning, match="numpify_carrays is deprecated"):
-        any_grid.numpify_carrays()
-
-    with pytest.warns(DeprecationWarning, match="get_cactnum is deprecated"):
-        any_grid.get_cactnum()
-
-
-def test_grid_get_indices_warns(any_grid):
-    if version.parse(xtgeo_version) < version.parse("1.16"):
-        pytest.skip()
-
-    with pytest.warns(DeprecationWarning, match="get_indices is deprecated"):
-        any_grid.get_indices()
 
 
 def test_grid_mask_warns(any_grid):

--- a/tests/test_surface/test_deprecation.py
+++ b/tests/test_surface/test_deprecation.py
@@ -1,7 +1,7 @@
 import functools
 
-import pytest
 import deprecation
+import pytest
 from packaging import version
 
 import xtgeo
@@ -41,27 +41,11 @@ def test_default_init_deprecation(missing_arg, expected_warning):
         assert len(record) == 1
 
 
-@fail_if_not_removed(version_limit="3")
+@fail_if_not_removed(version_limit="4")
 def test_default_values_deprecation():
     with pytest.warns(DeprecationWarning, match="Default values") as record:
         xtgeo.RegularSurface(**{"ncol": 5, "nrow": 3, "xinc": 25.0, "yinc": 25.0})
         assert len(record) == 1
-
-
-@fail_if_not_removed(version_limit="3", msg="nx as input has passed deprecation period")
-def test_nx_deprecation(default_surface):
-    default_surface.pop("ncol")
-    default_surface["nx"] = 5
-    with pytest.warns(DeprecationWarning, match="nx is deprecated"):
-        xtgeo.RegularSurface(**default_surface)
-
-
-@fail_if_not_removed(version_limit="3", msg="ny as input has passed deprecation period")
-def test_ny_deprecation(default_surface):
-    default_surface.pop("nrow")
-    default_surface["ny"] = 3
-    with pytest.warns(DeprecationWarning, match="ny is deprecated"):
-        xtgeo.RegularSurface(**default_surface)
 
 
 @deprecation.fail_if_not_removed


### PR DESCRIPTION
Remove tests and code that was marked for deprecation in version 3.

Also limit Roxar API to version 1.5 and above (this is inherently given that python 3.6 is not longer supported in XTGeo; since Roxar API version up to 1.4 is solely in python 3.6).