### PR TITLE
BUG: fix issue with get_randomline when using Polygons

### DIFF
--- a/src/xtgeo/grid3d/_grid3d_fence.py
+++ b/src/xtgeo/grid3d/_grid3d_fence.py
@@ -42,10 +42,11 @@ def get_randomline(
 
     _update_tmpvars(self)
 
-    if hincrement is None and isinstance(fencespec, Polygons):
-        logger.info("Estimate hincrement from Polygons instance...")
+    if hincrement is not None and not isinstance(hincrement, (float, int)):
+        raise TypeError("'hincrement' can only be a number or None")
+
+    if isinstance(fencespec, Polygons):
         fencespec = _get_randomline_fence(self, fencespec, hincrement, atleast, nextend)
-        logger.info("Estimate hincrement from Polygons instance... DONE")
 
     logger.info("Get property...")
     if isinstance(prop, str):
@@ -149,22 +150,22 @@ def _update_tmpvars(self: Grid, force: bool = False) -> None:
 def _get_randomline_fence(
     self: Grid,
     polygon: Polygons,
-    hincrement: float | int | None,
+    distance: float | int | None,
     atleast: int,
     nextend: int,
 ) -> np.ndarray:
     """Compute a resampled fence from a Polygons instance."""
-    if hincrement is None:
+    if distance is None:
+        logger.debug("Estimate fence distance from grid resolution...")
         geom = self.get_geometrics()
 
         avgdxdy = 0.5 * (geom[10] + geom[11])
         distance = 0.5 * avgdxdy
-    else:
-        distance = hincrement
+        logger.debug("Estimate fence distance from grid resolution... DONE")
 
-    logger.info("Getting fence from a Polygons instance...")
+    logger.debug("Getting fence from a Polygons instance...")
     fspec = polygon.get_fence(
         distance=distance, atleast=atleast, nextend=nextend, asnumpy=True
     )
-    logger.info("Getting fence from a Polygons instance... DONE")
+    logger.debug("Getting fence from a Polygons instance... DONE")
     return fspec

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -2651,7 +2651,7 @@ class Grid(_Grid3D):
         zmin: float | None = None,
         zmax: float | None = None,
         zincrement: float = 1.0,
-        hincrement: float | bool | None = None,
+        hincrement: float | None = None,
         atleast: int = 5,
         nextend: int = 2,
     ) -> tuple[float, float, float, float, np.ndarray]:
@@ -2667,8 +2667,8 @@ class Grid(_Grid3D):
 
         If input fencspec is a numpy 2D, it is important that the HLEN array
         has a constant increment and ideally a sampling that is less than the
-        Grid resolution. If a Polygons() instance, this is automated if hincrement is
-        None, and ignored if hincrement is False.
+        Grid resolution. If a Polygons() instance, this will be automated if
+        hincrement is None.
 
         Args:
             fencespec (:obj:`~numpy.ndarray` or :class:`~xtgeo.xyz.polygons.Polygons`):
@@ -2678,14 +2678,13 @@ class Grid(_Grid3D):
             zmin (float): Minimum Z (default is Grid Z minima/origin)
             zmax (float): Maximum Z (default is Grid Z maximum)
             zincrement (float): Sampling vertically, default is 1.0
-            hincrement (float or bool): Resampling horizontally. This applies only
+            hincrement (float): Resampling horizontally. This applies only
                 if the fencespec is a Polygons() instance. If None (default),
-                the distance will be deduced automatically. If False, then it assumes
-                the Polygons can be used as-is.
-            atleast (int): Minimum number of horizontal samples (only if
-                fencespec is a Polygons instance and hincrement != False)
-            nextend (int): Extend with nextend * hincrement in both ends (only if
-                fencespec is a Polygons instance and hincrement != False)
+                the distance will be deduced automatically.
+            atleast (int): Minimum number of horizontal samples This applies
+                only if the fencespec is a Polygons() instance.
+            nextend (int): Extend with nextend * hincrement in both ends.
+                This applies only if the fencespec is a Polygons() instance.
 
         Returns:
             A tuple: (hmin, hmax, vmin, vmax, ndarray2d)


### PR DESCRIPTION
In the `xtgeo.Grid.get_randomline()` function, having `hincrement` argument as a bool or a number together with a Polygon as `fencespec` triggered a bug. 

This PR fixes that, and removes the option to have `hincrement` as a bool to make the input more clear for users.

resolves #1040