### PR TITLE
CLN: Update GridProperty typing

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -51,9 +51,6 @@ ignore_errors = True
 [mypy-xtgeo.grid3d._grdecl_grid]
 ignore_errors = True
 
-[mypy-xtgeo.grid3d._grid3d]
-ignore_errors = True
-
 [mypy-xtgeo.grid3d._grid3d_fence]
 ignore_errors = True
 
@@ -130,7 +127,4 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-xtgeo.grid3d.grid_properties]
-ignore_errors = True
-
-[mypy-xtgeo.grid3d.grid_property]
 ignore_errors = True

--- a/src/xtgeo/common/xtgeo_dialog.py
+++ b/src/xtgeo/common/xtgeo_dialog.py
@@ -129,7 +129,7 @@ class XTGDescription:
         fmt = "=" * 99
         self._txt.append(fmt)
 
-    def txt(self, *atxt: str) -> None:
+    def txt(self, *atxt: Any) -> None:
         fmt = self._smartfmt(list(atxt))
         self._txt.append(fmt)
 


### PR DESCRIPTION
numpy typing has some peculiarities with dtypes; where `x: np.dtype`/`np.dtype[Any]` resolves as a class but the `np.float32` and the like resolve as types. So some explicitness was used for the dtypes. 