### PR TITLE
CLN,ENH: replace dataframe vs get dataframe() and set_dataframe()

### DIFF
--- a/examples/grid3d_prop_as_map.py
+++ b/examples/grid3d_prop_as_map.py
@@ -32,7 +32,7 @@ def make_map():
 
     points = xtgeo.Points()
     points.zname = "PORO"
-    points.dataframe = df
+    points.set_dataframe(df)
 
     # do gridding:
     surf.gridding(points)

--- a/examples/wellpath_fence_sample.py
+++ b/examples/wellpath_fence_sample.py
@@ -11,8 +11,8 @@ y = x.copy()
 
 y.rescale(10)
 
-IDGROUPSX = x.dataframe.groupby(x.pname)
-IDGROUPSY = y.dataframe.groupby(y.pname)
+IDGROUPSX = x.get_dataframe().groupby(x.pname)
+IDGROUPSY = y.get_dataframe().groupby(y.pname)
 
 plt.figure(figsize=(7, 7))
 for idx, grp in IDGROUPSX:
@@ -27,4 +27,4 @@ else:
     plt.show()
 
 
-print(y.dataframe)
+print(y.get_dataframe())

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -318,7 +318,8 @@ def get_ijk_from_points(
 
     _update_tmpvars(self, force=True)
 
-    arrsize = points.dataframe[points.xname].values.size
+    points_df = points.get_dataframe(copy=False)
+    arrsize = points_df[points.xname].values.size
 
     useflip = -1 if self.ijk_handedness == "left" else 1
 
@@ -326,9 +327,9 @@ def get_ijk_from_points(
 
     logger.info("Running C routine...")
     _, iarr, jarr, karr = _cxtgeo.grd3d_points_ijk_cells(
-        points.dataframe[points.xname].values,
-        points.dataframe[points.yname].values,
-        points.dataframe[points.zname].values,
+        points_df[points.xname].values,
+        points_df[points.yname].values,
+        points_df[points.zname].values,
         self._tmp["topd"].ncol,
         self._tmp["topd"].nrow,
         self._tmp["topd"].xori,
@@ -363,9 +364,9 @@ def get_ijk_from_points(
 
     proplist = {}
     if includepoints:
-        proplist["X_UTME"] = points.dataframe[points.xname].values
-        proplist["Y_UTME"] = points.dataframe[points.yname].values
-        proplist["Z_TVDSS"] = points.dataframe[points.zname].values
+        proplist["X_UTME"] = points_df[points.xname].values
+        proplist["Y_UTME"] = points_df[points.yname].values
+        proplist["Z_TVDSS"] = points_df[points.zname].values
 
     proplist[columnnames[0]] = iarr
     proplist[columnnames[1]] = jarr

--- a/src/xtgeo/grid3d/_grid_wellzone.py
+++ b/src/xtgeo/grid3d/_grid_wellzone.py
@@ -56,7 +56,7 @@ def report_zone_mismatch(
     if zoneprop is None or not isinstance(zoneprop, GridProperty):
         raise ValueError("Input zoneprop is missing or not a GridProperty() instance")
 
-    if zonelogname not in well.dataframe.columns:
+    if zonelogname not in well.get_dataframe(copy=False).columns:
         logger.warning("Zonelog %s is missing for well %s", zonelogname, well.name)
         return None
 
@@ -66,20 +66,20 @@ def report_zone_mismatch(
 
     # get the IJK along the well as logs; use a copy of the well instance
     wll = well.copy()
-    wll.dataframe[zonelogname] += zonelogshift
+    wll_df = wll.get_dataframe()
+    wll_df[zonelogname] += zonelogshift
 
     if depthrange:
         d1, d2 = depthrange
-        wll.dataframe = wll.dataframe[
-            (d1 < wll.dataframe.Z_TVDSS) & (d2 > wll.dataframe.Z_TVDSS)
-        ]
+        wll_df = wll_df[(d1 < wll_df.Z_TVDSS) & (d2 > wll_df.Z_TVDSS)]
+    wll.set_dataframe(wll_df)
 
     wll.get_gridproperties(zoneprop, self)
     zonename = zoneprop.name if zoneprop.name is not None else "Zone"
     zmodel = zonename + "_model"
 
     # from here, work with the dataframe only
-    df = wll.dataframe
+    df = wll.get_dataframe()
 
     # zonelogrange
     z1, z2 = zonelogrange
@@ -155,7 +155,7 @@ def report_zone_mismatch(
     res2 = dfuse2["zmatch2"].mean() * 100
 
     # update Well() copy (segment only)
-    wll.dataframe = dfuse2
+    wll.set_dataframe(dfuse2)
 
     return {
         "MATCH1": res1,

--- a/src/xtgeo/grid3d/_gridprop_op1.py
+++ b/src/xtgeo/grid3d/_gridprop_op1.py
@@ -110,7 +110,7 @@ def operation_polygons(
     proxy.values *= 0.0
     cvals = gl.update_carray(proxy)
 
-    idgroups = poly.dataframe.groupby(poly.pname)
+    idgroups = poly.get_dataframe(copy=False).groupby(poly.pname)
 
     for id_, grp in idgroups:
         xcor = grp[poly.xname].values

--- a/src/xtgeo/plot/xsection.py
+++ b/src/xtgeo/plot/xsection.py
@@ -392,13 +392,13 @@ class XSection(BasePlot):
         wo = self._well
 
         # reduce the well data by Pandas operations
-        dfr = wo.dataframe
-        wo.dataframe = dfr[dfr["Z_TVDSS"] > self._zmin]
+        dfr = wo.get_dataframe()
+        wo.set_dataframe(dfr[dfr["Z_TVDSS"] > self._zmin])
 
         # Create a relative XYLENGTH vector (0.0 where well starts)
         wo.create_relative_hlen()
 
-        dfr = wo.dataframe
+        dfr = wo.get_dataframe()
         if dfr.empty:
             self._showok = False
             return
@@ -436,7 +436,7 @@ class XSection(BasePlot):
 
     def set_xaxis_md(self, gridlines=False):
         """Set x-axis labels to measured depth."""
-        md_start = self._well.dataframe["MDEPTH"].iloc[0]
+        md_start = self._well.get_dataframe(copy=False)["MDEPTH"].iloc[0]
         md_start_round = int(math.floor(md_start / 100.0)) * 100
         md_start_delta = md_start - md_start_round
 
@@ -1116,7 +1116,7 @@ class XSection(BasePlot):
         data_well = data_well.loc[data_well["WELL"] == well.xwellname]
         del data_well["WELL"]
 
-        md_start = well.dataframe["MDEPTH"].iloc[0]
+        md_start = well.get_dataframe(copy=False)["MDEPTH"].iloc[0]
         data_well["R_HLEN"] = data_well["MDEPTH"]
         data_well["R_HLEN"] = data_well["R_HLEN"].subtract(md_start)
 
@@ -1147,8 +1147,8 @@ class XSection(BasePlot):
         ax = self._ax2
 
         if self.fence is not None:
-            xwellarray = self._well.dataframe["X_UTME"].values
-            ywellarray = self._well.dataframe["Y_UTMN"].values
+            xwellarray = self._well.get_dataframe(copy=False)["X_UTME"].values
+            ywellarray = self._well.get_dataframe(copy=False)["Y_UTMN"].values
 
             ax.plot(xwellarray, ywellarray, linewidth=4, c="cyan")
 
@@ -1171,8 +1171,8 @@ class XSection(BasePlot):
                     continue
                 if poly.name == self._well.xwellname:
                     continue
-                xwp = poly.dataframe[poly.xname].values
-                ywp = poly.dataframe[poly.yname].values
+                xwp = poly.get_dataframe(copy=False)[poly.xname].values
+                ywp = poly.get_dataframe(copy=False)[poly.yname].values
                 ax.plot(xwp, ywp, linewidth=1, c="grey")
                 ax.annotate(poly.name, xy=(xwp[-1], ywp[-1]), color="grey", size=5)
 
@@ -1186,9 +1186,9 @@ class XSection(BasePlot):
 
         ax = self._ax3
         if self.fence is not None:
-            xp = self._outline.dataframe["X_UTME"].values
-            yp = self._outline.dataframe["Y_UTMN"].values
-            ip = self._outline.dataframe["POLY_ID"].values
+            xp = self._outline.get_dataframe(copy=False)["X_UTME"].values
+            yp = self._outline.get_dataframe(copy=False)["Y_UTMN"].values
+            ip = self._outline.get_dataframe(copy=False)["POLY_ID"].values
 
             ax.plot(self._fence[:, 0], self._fence[:, 1], linewidth=3, c="red")
 

--- a/src/xtgeo/plot/xtmap.py
+++ b/src/xtgeo/plot/xtmap.py
@@ -175,7 +175,7 @@ class Map(BasePlot):
         """
         import matplotlib as mpl
 
-        aff = fpoly.dataframe.groupby(idname)
+        aff = fpoly.get_dataframe(copy=False).groupby(idname)
 
         for name, _group in aff:
             # make a dataframe sorted on faults (groupname)
@@ -208,7 +208,7 @@ class Map(BasePlot):
 
         .. _Matplotlib: http://matplotlib.org/api/colors_api.html
         """
-        aff = fpoly.dataframe.groupby(idname)
+        aff = fpoly.get_dataframe(copy=False).groupby(idname)
 
         for _name, group in aff:
             # make a dataframe sorted on groupname
@@ -232,7 +232,7 @@ class Map(BasePlot):
         """
         # This function is "in prep"
 
-        dataframe = points.dataframe
+        dataframe = points.get_dataframe(copy=False)
 
         self._ax.scatter(
             dataframe["X_UTME"].values, dataframe["Y_UTMN"].values, marker="x"
@@ -247,7 +247,7 @@ class Map(BasePlot):
 
         """
         for well in wells.wells:
-            dataframe = well.dataframe
+            dataframe = well.get_dataframe(copy=False)
 
             xval = dataframe["X_UTME"].values
             yval = dataframe["Y_UTMN"].values

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -26,7 +26,7 @@ def points_gridding(self, points, method="linear", coarsen=1):
 
     xiv, yiv = self.get_xy_values()
 
-    dfra = points.dataframe
+    dfra = points.get_dataframe(copy=False)
 
     xcv = dfra[points.xname].values
     ycv = dfra[points.yname].values

--- a/src/xtgeo/surface/_regsurf_oper.py
+++ b/src/xtgeo/surface/_regsurf_oper.py
@@ -473,7 +473,7 @@ def operation_polygons(self, poly, value, opname="add", inside=True):
         # turn scalar value into numpy array
         value = self.values.copy() * 0 + value
 
-    idgroups = poly.dataframe.groupby(poly.pname)
+    idgroups = poly.get_dataframe(copy=False).groupby(poly.pname)
 
     for _, grp in idgroups:
         xcor = grp[poly.xname].values
@@ -563,7 +563,7 @@ def _proxy_map_polygons(surf, poly, inside=True):
     import matplotlib.path as mplpath
 
     for pol in usepolys:
-        idgroups = pol.dataframe.groupby(pol.pname)
+        idgroups = pol.get_dataframe(copy=False).groupby(pol.pname)
         for _, grp in idgroups:
             singlepoly = np.array([grp[pol.xname].values, grp[pol.yname].values]).T
             poly_path = mplpath.Path(singlepoly)

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -1975,7 +1975,15 @@ class RegularSurface:
 
         return pd.DataFrame(entry)
 
-    dataframe = get_dataframe  # for compatibility backwards
+    def dataframe(self, **kwargs):
+        """Deprecated; see method get_dataframe()."""
+        warnings.warn(
+            "The dataframe() is deprecated and will be removed in xtgeo "
+            "version 5. Use get_dataframe() instead",
+            PendingDeprecationWarning,
+        )
+
+        return self.get_dataframe(**kwargs)
 
     def get_xy_value_lists(self, lformat="webportal", xyfmt=None, valuefmt=None):
         """Returns two lists for coordinates (x, y) and values.

--- a/src/xtgeo/well/_blockedwell_roxapi.py
+++ b/src/xtgeo/well/_blockedwell_roxapi.py
@@ -199,13 +199,13 @@ def _roxapi_export_bwell(self, rox, gname, bwname, wname, lognames, ijk, realisa
         usedtype = bwprop.dtype
         dind = bwset.get_data_indices([self._wname], realisation=realisation)
 
-        if self.dataframe[lname].values.size != dind.size:
+        if self.get_dataframe(copy=False)[lname].values.size != dind.size:
             raise ValueError(
                 "Dataframe is of wrong size, changing numbers of rows is not possible"
             )
-        maskedvalues = np.ma.masked_invalid(self.dataframe[lname].values).astype(
-            usedtype
-        )
+        maskedvalues = np.ma.masked_invalid(
+            self.get_dataframe(copy=False)[lname].values
+        ).astype(usedtype)
 
         # there are cases where the RMS API complains on the actual value of the masked
         # array being outside range; hence remedy is to set 'data' value to a usedtype

--- a/src/xtgeo/well/_well_roxapi.py
+++ b/src/xtgeo/well/_well_roxapi.py
@@ -206,12 +206,12 @@ def _store_log_in_roxapi(self, lrun: Any, logname: str) -> None:
 
     values = thelog.generate_values()
 
-    if values.size != self.dataframe[logname].values.size:
+    if values.size != self.get_dataframe(copy=False)[logname].values.size:
         raise ValueError("New logs have different sampling or size, not possible")
 
     usedtype = values.dtype
 
-    vals = np.ma.masked_invalid(self.dataframe[logname].values)
+    vals = np.ma.masked_invalid(self.get_dataframe(copy=False)[logname].values)
     vals = np.ma.masked_greater(vals, xtglimit)
     vals = vals.astype(usedtype)
     thelog.set_values(vals)
@@ -279,9 +279,11 @@ def _roxapi_create_well(self, rox, wname, lognames, logrun, trajectory, realisat
     traj = roxwell.wellbore.trajectories.create(trajectory)
 
     series = traj.survey_point_series
-    east = self.dataframe[self.xname].values
-    north = self.dataframe[self.yname].values
-    tvd = self.dataframe[self.zname].values
+
+    dataframe = self.get_dataframe(copy=False)
+    east = dataframe[self.xname].values
+    north = dataframe[self.yname].values
+    tvd = dataframe[self.zname].values
     values = np.array([east, north, tvd]).transpose()
     series.set_points(values)
 

--- a/src/xtgeo/well/_wells_utils.py
+++ b/src/xtgeo/well/_wells_utils.py
@@ -50,7 +50,7 @@ def wellintersections(
             logger.debug("Skip %s (cannot compute geometrics)", well.name)
             continue
 
-        welldfr = well.dataframe.copy()
+        welldfr = well.get_dataframe()
 
         xcor = welldfr[well.xname].values
         ycor = welldfr[well.yname].values
@@ -95,9 +95,10 @@ def wellintersections(
                     well, xtol=xtol, ytol=ytol, ztol=ztol, itol=itol, atol=atol
                 )
 
-            xcorc = owell.dataframe[well.xname].values
-            ycorc = owell.dataframe[well.yname].values
-            zcorc = owell.dataframe[well.zname].values
+            other_dframe = owell.get_dataframe()
+            xcorc = other_dframe[well.xname].values
+            ycorc = other_dframe[well.yname].values
+            zcorc = other_dframe[well.zname].values
 
             if xcorc.size < 2:
                 continue

--- a/src/xtgeo/well/wells.py
+++ b/src/xtgeo/well/wells.py
@@ -194,7 +194,7 @@ class Wells:
 
         bigdflist = []
         for well in self._wells:
-            dfr = well.dataframe.copy()
+            dfr = well.get_dataframe()
             dfr["WELLNAME"] = well.name
             logger.debug(well.name)
             if filled:

--- a/src/xtgeo/xyz/_polygons_oper.py
+++ b/src/xtgeo/xyz/_polygons_oper.py
@@ -50,9 +50,9 @@ def boundary_from_points(points, alpha_factor=1.0, alpha=None, concave=False):
 
     usepoints = points.copy()  # make a copy since points may be filtered
 
-    xvec = usepoints.dataframe[usepoints.xname].values
-    yvec = usepoints.dataframe[usepoints.yname].values
-    zvec = usepoints.dataframe[usepoints.zname].values
+    xvec = usepoints.get_dataframe(copy=False)[usepoints.xname].values
+    yvec = usepoints.get_dataframe(copy=False)[usepoints.yname].values
+    zvec = usepoints.get_dataframe(copy=False)[usepoints.zname].values
 
     if alpha is None:
         # use scipy to detect average distance; 30 points should be sufficient
@@ -242,12 +242,12 @@ def simplify_polygons(self, tolerance: float, preserve_topology: bool) -> bool:
     except AttributeError:
         pass
 
-    recompute_hlen = self.hname in self.dataframe
-    recompute_tlen = self.tname in self.dataframe
+    recompute_hlen = self.hname in self.get_dataframe(copy=False)
+    recompute_tlen = self.tname in self.get_dataframe(copy=False)
 
-    orig_len = len(self.dataframe)
+    orig_len = len(self.get_dataframe(copy=False))
 
-    idgroups = self.dataframe.groupby(self.pname)
+    idgroups = self.get_dataframe(copy=False).groupby(self.pname)
     dfrlist = []
     for idx, grp in idgroups:
         if len(grp.index) < 2:
@@ -268,13 +268,13 @@ def simplify_polygons(self, tolerance: float, preserve_topology: bool) -> bool:
         dfrlist.append(dfr)
 
     dfr = pd.concat(dfrlist)
-    self.dataframe = dfr.reset_index(drop=True)
+    self.set_dataframe(dfr.reset_index(drop=True))
 
     if recompute_hlen:
         self.hlen()
     if recompute_tlen:
         self.tlen()
 
-    new_len = len(self.dataframe)
+    new_len = len(self.get_dataframe(copy=False))
 
     return new_len < orig_len

--- a/src/xtgeo/xyz/_xyz_data.py
+++ b/src/xtgeo/xyz/_xyz_data.py
@@ -444,7 +444,7 @@ class _XYZData:
         since int32 do not support np.nan, the value for undefined values will be
         ``fill_value_int``
         """
-        dfr = self._df.copy()
+        dfr = self._df.copy(deep=True)
         if infer_dtype:
             for name, attrtype in self._attr_types.items():
                 if attrtype.name == _AttrType.DISC.value:
@@ -463,8 +463,11 @@ class _XYZData:
 
         return dfr
 
-    def get_dataframe(self):
-        """Get the dataframe."""
+    def get_dataframe(self, copy=True):
+        """Get the dataframe, as view or deep copy."""
+        if copy:
+            return self._df.copy(deep=True)
+
         return self._df
 
     def set_dataframe(self, dfr: pd.DataFrame):

--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -215,7 +215,7 @@ def to_file(
     pfile.check_folder(raiseerror=OSError)
 
     ncount = 0
-    if xyz.dataframe is None:
+    if xyz.get_dataframe(copy=False) is None:
         logger.warning("Nothing to export!")
         return ncount
 
@@ -260,7 +260,7 @@ def export_rms_attr(self, pfile, attributes=True, pfilter=None, ispolygons=False
         is made.
     """
 
-    df = self.dataframe.copy()
+    df = self.get_dataframe()
 
     if not df.index.any():
         logger.warning("Nothing to export")
@@ -356,7 +356,7 @@ def export_rms_wpicks(self, pfile, hcolumn, wcolumn, mdcolumn="M_MDEPTH"):
 
     """
 
-    df = self.dataframe.copy()
+    df = self.get_dataframe()
 
     if not df.index.any():
         logger.warning("Nothing to export")

--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -315,10 +315,13 @@ def _roxapi_export_xyz(
 
     roxxyz = _get_roxitem(self, proj, name, category, stype, mode="set")
 
-    if self.dataframe is None or len(self.dataframe.index) == 0:
+    if (
+        self.get_dataframe(copy=False) is None
+        or len(self.get_dataframe(copy=False).index) == 0
+    ):
         return
 
-    dfrcopy = self.dataframe.copy()
+    dfrcopy = self.get_dataframe()
     # apply pfilter if any
     if pfilter:
         for key, val in pfilter.items():
@@ -350,7 +353,11 @@ def _roxapi_export_xyz(
 
     roxxyz.set_values(arrxyz)
 
-    if attributes and isinstance(self, xtgeo.Points) and len(self.dataframe) >= 1:
+    if (
+        attributes
+        and isinstance(self, xtgeo.Points)
+        and len(self.get_dataframe(copy=False)) >= 1
+    ):
         dfr = _cast_dataframe_attrs_to_numeric(dfrcopy)
         for name in dfr.columns[3:]:
             values = dfr[name].values

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -571,15 +571,24 @@ class Points(XYZ):
     @dataframe.setter
     def dataframe(self, df):
         warnings.warn(
-            "Direct access to the dataframe property will be deprecated in xtgeo 5.0. "
-            "Use `set_dataframe(df)` instead.",
+            "Direct access to the dataframe property in Points class will be "
+            "deprecated in xtgeo 5.0. Use `set_dataframe(df)` instead.",
             PendingDeprecationWarning,
         )
         self.set_dataframe(df)
 
-    def get_dataframe(self) -> pd.DataFrame:
-        """Returns or set the Pandas dataframe object."""
-        return self._df.copy()
+    def get_dataframe(self, copy: bool = True) -> pd.DataFrame:
+        """Returns the Pandas dataframe object.
+
+        Args:
+            copy: If True (default) the a deep copy is returned; otherwise a view
+                which may be faster in some cases)
+
+        .. versionchanged:: 3.7 Add keyword `copy`, defaulted to True
+
+        """
+        if copy:
+            return self._df.copy()
 
     def set_dataframe(self, df):
         self._df = df.apply(deepcopy)

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -508,26 +508,27 @@ class Points(XYZ):
             self._dataframe_consistency_check()
 
     def _dataframe_consistency_check(self):
-        if self.xname not in self.dataframe:
+        dataframe = self.get_dataframe(copy=False)
+        if self.xname not in dataframe:
             raise ValueError(
                 f"xname={self.xname} is not a column "
-                f"of dataframe {self.dataframe.columns}"
+                f"of dataframe {dataframe.columns}"
             )
-        if self.yname not in self.dataframe:
+        if self.yname not in dataframe:
             raise ValueError(
                 f"yname={self.yname} is not a column "
-                f"of dataframe {self.dataframe.columns}"
+                f"of dataframe {dataframe.columns}"
             )
-        if self.zname not in self.dataframe:
+        if self.zname not in dataframe:
             raise ValueError(
                 f"zname={self.zname} is not a column "
-                f"of dataframe {self.dataframe.columns}"
+                f"of dataframe {dataframe.columns}"
             )
         for attr in self._attrs:
-            if attr not in self.dataframe:
+            if attr not in dataframe:
                 raise ValueError(
                     f"Attribute {attr} is not a column "
-                    f"of dataframe {self.dataframe.columns}"
+                    f"of dataframe {dataframe.columns}"
                 )
 
     def __repr__(self):
@@ -540,19 +541,19 @@ class Points(XYZ):
 
     def __eq__(self, value):
         """Magic method for ==."""
-        return self.dataframe[self.zname] == value
+        return self.get_dataframe(copy=False)[self.zname] == value
 
     def __gt__(self, value):
-        return self.dataframe[self.zname] > value
+        return self.get_dataframe(copy=False)[self.zname] > value
 
     def __ge__(self, value):
-        return self.dataframe[self.zname] >= value
+        return self.get_dataframe(copy=False)[self.zname] >= value
 
     def __lt__(self, value):
-        return self.dataframe[self.zname] < value
+        return self.get_dataframe(copy=False)[self.zname] < value
 
     def __le__(self, value):
-        return self.dataframe[self.zname] <= value
+        return self.get_dataframe(copy=False)[self.zname] <= value
 
     # ----------------------------------------------------------------------------------
     # Methods
@@ -562,8 +563,8 @@ class Points(XYZ):
     def dataframe(self) -> pd.DataFrame:
         """Returns or set the Pandas dataframe object."""
         warnings.warn(
-            "Direct access to the dataframe property will be deprecated in xtgeo 5.0. "
-            "Use `get_dataframe()` instead.",
+            "Direct access to the dataframe property in Points class will be "
+            "deprecated in xtgeo 5.0. Use `get_dataframe()` instead.",
             PendingDeprecationWarning,
         )
         return self._df
@@ -587,8 +588,7 @@ class Points(XYZ):
         .. versionchanged:: 3.7 Add keyword `copy`, defaulted to True
 
         """
-        if copy:
-            return self._df.copy()
+        return self._df.copy() if copy else self._df
 
     def set_dataframe(self, df):
         self._df = df.apply(deepcopy)
@@ -816,7 +816,7 @@ class Points(XYZ):
         self._reset(
             **_wells_importer(wells, tops, incl_limit, top_prefix, zonelist, use_undef)
         )
-        return self.dataframe["WellName"].nunique()
+        return self.get_dataframe(copy=False)["WellName"].nunique()
 
     @inherit_docstring(inherit_from=XYZ.from_list)
     @deprecation.deprecated(

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -438,9 +438,19 @@ class Polygons(XYZ):
         )
         self.set_dataframe(df)
 
-    def get_dataframe(self) -> pd.DataFrame:
-        """Returns or set the Pandas dataframe object."""
-        return self._df.copy()
+    def get_dataframe(self, copy: bool = True) -> pd.DataFrame:
+        """Returns the Pandas dataframe object.
+
+        Args:
+            copy: If True, return a deep copy of the dataframe
+
+
+        .. versionchanged: 3.7  Add keyword `copy` defaulted to True
+        """
+        if copy:
+            return self._df.copy()
+
+        return self._df
 
     def set_dataframe(self, df):
         self._df = df.apply(deepcopy)

--- a/tests/test_grid3d/test_grid_fence.py
+++ b/tests/test_grid3d/test_grid_fence.py
@@ -31,9 +31,8 @@ def test_randomline_fence_from_well(show_plot):
 
     # get the polygon for the well, limit it to 1200
     fspec = wll.get_fence_polyline(sampling=10, nextend=2, asnumpy=False, tvdmin=1200)
-    print(fspec.dataframe)
 
-    assert fspec.dataframe[fspec.dhname][4] == pytest.approx(12.6335, abs=0.001)
+    assert fspec.get_dataframe()[fspec.dhname][4] == pytest.approx(12.6335, abs=0.001)
 
     fspec = wll.get_fence_polyline(sampling=10, nextend=2, asnumpy=True, tvdmin=1200)
 
@@ -62,7 +61,7 @@ def test_randomline_fence_from_polygon(show_plot):
 
     # get the polygons
     fspec = fence.get_fence(distance=10, nextend=2, asnumpy=False)
-    assert fspec.dataframe[fspec.dhname][4] == pytest.approx(10, abs=1)
+    assert fspec.get_dataframe()[fspec.dhname][4] == pytest.approx(10, abs=1)
 
     fspec = fence.get_fence(distance=5, nextend=2, asnumpy=True)
 

--- a/tests/test_grid3d/test_grid_vs_points.py
+++ b/tests/test_grid3d/test_grid_vs_points.py
@@ -170,7 +170,7 @@ def test_get_ijk_from_points_smallcase():
     df2 = g1.get_dataframe(ijk=False, xyz=True)
 
     po = xtgeo.Points()
-    po.dataframe = df2
+    po.set_dataframe(df2)
 
     ijk = g1.get_ijk_from_points(po, includepoints=False)
 
@@ -211,7 +211,7 @@ def test_get_ijk_from_points_full():
     df2 = g1.get_dataframe(ijk=False, xyz=True)
 
     po = xtgeo.Points()
-    po.dataframe = df2
+    po.set_dataframe(df2)
 
     ijk = g1.get_ijk_from_points(po, includepoints=False)
 
@@ -285,7 +285,7 @@ def test_point_in_cell_compare_rms():
     dfr = grd.get_ijk_from_points(p1)
 
     for cname, cxname in {"I": "IX", "J": "JY", "K": "KZ"}.items():
-        list1 = p1.dataframe[cname].tolist()
+        list1 = p1.get_dataframe(copy=False)[cname].tolist()
         list2 = dfr[cxname].tolist()
 
         nall = len(list1)

--- a/tests/test_grid3d/test_grid_vs_well.py
+++ b/tests/test_grid3d/test_grid_vs_well.py
@@ -116,7 +116,7 @@ def test_report_zlog_mismatch_resultformat3(tmpdir):
         resultformat=3,
     )
     mywell = res["WELLINTV"]
-    logger.info("\n%s", mywell.dataframe.to_string())
+    logger.info("\n%s", mywell.get_dataframe().to_string())
     mywell.to_file(join(tmpdir, "w1_zlog_report.rmswell"))
 
 
@@ -128,7 +128,7 @@ def test_report_zlog_mismatch_perflog(tmpdir):
 
     w1 = xtgeo.well_from_file(PWELL1)
 
-    w1.dataframe.to_csv(join(tmpdir, "testw1.csv"))
+    w1.get_dataframe().to_csv(join(tmpdir, "testw1.csv"))
 
     res = g1.report_zone_mismatch(
         well=w1,
@@ -140,7 +140,7 @@ def test_report_zlog_mismatch_perflog(tmpdir):
         resultformat=2,
     )
     mywell = res["WELLINTV"]
-    logger.info("\n%s", mywell.dataframe.to_string())
+    logger.info("\n%s", mywell.get_dataframe().to_string())
     mywell.to_file(join(tmpdir, "w1_perf_report.rmswell"))
 
     assert res["MATCH2"] == pytest.approx(81, 1.5)

--- a/tests/test_plot/test_map.py
+++ b/tests/test_plot/test_map.py
@@ -47,9 +47,9 @@ def test_map_plot_with_points(tmpdir, generate_plot):
 
     mypoints = xtgeo.points_from_surface(mysurf)
 
-    df = mypoints.dataframe.copy()
+    df = mypoints.get_dataframe()
     df = df[::20]
-    mypoints.dataframe = df
+    mypoints.set_dataframe(df)
 
     # just make the instance, with a lot of defaults behind the scene
     myplot = Map()

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -4,6 +4,7 @@ from os.path import join
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 import xtgeo
 from packaging import version
@@ -806,18 +807,18 @@ def test_dataframe_simple():
 
     xmap = xtgeo.surface_from_file(TESTSET1)
 
-    dfrc = xmap.dataframe(ijcolumns=True, order="C", activeonly=True)
+    dfrc = xmap.get_dataframe(ijcolumns=True, order="C", activeonly=True)
 
     assert dfrc["X_UTME"][2] == pytest.approx(465956.274, abs=0.01)
 
     xmap = xtgeo.surface_from_file(TESTSET2)
 
-    dfrc = xmap.dataframe()
+    dfrc = xmap.get_dataframe()
 
     assert dfrc["X_UTME"][2] == pytest.approx(461582.562498, abs=0.01)
 
     xmap.coarsen(2)
-    dfrc = xmap.dataframe()
+    dfrc = xmap.get_dataframe()
 
     assert dfrc["X_UTME"][2] == pytest.approx(461577.5575, abs=0.01)
 
@@ -830,8 +831,8 @@ def test_dataframe_more(tmpdir):
 
     xmap.describe()
 
-    dfrc = xmap.dataframe(ijcolumns=True, order="C", activeonly=True)
-    dfrf = xmap.dataframe(ijcolumns=True, order="F", activeonly=True)
+    dfrc = xmap.get_dataframe(ijcolumns=True, order="C", activeonly=True)
+    dfrf = xmap.get_dataframe(ijcolumns=True, order="F", activeonly=True)
 
     dfrc.to_csv(join(tmpdir, "regsurf_df_c.csv"))
     dfrf.to_csv(join(tmpdir, "regsurf_df_f.csv"))
@@ -840,9 +841,9 @@ def test_dataframe_more(tmpdir):
     assert dfrc["X_UTME"][2] == pytest.approx(465956.274, abs=0.01)
     assert dfrf["X_UTME"][2] == pytest.approx(462679.773, abs=0.01)
 
-    dfrcx = xmap.dataframe(ijcolumns=False, order="C", activeonly=True)
+    dfrcx = xmap.get_dataframe(ijcolumns=False, order="C", activeonly=True)
     dfrcx.to_csv(join(tmpdir, "regsurf_df_noij_c.csv"))
-    dfrcy = xmap.dataframe(
+    dfrcy = xmap.get_dataframe(
         ijcolumns=False, order="C", activeonly=False, fill_value=None
     )
     dfrcy.to_csv(join(tmpdir, "regsurf_df_noij_c_all.csv"))
@@ -1095,7 +1096,7 @@ def test_get_randomline_frompolygon(show_plot):
 
     # get the polygon
     fspec = fence.get_fence(distance=10, nextend=2, asnumpy=False)
-    assert fspec.dataframe[fspec.dhname][4] == pytest.approx(10, abs=1)
+    assert fspec.get_dataframe()[fspec.dhname][4] == pytest.approx(10, abs=1)
 
     fspec = fence.get_fence(distance=20, nextend=5, asnumpy=True)
 
@@ -1283,7 +1284,7 @@ def test_get_boundary_polygons_simple(show_plot):
                 "linewidth": 2,
             },
         )
-    assert boundary.dataframe[boundary.yname].values.tolist() == pytest.approx(
+    assert boundary.get_dataframe()[boundary.yname].values.tolist() == pytest.approx(
         [
             20,
             20,
@@ -1323,8 +1324,10 @@ def test_get_boundary_polygons_complex(show_plot):
     # reveal any major issues by asserting averages (polygons are checked visually)
     # for some reasons, macos tests gives slightly different result; that is why a large
     # tolerance is given
-    assert boundary.dataframe[boundary.xname].mean() == pytest.approx(462208.0, abs=2.5)
-    assert boundary.dataframe[boundary.yname].mean() == pytest.approx(
+    assert boundary.get_dataframe()[boundary.xname].mean() == pytest.approx(
+        462208.0, abs=2.5
+    )
+    assert boundary.get_dataframe()[boundary.yname].mean() == pytest.approx(
         5933427.0, abs=4.0
     )
 

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -1343,3 +1343,31 @@ def test_get_boundary_polygons_complex(show_plot):
                 "linewidth": 2,
             },
         )
+
+
+def test_regsurface_get_dataframe(default_surface):
+    """Test getting a dataframe from a surface."""
+
+    surf = RegularSurface(**default_surface)
+    dataframe = surf.get_dataframe()
+    assert dataframe.VALUES.to_list() == [
+        1.0,
+        6.0,
+        11.0,
+        2.0,
+        7.0,
+        12.0,
+        3.0,
+        8.0,
+        4.0,
+        9.0,
+        14.0,
+        5.0,
+        10.0,
+        15.0,
+    ]
+
+    with pytest.warns(PendingDeprecationWarning):
+        dataframe2 = surf.dataframe()
+
+    pd.testing.assert_frame_equal(dataframe, dataframe2)

--- a/tests/test_surface/test_regular_surface_resample.py
+++ b/tests/test_surface/test_regular_surface_resample.py
@@ -317,9 +317,11 @@ def test_points_gridding(tmpdir, reek_map, generate_plot):
 
     xyz = Points(xs)
 
-    xyz.dataframe["Z_TVDSS"] = xyz.dataframe["Z_TVDSS"] + 300
+    dataframe = xyz.get_dataframe()
+    dataframe["Z_TVDSS"] = dataframe["Z_TVDSS"] + 300
+    xyz.set_dataframe(dataframe)
 
-    logger.info("Avg of points: %s", xyz.dataframe["Z_TVDSS"].mean())
+    logger.info("Avg of points: %s", xyz.get_dataframe()["Z_TVDSS"].mean())
 
     xscopy = xs.copy()
 

--- a/tests/test_surface/test_regular_surface_vs_points.py
+++ b/tests/test_surface/test_regular_surface_vs_points.py
@@ -59,12 +59,12 @@ def test_map_to_points(tmpdir, reek_map):
     outf = join(tmpdir, "points_from_surf_reek.poi")
     px.to_file(outf)
 
-    assert px.dataframe["X_UTME"].min() == 456719.75
-    assert px.dataframe["Z_TVDSS"].mean() == pytest.approx(0.57558, abs=0.001)
+    assert px.get_dataframe()["X_UTME"].min() == 456719.75
+    assert px.get_dataframe()["Z_TVDSS"].mean() == pytest.approx(0.57558, abs=0.001)
 
     # read the output for comparison
     pxx = xtgeo.points_from_file(outf)
 
-    assert px.dataframe["Z_TVDSS"].mean() == pytest.approx(
-        pxx.dataframe["Z_TVDSS"].mean(), abs=0.00001
+    assert px.get_dataframe()["Z_TVDSS"].mean() == pytest.approx(
+        pxx.get_dataframe()["Z_TVDSS"].mean(), abs=0.00001
     )

--- a/tests/test_well/test_blockedwell.py
+++ b/tests/test_well/test_blockedwell.py
@@ -39,4 +39,4 @@ def test_import_blockedwell(loadwell1):
         2: "Crevasse",
     }
 
-    assert mywell.dataframe["Poro"][4] == pytest.approx(0.224485, abs=0.0001)
+    assert mywell.get_dataframe()["Poro"][4] == pytest.approx(0.224485, abs=0.0001)

--- a/tests/test_well/test_well_to_polygons.py
+++ b/tests/test_well/test_well_to_polygons.py
@@ -26,6 +26,7 @@ def test_well_to_polygons():
     poly = mywell.get_polygons()
 
     assert isinstance(poly, xtgeo.xyz.Polygons)
-    print(poly.dataframe)
 
-    assert mywell.dataframe["X_UTME"].mean() == poly.dataframe["X_UTME"].mean()
+    assert (
+        mywell.get_dataframe()["X_UTME"].mean() == poly.get_dataframe()["X_UTME"].mean()
+    )

--- a/tests/test_well/test_well_vs_grid.py
+++ b/tests/test_well/test_well_vs_grid.py
@@ -52,7 +52,7 @@ def test_make_ijk_grid(loadwell1, loadgrid1):
 
     mywell.make_ijk_from_grid(mygrid)
 
-    df = mywell.dataframe
+    df = mywell.get_dataframe(copy=False)
 
     assert int(df.iloc[4850]["ICELL"]) == 29
     assert int(df.iloc[4850]["JCELL"]) == 28
@@ -79,8 +79,10 @@ def test_well_get_gridprops(tmpdir, loadwell1, loadgrid1, loadporo1):
 
     mywell.get_gridproperties(myactnum, mygrid)
     mywell.to_file(join(tmpdir, "w_from_gprops.w"))
-    assert mywell.dataframe.iloc[4775]["PORO_model"] == pytest.approx(0.2741, abs=0.001)
-    assert mywell.dataframe.iloc[4775]["ACTNUM_model"] == 1
+    assert mywell.get_dataframe().iloc[4775]["PORO_model"] == pytest.approx(
+        0.2741, abs=0.001
+    )
+    assert mywell.get_dataframe().iloc[4775]["ACTNUM_model"] == 1
     assert mywell.isdiscrete("ACTNUM_model") is True
 
 

--- a/tests/test_well/test_well_vs_surface.py
+++ b/tests/test_well/test_well_vs_surface.py
@@ -22,4 +22,4 @@ def test_get_well_x_surf():
     surf = xtgeo.surface_from_file(SFILE)
     top = wll.get_surface_picks(surf)
 
-    assert top.dataframe.Q_MDEPTH[5] == pytest.approx(5209.636860, abs=0.001)
+    assert top.get_dataframe().Q_MDEPTH[5] == pytest.approx(5209.636860, abs=0.001)

--- a/tests/test_xyz/test_points.py
+++ b/tests/test_xyz/test_points.py
@@ -34,9 +34,9 @@ def test_points_from_file_alternatives(testpath, filename, fformat):
     points3 = xtgeo.points_from_file(testpath / filename, fformat=fformat)
     points4 = xtgeo.points_from_file(testpath / filename)
 
-    pd.testing.assert_frame_equal(points1.dataframe, points2.dataframe)
-    pd.testing.assert_frame_equal(points2.dataframe, points3.dataframe)
-    pd.testing.assert_frame_equal(points3.dataframe, points4.dataframe)
+    pd.testing.assert_frame_equal(points1.get_dataframe(), points2.get_dataframe())
+    pd.testing.assert_frame_equal(points2.get_dataframe(), points3.get_dataframe())
+    pd.testing.assert_frame_equal(points3.get_dataframe(), points4.get_dataframe())
 
 
 def test_points_from_list_of_tuples():
@@ -44,8 +44,8 @@ def test_points_from_list_of_tuples():
 
     mypoints = Points(plist)
 
-    x0 = mypoints.dataframe["X_UTME"].values[0]
-    z2 = mypoints.dataframe["Z_TVDSS"].values[2]
+    x0 = mypoints.get_dataframe()["X_UTME"].values[0]
+    z2 = mypoints.get_dataframe()["Z_TVDSS"].values[2]
     assert x0 == 234
     assert z2 == 12
 
@@ -69,9 +69,15 @@ def test_create_pointset(points):
 
     assert len(points) == pointset.nrow
 
-    np.testing.assert_array_almost_equal(pointset.dataframe["X_UTME"], points[:, 0])
-    np.testing.assert_array_almost_equal(pointset.dataframe["Y_UTMN"], points[:, 1])
-    np.testing.assert_array_almost_equal(pointset.dataframe["Z_TVDSS"], points[:, 2])
+    np.testing.assert_array_almost_equal(
+        pointset.get_dataframe()["X_UTME"], points[:, 0]
+    )
+    np.testing.assert_array_almost_equal(
+        pointset.get_dataframe()["Y_UTMN"], points[:, 1]
+    )
+    np.testing.assert_array_almost_equal(
+        pointset.get_dataframe()["Z_TVDSS"], points[:, 2]
+    )
 
 
 def test_import(testpath):
@@ -81,7 +87,7 @@ def test_import(testpath):
         testpath / PFILE
     )  # should guess based on extesion
 
-    x0 = mypoints.dataframe["X_UTME"].values[0]
+    x0 = mypoints.get_dataframe()["X_UTME"].values[0]
     assert x0 == pytest.approx(460842.434326, 0.001)
 
 
@@ -95,7 +101,7 @@ def test_import_from_dataframe(testpath):
         values=dfr, xname="X", yname="Y", zname="Z", attributes=attr
     )
 
-    assert mypoints.dataframe.X.mean() == dfr.X.mean()
+    assert mypoints.get_dataframe().X.mean() == dfr.X.mean()
 
     with pytest.raises(ValueError):
         mypoints = Points(dfr, xname="NOTTHERE", yname="Y", zname="Z", attributes=attr)
@@ -111,9 +117,11 @@ def test_export_and_load_points(tmp_path):
 
     exported_points = xtgeo.points_from_file(export_path)
 
-    pd.testing.assert_frame_equal(test_points.dataframe, exported_points.dataframe)
+    pd.testing.assert_frame_equal(
+        test_points.get_dataframe(), exported_points.get_dataframe()
+    )
     assert list(itertools.chain.from_iterable(plist)) == list(
-        test_points.dataframe.values.flatten()
+        test_points.get_dataframe().values.flatten()
     )
 
 
@@ -130,7 +138,9 @@ def test_export_load_rmsformatted_points(testpath, tmp_path):
 
     reloaded_points = xtgeo.points_from_file(export_path)
 
-    pd.testing.assert_frame_equal(orig_points.dataframe, reloaded_points.dataframe)
+    pd.testing.assert_frame_equal(
+        orig_points.get_dataframe(), reloaded_points.get_dataframe()
+    )
 
 
 @pytest.mark.bigtest
@@ -147,7 +157,9 @@ def test_import_rmsattr_format(testpath, tmp_path):
 
     reloaded_points = Points()
     reloaded_points.from_file(export_path, fformat="rms_attr")
-    pd.testing.assert_frame_equal(orig_points.dataframe, reloaded_points.dataframe)
+    pd.testing.assert_frame_equal(
+        orig_points.get_dataframe(), reloaded_points.get_dataframe()
+    )
 
 
 def test_export_points_rmsattr(testpath, tmp_path):
@@ -161,9 +173,9 @@ def test_export_points_rmsattr(testpath, tmp_path):
     mypoints.to_file(output_path, fformat="rms_attr")
     mypoints2 = xtgeo.points_from_file(output_path)
 
-    assert mypoints.dataframe["Seg"].equals(mypoints2.dataframe["Seg"])
+    assert mypoints.get_dataframe()["Seg"].equals(mypoints2.get_dataframe()["Seg"])
 
     np.testing.assert_array_almost_equal(
-        mypoints.dataframe["MyNum"].values,
-        mypoints2.dataframe["MyNum"].values,
+        mypoints.get_dataframe()["MyNum"].values,
+        mypoints2.get_dataframe()["MyNum"].values,
     )

--- a/tests/test_xyz/test_points_from_surface.py
+++ b/tests/test_xyz/test_points_from_surface.py
@@ -12,14 +12,14 @@ def test_from_simple_surface():
         ncol=4, nrow=5, xori=0, yori=0, xinc=25, yinc=25, values=1234.0
     )
     poi = xtgeo.points_from_surface(surf)
-    assert poi.dataframe[poi.zname][0] == 1234.0
+    assert poi.get_dataframe()[poi.zname][0] == 1234.0
 
     poi.zname = "VALUES"
-    pd.testing.assert_frame_equal(poi.dataframe, surf.dataframe())
+    pd.testing.assert_frame_equal(poi.get_dataframe(), surf.get_dataframe())
 
     poi2 = xtgeo.points_from_surface(surf, zname="VALUES")
 
-    pd.testing.assert_frame_equal(poi2.dataframe, surf.dataframe())
+    pd.testing.assert_frame_equal(poi2.get_dataframe(), surf.get_dataframe())
 
 
 def test_init_with_surface_classmethod(testpath):
@@ -28,4 +28,4 @@ def test_init_with_surface_classmethod(testpath):
     poi = xtgeo.points_from_surface(surf)
 
     poi.zname = "VALUES"
-    pd.testing.assert_frame_equal(poi.dataframe, surf.dataframe())
+    pd.testing.assert_frame_equal(poi.get_dataframe(), surf.get_dataframe())

--- a/tests/test_xyz/test_points_from_wells.py
+++ b/tests/test_xyz/test_points_from_wells.py
@@ -19,8 +19,8 @@ def test_get_zone_tops_one_well_classmethod(testpath, tmp_path):
 
     mypoints = xtgeo.points_from_wells(wlist)
 
-    assert mypoints.dataframe["TopName"][2] == "TopBelow_TopLowerReek"
-    assert mypoints.dataframe["X_UTME"][2] == pytest.approx(462698.333)
+    assert mypoints.get_dataframe()["TopName"][2] == "TopBelow_TopLowerReek"
+    assert mypoints.get_dataframe()["X_UTME"][2] == pytest.approx(462698.333)
 
     mypoints.to_file(
         tmp_path / "points_w1_classmethod.rmsasc",
@@ -46,10 +46,10 @@ def test_get_zone_tops_one_well_w_undef(testpath):
     p2 = xtgeo.points_from_wells(wlist, use_undef=True)
     p3 = xtgeo.points_from_wells(wlist, use_undef=False)
 
-    assert p1.dataframe.equals(p2.dataframe)
+    assert p1.get_dataframe().equals(p2.get_dataframe())
 
-    assert p2.dataframe["Zone"][0] == 0
-    assert p3.dataframe["Zone"][0] == 1
+    assert p2.get_dataframe()["Zone"][0] == 0
+    assert p3.get_dataframe()["Zone"][0] == 1
 
 
 def test_get_zone_thickness_one_well(testpath):
@@ -60,7 +60,7 @@ def test_get_zone_thickness_one_well(testpath):
     mypoints = Points()
     mypoints = xtgeo.points_from_wells(wlist, tops=False, zonelist=[1, 2, 3])
     mypoints.zname = "THICKNESS"
-    assert mypoints.dataframe["THICKNESS"][0] == pytest.approx(16.8397)
+    assert mypoints.get_dataframe()["THICKNESS"][0] == pytest.approx(16.8397)
 
 
 def test_get_zone_thickness_some_wells(testpath, tmp_path, snapshot, helpers):
@@ -88,7 +88,7 @@ def test_get_zone_thickness_some_wells(testpath, tmp_path, snapshot, helpers):
     )
 
     # not the order in the dataframe may vary randomly so do a sort
-    dfr = mypoints.dataframe.sort_values(["WellName", "Zone", "Z_TVDSS"])
+    dfr = mypoints.get_dataframe().sort_values(["WellName", "Zone", "Z_TVDSS"])
     snapshot.assert_match(
         helpers.df2csv(dfr.head(10).round(), index=False),
         "zpoints_w_so622.csv",
@@ -114,7 +114,7 @@ def test_get_faciesfraction_some_wells_classmethod(testpath, tmp_path):
     mypoints.zname = "FACFRAC"
 
     myquery = 'WELLNAME == "OP_1" and ZONE == 1'
-    usedf = mypoints.dataframe.query(myquery)
+    usedf = mypoints.get_dataframe().query(myquery)
 
     assert abs(usedf[mypoints.zname].values[0] - 0.86957) < 0.001
 

--- a/tests/test_xyz/test_points_vs_other.py
+++ b/tests/test_xyz/test_points_vs_other.py
@@ -19,7 +19,9 @@ def test_snap_to_surface(testpath):
     mypoints.snap_surface(surf1)
     assert mypoints.nrow == 11
 
-    assert mypoints.dataframe["Z_TVDSS"].mean() == pytest.approx(1661.45, abs=0.01)
+    assert mypoints.get_dataframe()["Z_TVDSS"].mean() == pytest.approx(
+        1661.45, abs=0.01
+    )
 
     # repeat,using surface whithg rotaion and partial masks
 
@@ -28,10 +30,14 @@ def test_snap_to_surface(testpath):
 
     mypoints.snap_surface(surf2)
     assert mypoints.nrow == 12
-    assert mypoints.dataframe["Z_TVDSS"].mean() == pytest.approx(1687.45, abs=0.01)
+    assert mypoints.get_dataframe()["Z_TVDSS"].mean() == pytest.approx(
+        1687.45, abs=0.01
+    )
 
     # alternative; keep values as is using activeobnly=False
     mypoints = xtgeo.points_from_file(testpath / PFILE3)
     mypoints.snap_surface(surf2, activeonly=False)
     assert mypoints.nrow == 20
-    assert mypoints.dataframe["Z_TVDSS"].mean() == pytest.approx(1012.47, abs=0.01)
+    assert mypoints.get_dataframe()["Z_TVDSS"].mean() == pytest.approx(
+        1012.47, abs=0.01
+    )

--- a/tests/test_xyz/test_polygons_from_wells.py
+++ b/tests/test_xyz/test_polygons_from_wells.py
@@ -23,5 +23,4 @@ def test_get_polygons_many_wells(testpath):
         for wpath in glob.glob(str(testpath / WFILES2))
     ]
     mypoly = xtgeo.polygons_from_wells(wlist, 2, resample=10)
-    print(mypoly.dataframe)
     assert mypoly.nrow == 29

--- a/tests/test_xyz/test_xyz_deprecated.py
+++ b/tests/test_xyz/test_xyz_deprecated.py
@@ -44,7 +44,7 @@ def test_points_from_list_deprecated():
 
         old_points = xtgeo.Points()
         old_points.from_list(plist)
-        assert mypoints.dataframe.equals(old_points.dataframe)
+        assert mypoints.get_dataframe().equals(old_points.get_dataframe())
 
 
 def test_import_from_dataframe_deprecated(testpath):
@@ -57,7 +57,7 @@ def test_import_from_dataframe_deprecated(testpath):
     with pytest.warns(DeprecationWarning):
         mypoints.from_dataframe(dfr, east="X", north="Y", tvdmsl="Z", attributes=attr)
 
-    assert mypoints.dataframe.X_UTME.mean() == dfr.X.mean()
+    assert mypoints.get_dataframe().X_UTME.mean() == dfr.X.mean()
 
 
 @pytest.mark.parametrize(
@@ -83,9 +83,15 @@ def test_polygons_from_file_alternatives_with_deprecated(testpath, filename, ffo
         polygons3 = xtgeo.polygons_from_file(testpath / filename, fformat=fformat)
         polygons4 = xtgeo.polygons_from_file(testpath / filename)
 
-        pd.testing.assert_frame_equal(polygons1.dataframe, polygons2.dataframe)
-        pd.testing.assert_frame_equal(polygons2.dataframe, polygons3.dataframe)
-        pd.testing.assert_frame_equal(polygons3.dataframe, polygons4.dataframe)
+        pd.testing.assert_frame_equal(
+            polygons1.get_dataframe(), polygons2.get_dataframe()
+        )
+        pd.testing.assert_frame_equal(
+            polygons2.get_dataframe(), polygons3.get_dataframe()
+        )
+        pd.testing.assert_frame_equal(
+            polygons3.get_dataframe(), polygons4.get_dataframe()
+        )
 
 
 def test_get_polygons_one_well_deprecated(testpath, tmp_path):
@@ -118,7 +124,7 @@ def test_get_polygons_many_wells_deprecated(testpath, tmp_path):
     mypoly2.to_file(tmp_path / "poly_w1_many_new.irapasc")
 
     pd.testing.assert_frame_equal(
-        mypoly.dataframe.iloc[:, 0:4], mypoly2.dataframe.iloc[:, 0:4]
+        mypoly.get_dataframe().iloc[:, 0:4], mypoly2.get_dataframe().iloc[:, 0:4]
     )
 
 
@@ -132,7 +138,7 @@ def test_init_with_surface_deprecated(testpath):
         poi = xtgeo.Points(surf)
 
     poi.zname = "VALUES"
-    pd.testing.assert_frame_equal(poi.dataframe, surf.dataframe())
+    pd.testing.assert_frame_equal(poi.get_dataframe(), surf.get_dataframe())
 
 
 def test_get_zone_tops_one_well_deprecated(testpath):
@@ -146,7 +152,9 @@ def test_get_zone_tops_one_well_deprecated(testpath):
 
     mypoints_new = xtgeo.points_from_wells(wlist)
 
-    pd.testing.assert_frame_equal(mypoints.dataframe, mypoints_new.dataframe)
+    pd.testing.assert_frame_equal(
+        mypoints.get_dataframe(), mypoints_new.get_dataframe()
+    )
 
 
 def test_get_zone_tops_some_wells_deprecated(testpath):
@@ -165,7 +173,7 @@ def test_get_zone_tops_some_wells_deprecated(testpath):
 
     # classmethod
     p2 = xtgeo.points_from_wells(wlist)
-    assert p1.dataframe.equals(p2.dataframe)
+    assert p1.get_dataframe().equals(p2.get_dataframe())
 
 
 def test_get_faciesfraction_some_wells_deprecated(testpath):
@@ -186,6 +194,6 @@ def test_get_faciesfraction_some_wells_deprecated(testpath):
     mypoints.zname = "FACFRAC"
 
     myquery = 'WELLNAME == "OP_1" and ZONE == 1'
-    usedf = mypoints.dataframe.query(myquery)
+    usedf = mypoints.get_dataframe().query(myquery)
 
     assert abs(usedf[mypoints.zname].values[0] - 0.86957) < 0.001

--- a/tests/test_xyz/test_xyz_roxapi_mock.py
+++ b/tests/test_xyz/test_xyz_roxapi_mock.py
@@ -67,7 +67,7 @@ def polygon_set_in_roxvalues(polygons_set, mocker):
 @pytest.mark.usefixtures("mock_roxutils", "point_set_in_roxvalues")
 def test_load_points_from_roxar():
     poi = xtgeo.points_from_roxar("project", "Name", "Category")
-    assert poi.dataframe["X_UTME"][3] == 1.3
+    assert poi.get_dataframe()["X_UTME"][3] == 1.3
 
 
 @pytest.mark.usefixtures("mock_roxutils", "point_set_in_roxvalues")
@@ -87,7 +87,7 @@ def test_load_polygons_from_roxar():
     pol = xtgeo.polygons_from_roxar("project", "Name", "Category")
 
     assert_frame_equal(
-        pol.dataframe,
+        pol.get_dataframe(),
         pd.DataFrame(
             [
                 [1.0, 2.0, 44.0, 0],


### PR DESCRIPTION
Since `.dataframe` property now is deprecated, replace all instances in both code and tests with `get_dataframe()` and `set_dataframe()`.

Also deprecated `dataframe()` method in `RegularSurface`.

The `get_dataframe()` in Points/Polygons/Wells will have an option to use `copy=False` which will return a view of the Pandas dataframe instead of a copy, which will be faster and more memory efficient, but also more vulnerable if the dataframe is manipulated directly.
