### PR TITLE
CLN: Add types to grid3d_fence

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -51,9 +51,6 @@ ignore_errors = True
 [mypy-xtgeo.grid3d._grdecl_grid]
 ignore_errors = True
 
-[mypy-xtgeo.grid3d._grid3d_fence]
-ignore_errors = True
-
 [mypy-xtgeo.grid3d._grid3d_utils]
 ignore_errors = True
 

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -92,8 +92,29 @@ from xtgeo.well.wells import Wells
 
 _xprint("Import various XTGeo modules... wells...")
 
+from xtgeo.grid3d import GridRelative, Units, grid, grid_properties, grid_property
+from xtgeo.grid3d.grid import Grid
+from xtgeo.grid3d.grid_properties import (
+    GridProperties,
+    gridproperties_dataframe,
+    gridproperties_from_file,
+)
+from xtgeo.grid3d.grid_property import (
+    GridProperty,
+    gridproperty_from_file,
+    gridproperty_from_roxar,
+)
+
+_xprint("Import various XTGeo modules... 3D grids...")
+
 from xtgeo.surface import regular_surface
-from xtgeo.surface.regular_surface import RegularSurface
+from xtgeo.surface.regular_surface import (
+    RegularSurface,
+    surface_from_cube,
+    surface_from_file,
+    surface_from_grid3d,
+    surface_from_roxar,
+)
 from xtgeo.surface.surfaces import Surfaces
 
 _xprint("Import various XTGeo modules... surface...")
@@ -103,12 +124,6 @@ from xtgeo.cube.cube1 import Cube
 
 _xprint("Import various XTGeo modules... cube...")
 
-from xtgeo.grid3d import GridRelative, Units, grid, grid_properties, grid_property
-from xtgeo.grid3d.grid import Grid
-from xtgeo.grid3d.grid_properties import GridProperties, gridproperties_dataframe
-from xtgeo.grid3d.grid_property import GridProperty
-
-_xprint("Import various XTGeo modules... 3D grids...")
 
 from xtgeo.metadata.metadata import (
     MetaDataCPGeometry,
@@ -133,14 +148,6 @@ from xtgeo.grid3d.grid import (
     grid_from_cube,
     grid_from_file,
     grid_from_roxar,
-)
-from xtgeo.grid3d.grid_properties import gridproperties_from_file
-from xtgeo.grid3d.grid_property import gridproperty_from_file, gridproperty_from_roxar
-from xtgeo.surface.regular_surface import (
-    surface_from_cube,
-    surface_from_file,
-    surface_from_grid3d,
-    surface_from_roxar,
 )
 from xtgeo.well.blocked_well import blockedwell_from_file, blockedwell_from_roxar
 from xtgeo.well.blocked_wells import blockedwells_from_files, blockedwells_from_roxar

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -2654,7 +2654,7 @@ class Grid(_Grid3D):
         hincrement: float | bool | None = None,
         atleast: int = 5,
         nextend: int = 2,
-    ) -> tuple[int, int, int, int, np.ndarray]:
+    ) -> tuple[float, float, float, float, np.ndarray]:
         """Get a sampled randomline from a fence spesification.
 
         This randomline will be a 2D numpy with depth on the vertical


### PR DESCRIPTION
Addresses: https://github.com/equinor/xtgeo/issues/1011

Reordered imports in `xtgeo.__init__ ` to avoid circular imports.

- grid related imports are now imported before surface related imports