### PR TITLE
DEP: Deprecate dimension_only argument in `grid_from_roxar()`

### DIFF
--- a/docs/xtgeo_4_migration.md
+++ b/docs/xtgeo_4_migration.md
@@ -281,6 +281,8 @@ Additionally,
 
 - `Grid().report_zone_mismatch()` has deprecated the `onelayergrid` option.
   This option is redundant and unneeded.
+- `Grid().grid_from_roxar()` has deprecated the `dimensions_only` option.
+  This option is redundant and unneeded.
 
 ### GridProperties
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -142,7 +142,7 @@ def grid_from_roxar(
     project: str,
     gname: str,
     realisation: int = 0,
-    dimensions_only: bool = False,
+    dimensions_only: bool | None = None,
     info: bool = False,
 ) -> Grid:
     """Read a 3D grid inside a RMS project and return a Grid() instance.
@@ -165,11 +165,16 @@ def grid_from_roxar(
         mygrid = xtgeo.grid_from_roxar(project, "REEK_SIM")
 
     """
-    return Grid(
-        **_grid_roxapi.import_grid_roxapi(
-            project, gname, realisation, dimensions_only, info
+
+    if dimensions_only is not None:
+        warnings.warn(
+            "Argument 'dimension_only' is redundant and has no effect "
+            "It will no longer be supported in xtgeo version 4.0 and "
+            "can safely be removed.",
+            DeprecationWarning,
         )
-    )
+
+    return Grid(**_grid_roxapi.import_grid_roxapi(project, gname, realisation, info))
 
 
 def create_box_grid(
@@ -1097,7 +1102,7 @@ class Grid(_Grid3D):
         projectname: str,
         gname: str,
         realisation: int = 0,
-        dimensions_only: bool = False,
+        dimensions_only: bool | None = None,
         info: bool = False,
     ) -> None:
         """Import grid model geometry from RMS project, and makes an instance.
@@ -1116,9 +1121,16 @@ class Grid(_Grid3D):
 
 
         """
-        kwargs = _grid_roxapi.import_grid_roxapi(
-            projectname, gname, realisation, dimensions_only, info
-        )
+
+        if dimensions_only is not None:
+            warnings.warn(
+                "Argument 'dimension_only' is redundant and has no effect "
+                "It will no longer be supported in xtgeo version 4.0 and "
+                "can safely be removed.",
+                DeprecationWarning,
+            )
+
+        kwargs = _grid_roxapi.import_grid_roxapi(projectname, gname, realisation, info)
         self._reset(**kwargs)
 
     def convert_units(self, units: Units) -> None:


### PR DESCRIPTION
The `dimensions_only` argument available in `xtgeo.grid_from_roxar()`  does not work, and this PR resolves #1042. 

Its intended use of this argument was to create a grid with correct dimensions that could be used as a template for a new GridProperty. By only extracting the dimensions of a grid, the users could get a performance increase.

Extracting dimensions from a grid is pretty straightforward with the roxar API, hence this bug will not be fixed.

This PR adds a deprecation warning to the `dimensions_only` argument, and removes all code related to this argument since  `dimensions_only=True` did not work anyway.

- the deprecation warning is intended for users that tried setting  `dimensions_only=True` but instead set it to   `dimensions_only=False` when they got an error message