### PR TITLE
BLD: Pin wheel>=0.38, drop Python 3.7

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: "./.github/actions/build-xtgeo"
         with:
           python-version: 3.9

--- a/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
+++ b/.github/workflows/ci-test-xtgeo-cibuildwheel.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os.runs_on }}
     strategy:
       matrix:
-        cibw_python: [cp37, cp38, cp39, cp310, cp311]
+        cibw_python: [cp38, cp39, cp310, cp311]
         os:
           - runs_on: ubuntu-latest
             cibw_image: manylinux_x86_64
@@ -36,11 +36,11 @@ jobs:
       # CIBW_TEST_SKIP: "cp312*linux* cp312*macos*"
       CIBW_BEFORE_BUILD: python -m pip install "pip<=22.0.4"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
         run: >

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,8 +6,8 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Check black style and linting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   fast:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
@@ -23,7 +23,9 @@ jobs:
             python-version: 3.11
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: "./.github/actions/test_setup"
         with:
           python-version: ${{ matrix.python-version }}
@@ -32,7 +34,9 @@ jobs:
   hypothesis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: "./.github/actions/test_setup"
         with:
           python-version: 3.9
@@ -41,7 +45,9 @@ jobs:
   big:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: "./.github/actions/test_setup"
         with:
           python-version: 3.9
@@ -50,7 +56,9 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: "./.github/actions/test_setup"
         with:
           python-version: 3.9

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Detailed documentation for [XTGeo at Read _the_ Docs](https://xtgeo.readthedocs.
 
 ## Feature summary
 
--   Python 3.7+ support
+-   Python 3.8+ support
 -   Focus on high speed, using numpy and pandas with C backend
 -   Regular surfaces, i.e. 2D maps with regular sampling and rotation
 -   3D grids (corner-point), supporting several formats such as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.black]
 line-length = 88
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -29,13 +29,12 @@ exclude = '''
 [build-system]
 requires = [
   "setuptools>=43",
-  "wheel",
+  "wheel>=0.38",
   "scikit-build<0.17",
-  'cmake==3.15.3; python_version >= "3.7" and platform_system == "Linux"',
+  'cmake==3.15.3; python_version >= "3.8" and platform_system == "Linux"',
   'cmake==3.18.0; platform_system != "Linux"',
   "ninja",
   "setuptools_scm>=3.2.0",
-  'numpy>=1.15.4; python_version == "3.7"',
   'numpy==1.19.2; python_version == "3.8"',
   'numpy==1.19.5; python_version == "3.9"',
   'numpy==1.21.6; python_version == "3.10"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ exclude = '''
 [build-system]
 requires = [
   "setuptools>=43",
-  "wheel>=0.38",
   "scikit-build<0.17",
   'cmake==3.15.3; python_version >= "3.8" and platform_system == "Linux"',
   'cmake==3.18.0; platform_system != "Linux"',

--- a/requirements/pyproject.toml.komodo
+++ b/requirements/pyproject.toml.komodo
@@ -1,16 +1,15 @@
 # version to be runnable by older pips in Komodo bleeding (Equinor)
 [build-system]
 requires = [
-         "pip>=19.1.1",
-         "setuptools>=30.3.0",
-         "wheel",
-         "scikit-build<0.17",
-         'cmake>=3.6.0',
-         "ninja",
-         "setuptools_scm>=3.2.0",
-         'numpy>=1.19,
-         'Sphinx<4.0', # Due to sphinx-toolbox
-         'sphinx-rtd-theme',
-         'sphinxcontrib-apidoc',
-         'sphinx-autodoc-typehints',
-         ]
+     "pip>=19.1.1",
+     "setuptools>=30.3.0",
+     "scikit-build<0.17",
+     "cmake>=3.6.0",
+     "ninja",
+     "setuptools_scm>=3.2.0",
+     "numpy>=1.19",
+     "Sphinx<4.0", # Due to sphinx-toolbox
+     "sphinx-rtd-theme",
+     "sphinxcontrib-apidoc",
+     "sphinx-autodoc-typehints",
+ ]

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -4,7 +4,7 @@ scikit-build<0.17
 ninja>=1.9.0.post1
 cmake>3.13.3
 pip>=20
-wheel>=0.29.0
+wheel>=0.38
 flake8
 pydocstyle
 coverage>=4.1

--- a/requirements/requirements_dev_rms.txt
+++ b/requirements/requirements_dev_rms.txt
@@ -5,7 +5,7 @@ setuptools_scm>=3.2.0
 scikit-build
 ninja>=1.9.0.post1
 cmake==3.15.3
-wheel>=0.29.0
+wheel>=0.38
 flake8
 pydocstyle
 coverage>=4.1

--- a/requirements/requirements_setup.txt
+++ b/requirements/requirements_setup.txt
@@ -1,7 +1,7 @@
 # requirements for setup on localhost
 # see also ...setup_ci.txt and pyproject.toml
 setuptools>=43
-wheel
+wheel>=0.38
 numpy
 cmake
 setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ skbuild.setup(
         "Operating System :: POSIX :: Linux",
         "Natural Language :: English",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
- `wheel` 0.30 - <0.38 has a security vulnerability Snyk ranks as High
- Python 3.7 reaches EOL on June 26 2023, some dependencies (ecl-data-io) have already dropped support