### PR TITLE
Fix ecl read issues

### DIFF
--- a/src/xtgeo/grid3d/_find_gridprop_in_eclrun.py
+++ b/src/xtgeo/grid3d/_find_gridprop_in_eclrun.py
@@ -486,6 +486,10 @@ def section_generator(generator):
     """
     try:
         first_seq = next(generator)
+        # for a few (rare?) cases, restarts start with TNAVHEAD, not SEQNUM
+        if match_keyword(first_seq.read_keyword(), "TNAVHEAD"):
+            first_seq = next(generator)
+
         if not match_keyword(first_seq.read_keyword(), "SEQNUM"):
             raise ValueError("Restart file did not start with SEQNUM.")
     except StopIteration:

--- a/tests/test_grid3d/test_grid_specialcases.py
+++ b/tests/test_grid3d/test_grid_specialcases.py
@@ -1,0 +1,60 @@
+"""Testing some simulator results that can be regarded as corner cases
+
+* BENCH_SPE9: Older SPE 9 test case; have subtle differences in e.g. restart files
+* IX_HIST: Intersect results
+
+The tests where made on resolving issues #873, #874
+"""
+import pytest
+
+import xtgeo
+
+xtg = xtgeo.XTGeoDialog()
+
+if not xtg.testsetup():
+    raise SystemExit
+
+TPATH = xtg.testpathobj
+
+SPE9 = TPATH / "3dgrids/bench_spe9"
+SPE9_ROOT = SPE9 / "BENCH_SPE9"
+SPE9_INITS = ["PORO", "PERMX"]
+SPE9_RESTARTS = ["PRESSURE", "SWAT", "SOIL"]
+SPE9_DATES = [19901028, 19901117]
+
+
+IXH = TPATH / "3dgrids/ix_hist"
+IXH_ROOT = IXH / "IX_HIST"
+IXH_INITS = ["PORO", "PERMX"]
+IXH_RESTARTS = ["PRESSURE", "SWAT", "SOIL"]
+IXH_DATES = [19980201, 19980301]
+
+
+def test_grid_gridprops_spe9():
+    """Test BENCH_SPE9, which has restart that does not start with SEQNUM."""
+    grd = xtgeo.grid_from_file(
+        SPE9_ROOT,
+        fformat="eclipserun",
+        initprops=SPE9_INITS,
+        restartprops=SPE9_RESTARTS,
+        restartdates=SPE9_DATES,
+    )
+
+    dataframe = grd.get_dataframe()
+    assert dataframe.loc[0, "PORO"] == pytest.approx(0.087)
+    assert dataframe.loc[8999, "PERMX"] == pytest.approx(47.053421)
+
+
+def test_grid_gridprops_ixh():
+    """Test IX_HIST, which may have issues (as most IX cases...)."""
+    grd = xtgeo.grid_from_file(
+        IXH_ROOT,
+        fformat="eclipserun",
+        initprops=IXH_INITS,
+        restartprops=IXH_RESTARTS,
+        restartdates=IXH_DATES,
+    )
+
+    dataframe = grd.get_dataframe()
+    assert dataframe.loc[0, "PORO"] == pytest.approx(0.106738)
+    assert dataframe.loc[46612, "PERMX"] == pytest.approx(1551.469971)


### PR DESCRIPTION
Solves #874 

It seems that a restart (UNRST) is not always is starting with `SEQNUM` (which was the assumption) but may start with `TNAVHEAD`. This PR fix that issue, but does not solve if there may be other similar corner cases. 

