### PR TITLE
ENH: allow RegularSurface() store np.float32 values

### DIFF
--- a/src/xtgeo/surface/_regsurf_export.py
+++ b/src/xtgeo/surface/_regsurf_export.py
@@ -101,7 +101,7 @@ def _export_irap_ascii(self, mfile):
         self._xinc,
         self._yflip * self._yinc,
         self._rotation,
-        vals,
+        vals.astype(np.float64),
         0,
     )
     if ier != 0:
@@ -199,7 +199,7 @@ def _export_irap_binary_cxtgeo(self, mfile):
         self._xinc,
         self._yflip * self._yinc,
         self._rotation,
-        vals,
+        vals.astype(np.float64),
         0,
     )
 
@@ -225,7 +225,7 @@ def export_ijxyz_ascii(self, mfile):
         self._yflip,
         self._ilines,
         self._xlines,
-        vals,
+        vals.astype(np.float64),
         0,
     )
 
@@ -324,7 +324,7 @@ def _export_zmap_ascii(self, mfile):
         scopy._yori,
         scopy._xinc,
         yinc,
-        vals,
+        vals.astype(np.float64),
         zmin,
         zmax,
         0,
@@ -361,7 +361,9 @@ def export_storm_binary(self, mfile):
         scopy._yori,
         scopy._xinc,
         yinc,
-        scopy.get_values1d(order="F", asmasked=False, fill_value=self.undef),
+        scopy.get_values1d(order="F", asmasked=False, fill_value=self.undef).astype(
+            np.float64
+        ),
         zmin,
         zmax,
         0,
@@ -416,7 +418,7 @@ def export_petromod_binary(self, mfile, pmd_dataunits):
     _cxtgeo.surf_export_petromod_bin(
         mfile.get_cfhandle(),
         dsc,
-        values,
+        values.astype(np.float64),
     )
 
     mfile.cfclose()

--- a/src/xtgeo/surface/_regsurf_roxapi.py
+++ b/src/xtgeo/surface/_regsurf_roxapi.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 
+import numpy as np
+
 from xtgeo import RoxUtils
 from xtgeo.common import XTGeoDialog
 
@@ -152,7 +154,7 @@ def _roxapi_export_surface(
         try:
             roxroot = proj.horizons[name][category]
             roxg = _xtgeo_to_roxapi_grid(self)
-            roxg.set_values(self.values)
+            roxg.set_values(self.values.astype(np.float64))
             roxroot.set_grid(roxg, realisation=realisation)
         except KeyError as kwe:
             logger.error(kwe)
@@ -165,7 +167,7 @@ def _roxapi_export_surface(
         try:
             roxroot = proj.zones[name][category]
             roxg = _xtgeo_to_roxapi_grid(self)
-            roxg.set_values(self.values)
+            roxg.set_values(self.values.astype(np.float64))
             roxroot.set_grid(roxg)
         except KeyError as kwe:
             logger.error(kwe)
@@ -183,7 +185,7 @@ def _roxapi_export_surface(
 
         roxroot = styperef.create_surface(name, folders)
         roxg = _xtgeo_to_roxapi_grid(self)
-        roxg.set_values(self.values)
+        roxg.set_values(self.values.astype(np.float64))
         roxroot.set_grid(roxg)
 
     elif stype == "trends":

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -42,7 +42,7 @@ import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from types import FunctionType
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Type, Union
 
 import deprecation
 import numpy as np
@@ -80,7 +80,7 @@ def surface_from_file(
     template=None,
     values=True,
     engine: Optional[str] = "cxtgeo",
-    dtype: Optional[Union[np.float64, np.float32]] = np.float64,
+    dtype: Union[Type[np.float64], Type[np.float32]] = np.float64,
 ):
     """Make an instance of a RegularSurface directly from file import.
 
@@ -123,7 +123,7 @@ def surface_from_roxar(
     category,
     stype="horizons",
     realisation=0,
-    dtype: Optional[Union[np.float64, np.float32]] = np.float64,
+    dtype: Union[Type[np.float64], Type[np.float32]] = np.float64,
 ):
     """This makes an instance of a RegularSurface directly from roxar input.
 
@@ -347,7 +347,7 @@ class RegularSurface:
         filesrc: Optional[str] = None,
         fformat: Optional[str] = None,
         undef: Optional[float] = xtgeo.UNDEF,
-        dtype: Optional[Union[np.float64, np.float32]] = np.float64,
+        dtype: Union[Type[np.float64], Type[np.float32]] = np.float64,
     ):
         """Instantiating a RegularSurface::
 
@@ -719,7 +719,7 @@ class RegularSurface:
         return infer_dtype
 
     @dtype.setter
-    def dtype(self, wanted_dtype: Union[np.float64, np.float32]):
+    def dtype(self, wanted_dtype: Union[Type[np.float64], Type[np.float32]]):
         """Setting the dtype of the values (np.array); float64 or float32"""
         try:
             self._values = self._values.astype(wanted_dtype)

--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -172,6 +172,22 @@ def test_rox_surfaces(roxar_project):
 
 
 @pytest.mark.requires_roxar
+def test_rox_surfaces_dtype_switching(roxar_project):
+    """Test dtype switching for from_roxar"""
+    srf = xtgeo.surface_from_roxar(roxar_project, "TopReek", SURFCAT1, dtype="float32")
+    assert srf.ncol == 554
+    assert srf.values.mean() == pytest.approx(1698.648, abs=0.01)
+    assert srf.dtype == np.float32
+    srf.to_roxar(roxar_project, "TopReek_copy", "SomeFolder", stype="clipboard")
+
+    srf2 = srf.copy()
+    assert srf2.dtype == np.float32
+
+    srf2.dtype = np.float64
+    np.testing.assert_allclose(srf.values, srf2.values)
+
+
+@pytest.mark.requires_roxar
 def test_rox_surfaces_alternative_open(roxar_project):
     """Based on previous but instead use a project ref as first argument"""
 

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -181,6 +181,31 @@ def test_irapbin_import1():
     xsurf.describe()
 
 
+def test_irapbin_import_32bit():
+    """Import Reek Irap binary, force 32 bit storage in import."""
+    # setting dtype in importing surface
+    xsurf = xtgeo.surface_from_file(TESTSET2, dtype=np.float32)
+    assert xsurf.values.dtype == np.float32
+
+    # setting dtype explicit as 64 bit
+    xsurf.dtype = np.float64
+    assert xsurf.values.dtype == np.float64
+
+    # setting dtype explicit as 32 bit
+    xsurf.dtype = np.float32
+    assert xsurf.values.dtype == np.float32
+
+    xsurf.dtype = "float64"
+    assert xsurf.values.dtype == np.float64
+
+
+def test_irapbin_import_invalid_dtype():
+    """Import Reek Irap binary, invalid dtype."""
+    # setting dtype in importing surface
+    with pytest.raises(AttributeError):
+        xtgeo.surface_from_file(TESTSET2, dtype=np.float33)
+
+
 def test_irapbin_import_use_pathib():
     """Import Reek Irap binary."""
     logger.info("Import and export...")


### PR DESCRIPTION
As default, the numpy (masked) array is stored as 64 bit numpy, in line with Roxar API storage. Here it is allowed to cast to 32 bit in import. The methods surface_from_grid() and surface_from_cube() Still lack dtype, but it is easy to set with the property srf.dtype = ...