### PR TITLE
TST: fix hypothesis test failure

### DIFF
--- a/tests/test_grid3d/gridprop_generator.py
+++ b/tests/test_grid3d/gridprop_generator.py
@@ -18,6 +18,7 @@ def grid_properties(draw, name=keywords, grid=xtgeo_grids):
     grid = draw(grid)
     dims = grid.dimensions
     is_discrete = draw(st.booleans())
+    _name = draw(name)
     if is_discrete:
         num_codes = draw(st.integers(min_value=2, max_value=10))
         code_names = draw(
@@ -41,7 +42,7 @@ def grid_properties(draw, name=keywords, grid=xtgeo_grids):
         gp = GridProperty(
             grid,
             *dims,
-            draw(name),
+            _name,
             discrete=is_discrete,
             codes=dict(zip(code_values, code_names)),
             values=values,
@@ -55,7 +56,7 @@ def grid_properties(draw, name=keywords, grid=xtgeo_grids):
         return GridProperty(
             grid,
             *dims,
-            draw(name),
+            _name,
             discrete=is_discrete,
             values=values,
             grid=grid,


### PR DESCRIPTION
After the hypothesis profile change a test that generates a GridProperty started to fail reliably.

```sh
FAILED tests/test_grid3d/test_grid_properties.py::test_gridproperties_from_roff - ValueError: Requested keyword NA<< is not in ROFF file, valid entries are [], set strict=False to warn instead.
```

It seems like it might be timing related: drawing the name value outside of the GridProperty instantiation seems to fix it.