### PR TITLE
Update tables requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ dependencies = [
     "scipy>=1.5",
     "segyio>1.8.0",
     "shapely>=1.6.2",
-    "tables;platform_system != 'Darwin'",  # TODO: update when fixed for mac
+    "tables>=3.8.0;python_version == '3.8'",
+    "tables",
     "typing-extensions",
 ]
 


### PR DESCRIPTION
Tables no longer has support for python 3.8 after version 3.8.0