### PR TITLE
Update readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,16 +1,15 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 
-python:
-  version: 3.10
-  install:
-    - requirements: requirements/requirements.txt
-    - requirements: requirements/requirements_docs.txt
-    - method: setuptools
-      path: .
-  system_packages: true
-
+# Build from the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .[docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ requires = [
   'cmake==3.15.3; python_version >= "3.8" and platform_system == "Linux"',
   'cmake==3.18.0; platform_system != "Linux"',
   "ninja",
+  'swig',
   "setuptools_scm>=3.2.0",
   'numpy==1.19.2; python_version == "3.8"',
   'numpy==1.19.5; python_version == "3.9"',

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -31,3 +31,4 @@ pytest-cov
 h5py>=3
 hdf5plugin>=2.3
 tables>=3.5
+swig

--- a/requirements/requirements_setup.txt
+++ b/requirements/requirements_setup.txt
@@ -8,3 +8,4 @@ setuptools_scm
 scikit-build
 ninja
 pytest-runner
+swig


### PR DESCRIPTION
Change setup of `.readthedocs.yaml` to mitigate coming deprecation in RTD. Cf. https://blog.readthedocs.com/drop-support-system-packages/
