### PR TITLE
TST: xfail flaky OPM tests

### DIFF
--- a/tests/test_opm_integration/test_gridprop_io.py
+++ b/tests/test_opm_integration/test_gridprop_io.py
@@ -178,6 +178,7 @@ unit_systems = st.sampled_from(UnitSystem)
 opm_setups = st.builds(OpmSetup, xtgeo_grids, st.booleans(), unit_systems)
 
 
+@pytest.mark.xfail(reason="OPM flaky")
 @pytest.mark.requires_opm
 @pytest.mark.usefixtures("setup_tmpdir")
 @settings(max_examples=5)
@@ -245,6 +246,7 @@ def test_init_props_reading(case):
     assert poro.date == "20000101"
 
 
+@pytest.mark.xfail(reason="OPM flaky")
 @pytest.mark.requires_opm
 @pytest.mark.usefixtures("setup_tmpdir")
 @settings(max_examples=5)


### PR DESCRIPTION
Resolves #996 

These tests fail intermittently for a number of reasons. Sometimes segfaulting, sometimes FileNotFound or ValueError, sometimes results differ. These issues do not necessarily appear to be a result of xtgeo but should maybe be looked at more closely.

Will investigate a bit further still since it might be something to report to OPM.