### PR TITLE
ENH: Add `list_gridproperties` function

### DIFF
--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -97,6 +97,7 @@ from xtgeo.grid3d.grid_properties import (
     GridProperties,
     gridproperties_dataframe,
     gridproperties_from_file,
+    list_gridproperties,
 )
 from xtgeo.grid3d.grid_property import (
     GridProperty,

--- a/src/xtgeo/cube/__init__.py
+++ b/src/xtgeo/cube/__init__.py
@@ -1,5 +1,3 @@
 """The XTGeo cube package."""
 
-from xtgeo.cube.cube1 import (  # type: ignore # noqa
-    Cube,
-)
+from xtgeo.cube.cube1 import Cube  # type: ignore # noqa

--- a/src/xtgeo/grid3d/__init__.py
+++ b/src/xtgeo/grid3d/__init__.py
@@ -10,5 +10,5 @@ from xtgeo.common.exceptions import (
 
 from ._ecl_grid import GridRelative, Units
 from .grid import Grid
-from .grid_properties import GridProperties
+from .grid_properties import GridProperties, list_gridproperties
 from .grid_property import GridProperty

--- a/src/xtgeo/grid3d/_gridprop_import_eclrun.py
+++ b/src/xtgeo/grid3d/_gridprop_import_eclrun.py
@@ -52,7 +52,7 @@ def import_gridprop_from_init(pfile, name, grid, fracture=False):
 
 
 def sanitize_date(
-    date: int | str | Literal["first", "last"]
+    date: int | str | Literal["first", "last"],
 ) -> list[int] | Literal["first", "last"]:
     """
     Converts dateformats of the form 'YYYY-MM-DD', 'YYYYMMDD' or YYYYMMDD to

--- a/tests/test_grid3d/test_gridprops_list_properties.py
+++ b/tests/test_grid3d/test_gridprops_list_properties.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+import pytest
+from xtgeo.common import XTGeoDialog, _XTGeoFile
+from xtgeo.grid3d import list_gridproperties
+from xtgeo.grid3d._gridprops_import_roff import read_roff_properties
+
+xtg = XTGeoDialog()
+
+if not xtg.testsetup():
+    sys.exit(-9)
+
+TPATH = xtg.testpathobj
+
+logger = xtg.basiclogger(__name__)
+
+E100_BO_FINIT = TPATH / "3dgrids/simpleb8/E100_BO.FINIT"
+E100_BO_FUNRST = TPATH / "3dgrids/simpleb8/E100_BO.FUNRST"
+SPE_UNRST = TPATH / "3dgrids/bench_spe9/BENCH_SPE9.UNRST"
+SPE_INIT = TPATH / "3dgrids/bench_spe9/BENCH_SPE9.INIT"
+REEK_INIT = TPATH / "3dgrids/reek/REEK.INIT"
+REEK_UNRST = TPATH / "3dgrids/reek/REEK.UNRST"
+
+REEK_SIM_PORO = TPATH / "3dgrids/reek/reek_sim_poro.roff"
+ROFF_PROPS = TPATH / "3dgrids/reek/reek_grd_w_props.roff"
+ROFFASC_PROPS = TPATH / "3dgrids/reek/reek_grd_w_props.roffasc"
+ROFF_THREE_PROPS = TPATH / "3dgrids/reek/reek_geo2_grid_3props.roff"
+
+
+@pytest.mark.parametrize("test_file", ["A.EGRID", "b.grdecl", "t.segy", "c.RSSPEC"])
+def test_raise_on_invalid_filetype(tmp_path, test_file):
+    filepath = tmp_path / test_file
+    Path(filepath).touch()
+    with pytest.raises(ValueError, match="file format"):
+        list_gridproperties(filepath)
+
+
+@pytest.mark.parametrize(
+    "test_file, expected",
+    [
+        (REEK_SIM_PORO, ["PORO"]),
+        (ROFF_PROPS, ["PORV", "PORO", "EQLNUM", "FIPNUM"]),
+        (ROFF_THREE_PROPS, ["Poro", "EQLNUM", "Facies"]),
+    ],
+)
+def test_read_roff_properties(test_file, expected):
+    xtg_file = _XTGeoFile(test_file)
+    assert list(read_roff_properties(xtg_file)) == expected
+
+
+@pytest.mark.parametrize(
+    "test_file, expected",
+    [
+        (REEK_SIM_PORO, ["PORO"]),
+        (ROFF_PROPS, ["PORV", "PORO", "EQLNUM", "FIPNUM"]),
+        # ROFFASC_PROPS is slow
+        (ROFFASC_PROPS, ["PORV", "PORO", "EQLNUM", "FIPNUM"]),
+        (ROFF_THREE_PROPS, ["Poro", "EQLNUM", "Facies"]),
+    ],
+)
+def test_list_properties_from_roff(test_file, expected):
+    assert list_gridproperties(test_file) == expected
+
+
+@pytest.mark.parametrize("test_file", [SPE_INIT, REEK_INIT, E100_BO_FINIT])
+def test_list_properties_from_init(test_file):
+    props = list_gridproperties(test_file)
+    # Just some common static properties
+    for prop in (
+        "PORV",
+        "DX",
+        "DY",
+        "DZ",
+        "PERMX",
+        "PERMY",
+        "PERMZ",
+        "EQLNUM",
+        "FIPNUM",
+    ):
+        assert prop in props
+
+
+@pytest.mark.parametrize("test_file", [SPE_UNRST, REEK_UNRST, E100_BO_FUNRST])
+def test_list_properties_from_unrst(test_file):
+    props = list_gridproperties(test_file)
+    # Just some common dynamic properties
+    for prop in ("PRESSURE", "SWAT", "SGAS", "RS"):
+        assert prop in props


### PR DESCRIPTION
Resolves #1084

This function helps to replace the now-deprecated `scan_keywords` static method. It can be used to get a list of grid properties within a roff file or within an Eclipse init (static properties) or restart (dynamic properties) file.