### PR TITLE
Improve points etc in polygons operations

### DIFF
--- a/docs/usextgeoroxar.rst
+++ b/docs/usextgeoroxar.rst
@@ -521,4 +521,39 @@ be input to Equinor's APS module.
 Line point data
 ---------------
 
-Examples to come...
+Add to or remove points inside or outside polygons
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the following example, remove or add to points being inside or outside polygons on clipboard.
+
+.. code-block:: python
+
+    import xtgeo
+
+    PRJ = project
+
+    POLYGONS = ["mypolygons", "myfolder"]  # mypolygons in folder myfolder on clipboard
+    POINTSET1 = ["points1", "myfolder"]
+    POINTSET2 = ["points2", "myfolder"]
+
+    POINTSET1_UPDATED = ["points1_edit", "myfolder"]
+    POINTSET2_UPDATED = ["points2_edit", "myfolder"]
+
+    def main():
+        """Operations on points inside or outside polygons."""
+
+        poly = xtgeo.polygons_from_roxar(PRJ, *POLYGONS, stype="clipboard")
+        po1 = xtgeo.points_from_roxar(PRJ, *POINTSET1, stype="clipboard")
+        po2 = xtgeo.points_from_roxar(PRJ, *POINTSET2, stype="clipboard")
+
+        po1.eli_inside_polygons(poly)
+        po1.to_roxar(PRJ, *POINTSET1_UPDATED, stype="clipboard")  # store
+
+        # now add 100 inside polugons for POINTSET2, and then remove all points outside
+        po2.add_inside_polygons(poly, 100)
+        po2.eli_outside_polygons(poly)
+        po2.to_roxar(PRJ, *POINTSET2_UPDATED, stype="clipboard")  # store
+
+
+    if __name__ == "__main__":
+        main()

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -2043,7 +2043,7 @@ class RegularSurface:
     # Operations restricted to inside/outside polygons
     # ==================================================================================
 
-    def operation_polygons(self, poly, value, opname="add", inside=True):
+    def operation_polygons(self, poly, value, opname="add", inside=True, _version=2):
         """A generic function for map operations inside or outside polygon(s).
 
         Args:
@@ -2051,10 +2051,18 @@ class RegularSurface:
             value(float or RegularSurface): Value to add, subtract etc
             opname (str): Name of operation... 'add', 'sub', etc
             inside (bool): If True do operation inside polygons; else outside.
+            _version (int): Algorithm version, 2 will be much faster when many points
+                on polygons (this key will be removed in later versions and shall not
+                be applied)
         """
-        _regsurf_oper.operation_polygons(
-            self, poly, value, opname=opname, inside=inside
-        )
+        if _version == 2:
+            _regsurf_oper.operation_polygons_v2(
+                self, poly, value, opname=opname, inside=inside
+            )
+        else:
+            _regsurf_oper.operation_polygons(
+                self, poly, value, opname=opname, inside=inside
+            )
 
     # shortforms
     def add_inside(self, poly, value):

--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """XTGeo XYZ module (abstract base class)"""
 from abc import ABC, abstractmethod
-from typing import List, Union
+from typing import List, TypeVar, Union
 from warnings import warn
 
 import numpy as np
@@ -13,6 +13,8 @@ from . import _xyz_oper
 
 xtg = XTGeoDialog()
 logger = xtg.functionlogger(__name__)
+
+Polygons = TypeVar("Polygons")
 
 
 class XYZ(ABC):
@@ -275,7 +277,7 @@ class XYZ(ABC):
 
     def mark_in_polygons(
         self,
-        poly: Union["Polygons", List["Polygons"]],  # noqa: F821
+        poly: Union[Polygons, List[Polygons]],  # noqa: F821
         name: str = "pstatus",
         inside_value: int = 1,
         outside_value: int = 0,
@@ -297,7 +299,7 @@ class XYZ(ABC):
 
     def operation_polygons(
         self,
-        poly: Union["Polygons", List["Polygons"]],  # noqa: F821
+        poly: Union[Polygons, List[Polygons]],  # noqa: F821
         value: float,
         opname: str = "add",
         inside: bool = True,
@@ -342,7 +344,7 @@ class XYZ(ABC):
             overlapping part. Similarly, using e.g. "eli, outside" will completely
             remove all points of two non-overlapping polygons are given as input.
 
-            ``version=2``: This is a new and recommended implemenation. It works
+            ``version=2``: This is a new and recommended implementation. It works
             much faster and intuitively for both inside and outside, overlapping and
             multiple polygons within a Polygons instance.
 
@@ -384,7 +386,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="add", inside=True, version=0)
 
     def add_inside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Add a value (scalar) to points inside polygons (new behaviour).
 
@@ -413,7 +415,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="add", inside=False, version=0)
 
     def add_outside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Add a value (scalar) to points outside polygons (new behaviour).
 
@@ -442,7 +444,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="sub", inside=True, version=1)
 
     def sub_inside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Subtract a value (scalar) for points inside polygons (new behaviour).
 
@@ -471,7 +473,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="sub", inside=False, version=0)
 
     def sub_outside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Subtract a value (scalar) for points outside polygons (new behaviour).
 
@@ -500,7 +502,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="mul", inside=True, version=0)
 
     def mul_inside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Multiply a value (scalar) for points inside polygons (new behaviour).
 
@@ -529,7 +531,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="mul", inside=False, version=0)
 
     def mul_outside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Multiply a value (scalar) for points outside polygons (new behaviour).
 
@@ -558,7 +560,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="div", inside=True, version=0)
 
     def div_inside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Divide a value (scalar) for points inside polygons (new behaviour).
 
@@ -587,7 +589,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="div", inside=False, version=0)
 
     def div_outside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Divide a value (scalar) for points outside polygons (new behaviour).
 
@@ -618,7 +620,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="set", inside=True, version=0)
 
     def set_inside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Set a value (scalar) for points inside polygons (new behaviour).
 
@@ -647,7 +649,7 @@ class XYZ(ABC):
         self.operation_polygons(poly, value, opname="set", inside=False, version=0)
 
     def set_outside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]], value: float  # noqa: F821
+        self, poly: Union[Polygons, List[Polygons]], value: float  # noqa: F821
     ):
         """Set a value (scalar) for points outside polygons (new behaviour).
 
@@ -674,9 +676,7 @@ class XYZ(ABC):
         """
         self.operation_polygons(poly, 0, opname="eli", inside=True, version=0)
 
-    def eli_inside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]]  # noqa: F821
-    ):
+    def eli_inside_polygons(self, poly: Union[Polygons, List[Polygons]]):  # noqa: F821
         """Remove points inside polygons.
 
         This is an improved implementation than :meth:`eli_inside()`, and is now the
@@ -701,9 +701,7 @@ class XYZ(ABC):
         """
         self.operation_polygons(poly, 0, opname="eli", inside=False, version=0)
 
-    def eli_outside_polygons(
-        self, poly: Union["Polygons", List["Polygons"]]  # noqa: F821
-    ):
+    def eli_outside_polygons(self, poly: Union[Polygons, List[Polygons]]):  # noqa: F821
         """Remove points outside polygons.
 
         This is an improved implementation than :meth:`eli_outside()`, and is now the


### PR DESCRIPTION
[ENH: improve points in polygons methods](https://github.com/equinor/xtgeo/pull/877/commits/2369745837fecdf23268ca78183fb7ff20cc3c2f) 

Improve both speed and logics. Speed by using MPath from matplotlib,
and logics to adress the strange behaviour in previous versions, when
e.g. ovelaping polygons areas gets cumulated values.

[ENH: improve speed for surf vs polygons operations](https://github.com/equinor/xtgeo/pull/877/commits/14a93c703b1f7fc3d4c1b1a6a4a0be7d488a1cee) 

Replace  internal methods with matplotlib MPath for surface
vs polygons operations. When many points in the polygons, the
speed improvement is magnitude of orders!

In contrast the points in polygons, the 'add_inside()' etc methods
works as before, hence the ``_version`` key is marked
intentionally as private
