### PR TITLE
FIX: improve use of "order" in np.ravel()

### DIFF
--- a/requirements/pyproject.toml.komodo
+++ b/requirements/pyproject.toml.komodo
@@ -8,7 +8,7 @@ requires = [
          'cmake>=3.6.0',
          "ninja",
          "setuptools_scm>=3.2.0",
-         'numpy>=1.13,!=1.24.3',
+         'numpy>=1.19,
          'Sphinx<4.0', # Due to sphinx-toolbox
          'sphinx-rtd-theme',
          'sphinxcontrib-apidoc',

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 deprecation
-numpy>=1.19, !=1.24.3
+numpy>=1.19,
 shapely>=1.6.2
 matplotlib>=3.3
 scipy>=1.5

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -17,7 +17,7 @@ sphinx-toolbox
 autoclasstoc
 myst-parser
 bandit
-numpy>1.19, !=1.24.3
+numpy>1.19
 pandas>=1.1
 segyio>=1.8.6
 matplotlib>=3.3

--- a/src/xtgeo/grid3d/_grid_roxapi.py
+++ b/src/xtgeo/grid3d/_grid_roxapi.py
@@ -137,8 +137,8 @@ def _convert_to_xtgeo_grid_v1(rox, roxgrid, corners, gname):  # pragma: no cover
 
     logger.info("Handedness (new) %s", indexer.ijk_handedness)
 
-    corners = corners.ravel(order="K")
-    actnum = actnum.ravel(order="K")
+    corners = corners.ravel()
+    actnum = actnum.ravel()
 
     ntot = ncol * nrow * nlay
     ncoord = (ncol + 1) * (nrow + 1) * 2 * 3

--- a/src/xtgeo/grid3d/_gridprop_lowlevel.py
+++ b/src/xtgeo/grid3d/_gridprop_lowlevel.py
@@ -19,7 +19,7 @@ def f2c_order(obj, values1d):
     """
     val = np.reshape(values1d, (obj.ncol, obj.nrow, obj.nlay), order="F")
     val = np.asanyarray(val, order="C")
-    val = val.ravel(order="K")
+    val = val.ravel()
     return val
 
 
@@ -29,7 +29,7 @@ def c2f_order(obj, values1d):
     """
     val = np.reshape(values1d, (obj.ncol, obj.nrow, obj.nlay), order="C")
     val = np.asanyarray(val, order="F")
-    val = val.ravel(order="K")
+    val = val.ravel(order="F")
     return val
 
 
@@ -98,7 +98,7 @@ def update_carray(self, undef=None, discrete=None, dtype=None, order="F"):
 
     if order == "F":
         values = np.asfortranarray(values)
-        values1d = np.ravel(values, order="K")
+        values1d = np.ravel(values, order="F")
 
     if values1d.dtype == "float64" and dstatus and not dtype:
         values1d = values1d.astype("int32")

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -1468,7 +1468,7 @@ class Grid(_Grid3D):
         .. versionchanged:: 2.18 Added inverse option
         """
         actnumv = self.get_actnum().values.copy(order=order)
-        actnumv = np.ravel(actnumv, order="K")
+        actnumv = np.ravel(actnumv, order=order)
         if inverse:
             actnumv -= 1
             return np.flatnonzero(actnumv)
@@ -1486,7 +1486,7 @@ class Grid(_Grid3D):
             return None
 
         actnumv = self._dualactnum.values.copy(order=order)
-        actnumv = np.ravel(actnumv, order="K")
+        actnumv = np.ravel(actnumv, order=order)
 
         if not fracture:
             actnumvm = actnumv.copy()
@@ -1594,7 +1594,7 @@ class Grid(_Grid3D):
             >>> act.values[:, :, 4] = 0
             >>> mygrid.set_actnum(act)
         """
-        val1d = actnum.values.ravel(order="K")
+        val1d = actnum.values.ravel()
 
         if self._xtgformat == 1:
             self._actnumsv = _gridprop_lowlevel.c2f_order(self, val1d)

--- a/src/xtgeo/surface/_regsurf_grid3d.py
+++ b/src/xtgeo/surface/_regsurf_grid3d.py
@@ -97,7 +97,7 @@ def from_grid3d(grid, template=None, where="top", mode="depth", rfactor=1):
     args["rotation"] = 0.0
     # call C function to make a map
     val = args["values"]
-    val = val.ravel(order="K")
+    val = val.ravel()
     val = ma.filled(val, fill_value=xtgeo.UNDEF)
 
     svalues = val * 0.0 + xtgeo.UNDEF

--- a/src/xtgeo/surface/_regsurf_oper.py
+++ b/src/xtgeo/surface/_regsurf_oper.py
@@ -280,8 +280,8 @@ def get_ij_values1d(self, zero_based=False, activeonly=True, order="C"):
 
     ixn, jyn = self.get_ij_values(zero_based=zero_based, order=order)
 
-    ixn = ixn.ravel(order="K")
-    jyn = jyn.ravel(order="K")
+    ixn = ixn.ravel(order=order)
+    jyn = jyn.ravel(order=order)
 
     if activeonly:
         tmask = ma.getmaskarray(self.get_values1d(order=order, asmasked=True))

--- a/tests/test_common/test_numpy.py
+++ b/tests/test_common/test_numpy.py
@@ -22,13 +22,14 @@ def test_order_change_variant1():
 
     val = np.ma.masked_invalid(val)
 
-    val1d = val.ravel(order="K")
+    val1d = val.ravel(order="F")
+    assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"
 
-    if versionparse(np.__version__) < versionparse("1.24"):
-        assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"
-    else:
-        # this may actually be a bug;
-        assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 nan -- 8.0]"
+    # if versionparse(np.__version__) < versionparse("1.24"):
+    #     assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"
+    # else:
+    #     # this may actually be a bug;
+    #     assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 nan -- 8.0]"
 
 
 def test_order_change_variant2():
@@ -42,6 +43,6 @@ def test_order_change_variant2():
 
     val = np.ma.array(arrdata, mask=arrmask)
 
-    val1d = val.ravel(order="K")
+    val1d = val.ravel(order="F")
 
     assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"

--- a/tests/test_common/test_numpy.py
+++ b/tests/test_common/test_numpy.py
@@ -25,11 +25,16 @@ def test_order_change_variant1():
     val1d = val.ravel(order="F")
     assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"
 
-    # if versionparse(np.__version__) < versionparse("1.24"):
-    #     assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"
-    # else:
-    #     # this may actually be a bug;
-    #     assert str(val1d) == "[1.0 5.0 2.0 6.0 3.0 nan -- 8.0]"
+    # Tests for earlier usage of order="K", where it appears to be bugs in some
+    # versions of numpy. However, using order="K" is probably something that in general
+    # should be avoided.
+    val1d_k = val.ravel(order="K")
+    if versionparse(np.__version__).public in ("1.24.0", "1.24.1", "1.24.2"):
+        assert str(val1d_k) == "[1.0 5.0 2.0 6.0 3.0 nan -- 8.0]"  # probable bug
+    elif versionparse(np.__version__).public in ("1.24.3"):
+        assert str(val1d_k) == "[1.0 2.0 3.0 4.0 5.0 6.0 -- 8.0]"  # probable bug
+    else:
+        assert str(val1d_k) == "[1.0 5.0 2.0 6.0 3.0 -- 4.0 8.0]"
 
 
 def test_order_change_variant2():

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import xtgeo
 from packaging import version
+
+import xtgeo
 from xtgeo import RegularSurface
 from xtgeo.common import XTGeoDialog
 
@@ -732,22 +733,23 @@ def test_get_xy_values(default_surface):
     xmap = xtgeo.RegularSurface(**default_surface)
 
     xcv, _ycv = xmap.get_xy_values(order="C")
+    print(type(xcv))
 
-    xxv = xcv.ravel(order="K")
+    xxv = xcv.ravel()
     assert xxv[1] == pytest.approx(0.0, abs=0.001)
 
     xcv, _ycv = xmap.get_xy_values(order="F")
-    xxv = xcv.ravel(order="K")
+    xxv = xcv.ravel(order="F")
     assert xxv[1] == pytest.approx(25.0, abs=0.001)
 
     xcv, _ycv = xmap.get_xy_values(order="C", asmasked=True)
 
-    xxv = xcv.ravel(order="K")
+    xxv = xcv.ravel(order="C")
     assert xxv[1] == pytest.approx(0.0, abs=0.001)
 
     xcv, _ycv = xmap.get_xy_values(order="F", asmasked=True)
 
-    xxv = xcv.ravel(order="K")
+    xxv = xcv.ravel(order="F")
     assert xxv[1] == pytest.approx(25.0, abs=0.001)
 
 


### PR DESCRIPTION
It appears that using order="K" in numpy.ravel() and numpy.ma.ravel() is prone to problems. Rather be spesific on required order ("F" or "C"). Cf. issue #861 

By improving code, the restrictions set on numpy version 1.24.3 can be removed. 
