### PR TITLE
Pin pytables because it requires Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "scipy>=1.5",
     "segyio>1.8.0",
     "shapely>=1.6.2",
-    "tables;platform_system != 'Darwin'",  # TODO: update when fixed for mac
+    "tables<3.9;platform_system != 'Darwin'",  # TODO: update when fixed for mac
     "typing-extensions",
 ]
 


### PR DESCRIPTION
ERT still needs to support Python 3.8