### PR TITLE
FIX: use mpl agg backend across OSs without display

### DIFF
--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     ROXAR = False
 
-if sys.platform == "linux" and not ROXAR:
+if not ROXAR:
     _display = os.environ.get("DISPLAY", "")
     _hostname = os.environ.get("HOSTNAME", "")
     _host = os.environ.get("HOST", "")


### PR DESCRIPTION
We can skip generating plots for them and also handle them separately, making the test-linux job a bit clearer.

Resolves #1105