### PR TITLE
CLN: In C-code: Remove unused function, init variable and fix 'strncpy maxlen'

### DIFF
--- a/src/clib/xtg/except.c
+++ b/src/clib/xtg/except.c
@@ -11,7 +11,7 @@ static int error_status = 0;
 void
 throw_exception(char *msg)
 {
-    strncpy(error_message, msg, 256);
+    strncpy(error_message, msg, 255);
     error_status = 1;
 }
 

--- a/src/clib/xtg/grd3d_points_ijk_cells.c
+++ b/src/clib/xtg/grd3d_points_ijk_cells.c
@@ -283,7 +283,7 @@ _point_val_ijk(double xc,
      * iin, jin         I J column
      */
 
-    int score;
+    int score = 0;
 
     int k, nib;
 

--- a/src/clib/xtg/grdcp3d_get_vtk_esg_geometry_data.c
+++ b/src/clib/xtg/grdcp3d_get_vtk_esg_geometry_data.c
@@ -46,7 +46,6 @@ static struct GeoMaker* gm_create(long cellCountI, long cellCountJ, long cellCou
 static void gm_destroy(struct GeoMaker* gm);
 static void gm_addVertex(struct GeoMaker* gm, long i, long j, long k, double v[3]);
 static long gm_vertexCount(const struct GeoMaker* gm);
-static long gm_connectivityCount(const struct GeoMaker* gm);
 
 
 long grdcp3d_get_vtk_esg_geometry_data(long ncol,
@@ -280,10 +279,4 @@ static void gm_addVertex(GeoMaker* gm, long i, long j, long k, double v[3])
 static long gm_vertexCount(const GeoMaker* gm)
 {
     return gm->numVerticesAdded;
-}
-
-// ------------------------------------------------------------------------------------
-static long gm_connectivityCount(const GeoMaker* gm)
-{
-    return gm->numConnAdded;
 }


### PR DESCRIPTION
This is related to #904.

There are still macOS-related tasks left in #904.