### PR TITLE
CLN: Refactor and type `_gridprop_export`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -60,9 +60,6 @@ ignore_errors = True
 [mypy-xtgeo.grid3d._grid_refine]
 ignore_errors = True
 
-[mypy-xtgeo.grid3d._gridprop_export]
-ignore_errors = True
-
 [mypy-xtgeo.grid3d._gridprop_op1]
 ignore_errors = True
 

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -494,7 +494,7 @@ class GridProperty(_Grid3D):
                 self.geometry = gridlike
             gridlike.append_prop(self)
 
-        self._metadata = MetaDataCPProperty()
+        self._metadata: MetaDataCPProperty = MetaDataCPProperty()
 
     def _set_initial_dimensions(
         self,
@@ -1020,7 +1020,7 @@ class GridProperty(_Grid3D):
     def to_file(
         self,
         pfile: FileLike,
-        fformat: str = "roff",
+        fformat: Literal["roff", "roffasc", "grdecl", "bgrdecl", "xtgcpprop"] = "roff",
         name: str | None = None,
         append: bool = False,
         dtype: type[np.float32] | type[np.float64] | type[np.int32] | None = None,


### PR DESCRIPTION
These functions did not support memory streams which made _only_ typing them not possible. Some changes needed to be made to support writing and appending to streams as well.

Adds to #1011