### PR TITLE
DEP: Issue deprecation warning for `xtgeo.plot`

### DIFF
--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -123,11 +123,6 @@ from xtgeo.xyz.polygons import Polygons
 
 _xprint("Import various XTGeo modules... xyz...")
 
-if not ROXAR:
-    from xtgeo.plot import baseplot, grid3d_slice, xsection, xtmap
-
-_xprint("Import various XTGeo modules... plots...")
-
 _xprint("Import various XTGeo modules...DONE")
 
 # some function wrappers to initiate objects from imports

--- a/src/xtgeo/plot/__init__.py
+++ b/src/xtgeo/plot/__init__.py
@@ -1,8 +1,15 @@
 """The XTGeo plot package"""
+# flake8: noqa
 
+import warnings
 
 from xtgeo.plot.grid3d_slice import Grid3DSlice
-
-# flake8: noqa
 from xtgeo.plot.xsection import XSection
 from xtgeo.plot.xtmap import Map
+
+warnings.warn(
+    "xtgeo.plot is deprecated and will be removed in xtgeo 4.0. "
+    "This functionality now lives in the `xtgeoviz` package.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
This also removes the default top-level import so a deprecation warning is not issued on _all_ xtgeo usage.

Resolves #573 