### PR TITLE
CLN: Remove unused variable in grdcp3d_get_vtk_esg_geometry_data.c

### DIFF
--- a/src/clib/xtg/grdcp3d_get_vtk_esg_geometry_data.c
+++ b/src/clib/xtg/grdcp3d_get_vtk_esg_geometry_data.c
@@ -114,7 +114,6 @@ long grdcp3d_get_vtk_esg_geometry_data(long ncol,
     }
 
     const long finalVertexCount = gm_vertexCount(gm);
-    const long finalConnCount = gm_connectivityCount(gm);
 
     gm_destroy(gm);
     gm = NULL;


### PR DESCRIPTION
Remove unused variable in grdcp3d_get_vtk_esg_geometry_data.c ( related to # 904).
