### PR TITLE
ENH: Roxar well picks support

### DIFF
--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -1,56 +1,136 @@
 # coding: utf-8
 """Roxar API functions for XTGeo Points/Polygons"""
+from __future__ import annotations
+
 import os
 import tempfile
+from enum import Enum
+from typing import Any, Literal, Type, cast
 
 import numpy as np
 import pandas as pd
 
-import xtgeo
+from xtgeo import ROXAR  # type: ignore
 from xtgeo.common import _XTGeoFile, null_logger
+from xtgeo.common._xyz_enum import _AttrName
+from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_INT_LIMIT, UNDEF_LIMIT
 from xtgeo.roxutils import RoxUtils
-from xtgeo.xyz import _xyz_io
+from xtgeo.xyz import _xyz_io, points, polygons
+
+if ROXAR:
+    import roxar
+    import roxar.well_picks as roxwp
 
 logger = null_logger(__name__)
 
 
-VALID_STYPES = ["horizons", "zones", "clipboard", "general2d_data", "faults"]
-VALID_STYPES_EXPORT = VALID_STYPES + ["horizon_picks"]
+class STYPE(str, Enum):
+    HORIZONS = "horizons"
+    ZONES = "zones"
+    CLIPBOARD = "clipboard"
+    GENERAL2D_DATA = "general2d_data"
+    FAULTS = "faults"
+    WELL_PICKS = "well_picks"
+
+    @classmethod
+    def _missing_(cls: Type[STYPE], value: object) -> None:
+        valid_values = [m.value for m in cls]
+        raise ValueError(f"Invalid stype {value}. Valid entries are {valid_values}")
 
 
-def _check_stypes_names_category(roxutils, stype, name, category, export=False):
+XYZ_COLUMNS = [_AttrName.XNAME.value, _AttrName.YNAME.value, _AttrName.ZNAME.value]
+REQUIRED_WELL_PICK_ATTRIBUTES = [_AttrName.M_MD_NAME.value, "WELLNAME", "TRAJECTORY"]
+VALID_WELL_PICK_TYPES = ["fault", "horizon"]
+
+
+def _check_input_and_version_requirement(
+    roxutils: RoxUtils,
+    stype: STYPE,
+    category: str | list[str] | None,
+    attributes: list[str] | bool | None,
+    is_polygons: bool,
+    mode: Literal["set", "get"],
+) -> None:
     """General check of some input values."""
-    stype = stype.lower()
 
-    valid_stypes = VALID_STYPES_EXPORT if export else VALID_STYPES
+    if attributes is not None:
+        if mode == "get" and not isinstance(attributes, (list, bool)):
+            raise TypeError("'attributes' argument can only be of type list or bool")
+        if mode == "set" and not isinstance(attributes, bool):
+            raise TypeError("'attributes' argument can only be of type bool")
 
-    if stype not in valid_stypes:
-        raise ValueError(
-            f"Invalid stype value! For key <stype> the value {stype} is not supported, "
-            f"legal stype values are: {valid_stypes}"
-        )
-
-    if not name:
-        raise ValueError("The name is missing or empty.")
-
-    logger.info("The stype is: %s", stype)
-    if stype in ("horizons", "zones") and (name is None or not category):
-        raise ValueError(
-            "Need to spesify both name and category for horizons and zones"
-        )
+    logger.info("The stype is: %s", stype.value)
 
     # note: check of clipboard va Roxar API 1.2 is now removed as usage of
     # such old API versions is obsolute.
-    if stype == "general2d_data" and not roxutils.version_required("1.6"):
+    if stype in (
+        STYPE.GENERAL2D_DATA,
+        STYPE.WELL_PICKS,
+    ) and not roxutils.version_required("1.6"):
         raise NotImplementedError(
-            "API Support for general2d_data is missing in this RMS version"
-            f"(current API version is {roxutils.roxversion} - required is 1.6"
+            f"API Support for {stype} is missing in this RMS version "
+            f"(current API version is {roxutils.roxversion} - required is 1.6)"
         )
+
+    if stype == STYPE.WELL_PICKS:
+        if category not in VALID_WELL_PICK_TYPES:
+            raise ValueError(
+                f"Invalid {category=}. Valid entries are {VALID_WELL_PICK_TYPES}"
+            )
+        if is_polygons:
+            raise ValueError(f"Polygons does not support {stype=}.")
+
+
+def _check_presence_in_project(
+    rox: RoxUtils,
+    name: str,
+    category: str | list[str] | None,
+    stype: STYPE,
+    realisation: int,
+    mode: Literal["set", "get"] = "get",
+) -> None:
+    """Helper to check if valid placeholder' whithin RMS."""
+
+    logger.warning("Realisation %s not in use", realisation)
+
+    project_attr = getattr(rox.project, stype)
+
+    if stype in [STYPE.HORIZONS, STYPE.ZONES, STYPE.FAULTS]:
+        if name not in project_attr:
+            raise ValueError(f"Cannot access {name=} in {stype}")
+        if category is None:
+            raise ValueError("Need to specify category for horizons, zones and faults")
+        if isinstance(category, list) or category not in project_attr:
+            raise ValueError(f"Cannot access {category=} in {stype}")
+
+    # only need to check presence in clipboard/general2d_data/well_picks if mode = get.
+    if mode == "get":
+        if stype in [STYPE.CLIPBOARD, STYPE.GENERAL2D_DATA]:
+            folders = _get_rox_clipboard_folders(category)
+
+            try:
+                rox_folder = project_attr.folders[folders]
+            except KeyError as keyerr:
+                raise ValueError(
+                    "Cannot access clipboards folder (not existing?)"
+                ) from keyerr
+
+            if name not in rox_folder:
+                raise ValueError(f"Name {name} is not within Clipboard...")
+
+        if stype == STYPE.WELL_PICKS and name not in project_attr.sets:
+            raise ValueError(f"Well pick set {name} is not within Well Picks.")
 
 
 def import_xyz_roxapi(
-    project, name, category, stype, realisation, attributes, is_polygons
-):  # pragma: no cover
+    project: roxar.project,
+    name: str,
+    category: str | list[str],
+    stype: str = "horizons",
+    realisation: int = 0,
+    attributes: list[str] | bool | None = False,
+    is_polygons: bool = False,
+) -> dict[str, Any]:
     """Import a Points or Polygons item via ROXAR API spec.
 
     'Import' means transfer of data from Roxar API memory space to XTGeo memory space.
@@ -68,12 +148,22 @@ def import_xyz_roxapi(
     """
 
     rox = RoxUtils(project, readonly=True)
+    stype = STYPE(stype.lower())
 
-    _check_stypes_names_category(rox, stype, name, category)
+    _check_input_and_version_requirement(
+        rox, stype, category, attributes, is_polygons, mode="get"
+    )
+    _check_presence_in_project(rox, name, category, stype, realisation, mode="get")
 
     if attributes and not rox.version_required("1.6"):
-        result = _roxapi_import_xyz_viafile(
-            rox, name, category, stype, realisation, is_polygons
+        result = _roxapi_import_xyz_viafile(rox, name, category, stype, is_polygons)
+    elif stype == STYPE.WELL_PICKS:
+        category = cast(Literal["fault", "horizon"], category)
+        result = _roxapi_import_wellpicks(
+            rox=rox,
+            well_pick_set=name,
+            wp_category=category,
+            attributes=attributes,
         )
     else:
         result = _roxapi_import_xyz(
@@ -85,8 +175,12 @@ def import_xyz_roxapi(
 
 
 def _roxapi_import_xyz_viafile(
-    rox, name, category, stype, realisation, is_polygons
-):  # pragma: no cover
+    rox: RoxUtils,
+    name: str,
+    category: str | list[str] | None,
+    stype: STYPE,
+    is_polygons: bool,
+) -> dict[str, Any]:
     """Read XYZ from file due to a missing feature in Roxar API wrt attributes.
 
     However, attributes will be present in Roxar API from RMS version 12, and this
@@ -100,13 +194,7 @@ def _roxapi_import_xyz_viafile(
             "roxar not available, this functionality is not available"
         ) from err
 
-    if not _check_category_etc(rox.project, name, category, stype, realisation):
-        raise RuntimeError(
-            f"It appears that name and or category is not present: name={name}, "
-            f"category/folder={category}, stype={stype}"
-        )
-
-    rox_xyz = _get_roxxyz(
+    rox_xyz = _get_roxitem(
         rox,
         name,
         category,
@@ -131,25 +219,26 @@ def _roxapi_import_xyz_viafile(
 
 
 def _roxapi_import_xyz(
-    rox, name, category, stype, realisation, is_polygons, attributes
-):  # pragma: no cover
+    rox: RoxUtils,
+    name: str,
+    category: str | list[str] | None,
+    stype: STYPE,
+    realisation: int,
+    is_polygons: bool,
+    attributes: bool | list[str],
+) -> dict[str, str | dict | pd.DataFrame]:
     """From RMS to XTGeo"""
-    kwargs = {}
 
-    if not _check_category_etc(rox.project, name, category, stype, realisation):
-        raise RuntimeError(
-            f"It appears that name and or category is not present: name={name}, "
-            f"category/folder={category}, stype={stype}"
-        )
-
-    kwargs["xname"] = "X_UTME"
-    kwargs["yname"] = "Y_UTMN"
-    kwargs["zname"] = "Z_TVDSS"
+    kwargs: dict[str, str | dict | pd.DataFrame] = {
+        "xname": _AttrName.XNAME.value,
+        "yname": _AttrName.YNAME.value,
+        "zname": _AttrName.ZNAME.value,
+    }
 
     if is_polygons:
         kwargs["pname"] = "POLY_ID"
 
-    roxxyz = _get_roxxyz(
+    roxxyz = _get_roxitem(
         rox,
         name,
         category,
@@ -157,7 +246,6 @@ def _roxapi_import_xyz(
         mode="get",
         is_polygons=is_polygons,
     )
-
     values = _get_roxvalues(roxxyz, realisation=realisation)
 
     dfr = _roxapi_xyz_to_dataframe(values, is_polygons=is_polygons)
@@ -165,6 +253,8 @@ def _roxapi_import_xyz(
     # handling attributes for points, from Roxar API version 1.6
     if attributes and not is_polygons:
         attr_names = roxxyz.get_attributes_names(realisation=realisation)
+        if isinstance(attributes, list):
+            attr_names = [a for a in attr_names if a in attributes]
         logger.info("XYZ attribute names are: %s", attr_names)
         attr_dict = _get_rox_attrvalues(roxxyz, attr_names, realisation=realisation)
         dfr, datatypes = _add_attributes_to_dataframe(dfr, attr_dict)
@@ -174,7 +264,9 @@ def _roxapi_import_xyz(
     return kwargs
 
 
-def _roxapi_xyz_to_dataframe(roxxyz, is_polygons=False):  # pragma: no cover
+def _roxapi_xyz_to_dataframe(
+    roxxyz: list[np.ndarray] | np.ndarray, is_polygons: bool = False
+) -> pd.DataFrame:
     """Transforming some XYZ from ROXAPI to a Pandas dataframe."""
 
     # In ROXAPI, polygons/polylines are a list of numpies, while
@@ -182,13 +274,12 @@ def _roxapi_xyz_to_dataframe(roxxyz, is_polygons=False):  # pragma: no cover
     # by being a list after import
 
     logger.info("Points/polygons/polylines from roxapi to xtgeo...")
-    cnames = ["X_UTME", "Y_UTMN", "Z_TVDSS"]
 
     if is_polygons and isinstance(roxxyz, list):
         # polylines/-gons
         dfs = []
         for idx, poly in enumerate(roxxyz):
-            dataset = pd.DataFrame.from_records(poly, columns=cnames)
+            dataset = pd.DataFrame.from_records(poly, columns=XYZ_COLUMNS)
             dataset["POLY_ID"] = idx
             dfs.append(dataset)
 
@@ -196,7 +287,7 @@ def _roxapi_xyz_to_dataframe(roxxyz, is_polygons=False):  # pragma: no cover
 
     elif not is_polygons and isinstance(roxxyz, np.ndarray):
         # points
-        dfr = pd.DataFrame.from_records(roxxyz, columns=cnames)
+        dfr = pd.DataFrame.from_records(roxxyz, columns=XYZ_COLUMNS)
 
     else:
         raise RuntimeError(f"Unknown error in getting data from Roxar: {type(roxxyz)}")
@@ -205,7 +296,9 @@ def _roxapi_xyz_to_dataframe(roxxyz, is_polygons=False):  # pragma: no cover
     return dfr
 
 
-def _add_attributes_to_dataframe(dfr, attributes: dict):  # pragma: no cover
+def _add_attributes_to_dataframe(
+    dfr: pd.DataFrame, attributes: dict
+) -> tuple[pd.DataFrame, dict[str, str]]:
     """Add attributes to dataframe (points only) for Roxar API ver 1.6+"""
 
     logger.info("Attributes adding to dataframe...")
@@ -216,10 +309,10 @@ def _add_attributes_to_dataframe(dfr, attributes: dict):  # pragma: no cover
         dtype = str(values.dtype)
         if "int" in dtype:
             datatypes[name] = "int"
-            values = np.ma.filled(values, fill_value=xtgeo.UNDEF_INT)
+            values = np.ma.filled(values, fill_value=UNDEF_INT)
         elif "float" in dtype:
             datatypes[name] = "float"
-            values = np.ma.filled(values, fill_value=xtgeo.UNDEF)
+            values = np.ma.filled(values, fill_value=UNDEF)
         else:
             datatypes[name] = "str"
             values = np.ma.filled(values, fill_value="UNDEF")
@@ -230,22 +323,33 @@ def _add_attributes_to_dataframe(dfr, attributes: dict):  # pragma: no cover
 
 
 def export_xyz_roxapi(
-    self, project, name, category, stype, pfilter, realisation, attributes
-):  # pragma: no cover
+    self: points.Points | polygons.Polygons,
+    project: roxar.Project,
+    name: str,
+    category: str | list[str] | None,
+    stype: str,
+    pfilter: dict[str, list],
+    realisation: int,
+    attributes: bool = False,
+) -> None:
     """Export (store) a XYZ item from XTGeo to RMS via ROXAR API spec."""
+    is_polygons = isinstance(self, polygons.Polygons)
     rox = RoxUtils(project, readonly=False)
+    stype = STYPE(stype.lower())
 
-    _check_stypes_names_category(rox, stype, name, category, export=True)
-
-    if stype == "horizon_picks":
-        _roxapi_export_xyz_hpicks(
-            self, rox, name, category, stype, realisation, attributes
-        )
+    _check_input_and_version_requirement(
+        rox, stype, category, attributes, is_polygons, mode="set"
+    )
+    _check_presence_in_project(rox, name, category, stype, realisation, mode="set")
 
     if attributes and not rox.version_required("1.6"):
         _roxapi_export_xyz_viafile(
             self, rox, name, category, stype, pfilter, realisation, attributes
         )
+    elif stype == STYPE.WELL_PICKS:
+        assert isinstance(self, points.Points)
+        category = cast(Literal["fault", "horizon"], category)
+        _roxapi_export_xyz_well_picks(self, rox, name, category, attributes, pfilter)
     else:
         _roxapi_export_xyz(
             self, rox, name, category, stype, pfilter, realisation, attributes
@@ -257,19 +361,16 @@ def export_xyz_roxapi(
     rox.safe_close()
 
 
-def _roxapi_export_xyz_hpicks(
-    self, rox, name, category, stype, realisation, attributes
-):  # pragma: no cover
-    """
-    Export/store as RMS horizon picks; this is only valid if points belong to wells
-    """
-    # need to think on design!
-    raise NotImplementedError
-
-
 def _roxapi_export_xyz_viafile(
-    self, rox, name, category, stype, pfilter, realisation, attributes
-):  # pragma: no cover
+    self: points.Points | polygons.Polygons,
+    rox: RoxUtils,
+    name: str,
+    category: str | list[str] | None,
+    stype: STYPE,
+    pfilter: dict[str, list],
+    realisation: int,
+    attributes: bool,
+) -> None:
     """Set points/polys within RMS with attributes, using file workaround"""
 
     logger.warning("Realisation %s not in use", realisation)
@@ -281,12 +382,10 @@ def _roxapi_export_xyz_viafile(
             "roxar not available, this functionality is not available"
         ) from err
 
-    proj = rox.project
-
-    if not _check_category_etc(proj, name, category, stype, realisation, mode="set"):
-        raise RuntimeError("Cannot access correct category or name in RMS")
-
-    roxxyz = _get_roxitem(self, proj, name, category, stype, mode="set")
+    is_polygons = isinstance(self, polygons.Polygons)
+    roxxyz = _get_roxitem(
+        rox, name, category, stype, mode="set", is_polygons=is_polygons
+    )
 
     # make a temporary folder and work within the with.. block
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -305,244 +404,141 @@ def _roxapi_export_xyz_viafile(
 
 
 def _roxapi_export_xyz(
-    self, rox, name, category, stype, pfilter, realisation, attributes
-):  # pragma: no cover
+    self: points.Points | polygons.Polygons,
+    rox: RoxUtils,
+    name: str,
+    category: str | list[str] | None,
+    stype: STYPE,
+    pfilter: dict[str, list] | None,
+    realisation: int,
+    attributes: bool,
+) -> None:
     logger.warning("Realisation %s not in use", realisation)
 
-    proj = rox.project
-    if not _check_category_etc(proj, name, category, stype, realisation, mode="set"):
-        raise RuntimeError("Cannot access correct category or name in RMS")
-
-    roxxyz = _get_roxitem(self, proj, name, category, stype, mode="set")
-
-    if (
-        self.get_dataframe(copy=False) is None
-        or len(self.get_dataframe(copy=False).index) == 0
-    ):
+    df = self.get_dataframe()
+    if df is None or df.empty:
+        logger.warning("Empty dataframe! Skipping object update...")
         return
 
-    dfrcopy = self.get_dataframe()
-    # apply pfilter if any
-    if pfilter:
-        for key, val in pfilter.items():
-            if key in dfrcopy.columns:
-                dfrcopy = dfrcopy.loc[dfrcopy[key].isin(val)]
-            else:
-                raise KeyError(
-                    f"The requested pfilter key {key} was not found in dataframe. "
-                    f"Valid keys are {dfrcopy.columns}"
-                )
+    is_polygons = isinstance(self, polygons.Polygons)
 
-    if isinstance(self, xtgeo.Polygons):
-        arrxyz = []
-        polys = dfrcopy.groupby(self.pname)
-        for _id, grp in polys:
-            arr = np.stack([grp[self.xname], grp[self.yname], grp[self.zname]], axis=1)
-            arrxyz.append(arr)
-    else:
-        xyz = dfrcopy
-        arrxyz = np.stack([xyz[self.xname], xyz[self.yname], xyz[self.zname]], axis=1)
+    roxxyz = _get_roxitem(
+        rox, name, category, stype, mode="set", is_polygons=is_polygons
+    )
 
-    if (
-        isinstance(arrxyz, np.ndarray)
-        and arrxyz.size == 0
-        or isinstance(arrxyz, list)
-        and len(arrxyz) == 0
-    ):
-        return
+    df = _apply_pfilter_to_dataframe(df, pfilter)
+    if df.empty:
+        raise ValueError("Empty dataframe, no data left after filtering")
+
+    arrxyz = (
+        [polydf[XYZ_COLUMNS].to_numpy() for _, polydf in df.groupby(self.pname)]
+        if is_polygons
+        else df[XYZ_COLUMNS].to_numpy()
+    )
 
     roxxyz.set_values(arrxyz)
 
-    if (
-        attributes
-        and isinstance(self, xtgeo.Points)
-        and len(self.get_dataframe(copy=False)) >= 1
-    ):
-        dfr = _cast_dataframe_attrs_to_numeric(dfrcopy)
-        for name in dfr.columns[3:]:
-            values = dfr[name].values
-            if "float" in str(values.dtype):
-                values = np.ma.masked_greater(values, xtgeo.UNDEF_LIMIT)
-            elif "int" in str(values.dtype):
-                values = np.ma.masked_greater(values, xtgeo.UNDEF_INT_LIMIT)
-            else:
-                # masking has no meaning for strings?
-                values = values.astype(str)
-                values = np.char.replace(values, "UNDEF", "")
+    if attributes and isinstance(self, points.Points):
+        for attr in _get_attribute_names_from_dataframe(df):
+            values = _replace_undefined_values(
+                values=df[attr].values, dtype=self._attrs.get(attr)
+            )
 
             logger.info("Store Point attribute %s to Roxar API", name)
-            roxxyz.set_attribute_values(name, values)
+            roxxyz.set_attribute_values(attr, values)
 
 
-def _cast_dataframe_attrs_to_numeric(dfr):
-    """Cast the attribute dataframe columns to numerical datatypes if possible.
-
-    In some case, attribute columns get dtype 'object' while they clearly
-    represents a numerical property (int or float). Here the pandas to_numerics()
-    function is applied per attribute column, and will do a conversion if possible;
-    otherwise the 'object' dtype will be preserved.
-    """
-    if len(dfr) < 1:
-        return dfr
-
-    newdfr = dfr.copy()
-    for name in dfr.columns[3:]:
-        newdfr[name] = pd.to_numeric(dfr[name], errors="ignore")
-    return newdfr
+def _get_attribute_names_from_dataframe(df: pd.DataFrame) -> list[str]:
+    return [col for col in df.columns if col not in XYZ_COLUMNS]
 
 
-def _check_category_etc(
-    proj,
-    name,
-    category,
-    stype,
-    realisation,
-    mode="get",
-):
-    """Helper to check if valid placeholder' whithin RMS."""
+def _get_attribute_type_from_values(values: np.ndarray) -> str:
+    if "float" in str(values.dtype):
+        return "float"
+    if "int" in str(values.dtype):
+        return "int"
+    return "str"
 
-    logger.warning("Realisation %s not in use", realisation)
 
-    stypedict = {"horizons": proj.horizons, "zones": proj.zones, "faults": proj.faults}
+def _replace_undefined_values(
+    values: np.ndarray, dtype: str | None = None
+) -> np.ndarray:
+    """Set xtgeo UNDEF values to np.nan or empty string dependent on type"""
+    values = pd.to_numeric(values, errors="ignore")
 
-    if stype in stypedict:
-        if name not in stypedict[stype]:
-            logger.error("Cannot access name in stype=%s: %s", stype, name)
-            return False
-        if category not in stypedict[stype].representations:
-            logger.error("Cannot access category in stype=%s: %s", stype, category)
-            return False
+    dtype = dtype or _get_attribute_type_from_values(values)
 
-    elif stype in ("clipboard", "general2d_data") and mode == "get":
-        folders = None
-        if category:
-            if isinstance(category, list):
-                folders = category
-            elif isinstance(category, str) and "|" in category:
-                folders = category.split("|")
-            elif isinstance(category, str) and "/" in category:
-                folders = category.split("/")
-            elif isinstance(category, str):
-                folders = []
-                folders.append(category)
-            else:
-                raise RuntimeError(
-                    f"Cannot parse category: {category}, see documentation!"
+    if dtype == "float":
+        return np.where(values > UNDEF_LIMIT, np.nan, values)
+
+    if dtype == "int":
+        return np.where(values > UNDEF_INT_LIMIT, np.nan, values)
+
+    # string attributes does not support nan values
+    # and requires string type array returned
+    values = values.astype(str)
+    return np.where(np.isin(values, ["UNDEF", "nan"]), "", values)
+
+
+def _apply_pfilter_to_dataframe(
+    df: pd.DataFrame, pfilter: dict[str, list] | None
+) -> pd.DataFrame:
+    if pfilter is not None:
+        for key, val in pfilter.items():
+            if key not in df:
+                raise KeyError(
+                    f"The requested pfilter key {key} was not found in dataframe. "
+                    f"Valid keys are {list(df.columns)}"
                 )
-            try:
-                roxxyz = getattr(proj, stype).folders[folders]
-            except KeyError as keyerr:
-                logger.error(
-                    "Cannot access clipboards folder (not existing?): %s", keyerr
-                )
-                return False
-        else:
-            roxxyz = proj.clipboard
-
-        if name not in roxxyz:
-            raise ValueError(f"Name {name} is not within Clipboard...")
-
-    elif stype in ("clipboard", "general2d_data") and mode == "set":
-        logger.info("No need to check clipboard while setting data")
-    else:
-        raise ValueError(f"Invalid stype: {stype}")
-
-    return True
+            df = df.loc[df[key].isin(val)]
+    return df
 
 
-def _get_roxitem(self, proj, name, category, stype, mode="set"):  # pragma: no cover
-    if stype == "horizons":
-        roxxyz = proj.horizons[name][category]
-    elif stype == "zones":
-        roxxyz = proj.zones[name][category]
-    elif stype == "faults":
-        roxxyz = proj.faults[name][category]
-    elif stype in ["clipboard", "general2d_data"]:
-        folders = None
-        roxxyz = getattr(proj, stype)
-        if category:
-            if isinstance(category, list):
-                folders = category
-            elif isinstance(category, str) and "|" in category:
-                folders = category.split("|")
-            elif isinstance(category, str) and "/" in category:
-                folders = category.split("/")
-            elif isinstance(category, str):
-                folders = []
-                folders.append(category)
-            else:
-                raise RuntimeError(
-                    f"Cannot parse category: {category}, see documentation!"
-                )
+def _get_rox_clipboard_folders(category: str | list[str] | None) -> list[str]:
+    if category is None or category == "":
+        return []
 
-            if mode == "get":
-                roxxyz = roxxyz.folders[folders]
+    if isinstance(category, list):
+        return category
 
-        if mode == "get":
-            roxxyz = roxxyz[name]
+    if isinstance(category, str):
+        if "|" in category:
+            return category.split("|")
+        if "/" in category:
+            return category.split("/")
+        return [category]
 
-        elif mode == "set":
-            # clipboard folders will be created if not present, and overwritten else
-            if isinstance(self, xtgeo.Polygons):
-                roxxyz = roxxyz.create_polylines(name, folders)
-            else:
-                roxxyz = roxxyz.create_points(name, folders)
-
-    else:
-        raise ValueError(f"Unsupported stype: {stype}")
-
-    return roxxyz
+    raise RuntimeError(f"Cannot parse category: {category}, see documentation!")
 
 
-def _get_roxxyz(
-    rox, name, category, stype, mode="set", is_polygons=False
-):  # pragma: no cover
+def _get_roxitem(
+    rox: RoxUtils,
+    name: str,
+    category: str | list[str] | None,
+    stype: STYPE,
+    mode: Literal["set", "get"] = "set",
+    is_polygons: bool = False,
+) -> Any:
     """Get the correct rox_xyz which is some pointer to a RoxarAPI structure."""
-    if stype == "horizons":
-        rox_xyz = rox.project.horizons[name][category]
-    elif stype == "zones":
-        rox_xyz = rox.project.zones[name][category]
-    elif stype == "faults":
-        rox_xyz = rox.project.faults[name][category]
-    elif stype in ["clipboard", "general2d_data"]:
-        folders = None
-        rox_xyz = getattr(rox.project, stype)
-        if category:
-            if isinstance(category, list):
-                folders = category
-                folders.append(category)
-            elif isinstance(category, str) and "|" in category:
-                folders = category.split("|")
-            elif isinstance(category, str) and "/" in category:
-                folders = category.split("/")
-            elif isinstance(category, str):
-                folders = []
-                folders.append(category)
-            else:
-                raise RuntimeError(
-                    f"Cannot parse category: {category}, see documentation!"
-                )
 
-            if mode == "get":
-                rox_xyz = rox_xyz.folders[folders]
+    project_attr = getattr(rox.project, stype)
 
-        if mode == "get":
-            rox_xyz = rox_xyz[name]
+    if stype not in [STYPE.CLIPBOARD, STYPE.GENERAL2D_DATA]:
+        return project_attr[name][category]
 
-        elif mode == "set":
-            # clipboard folders will be created if not present, and overwritten else
-            if is_polygons:
-                rox_xyz = rox_xyz.create_polylines(name, folders)
-            else:
-                rox_xyz = rox_xyz.create_points(name, folders)
+    folders = _get_rox_clipboard_folders(category)
+    if mode == "get":
+        return project_attr.folders[folders][name]
 
-    else:
-        raise TypeError(f"Unsupported stype: {stype}")  # shall never get this far...
-
-    return rox_xyz
+    # clipboard folders will be created if not present, and overwritten else
+    return (
+        project_attr.create_polylines(name, folders)
+        if is_polygons
+        else project_attr.create_points(name, folders)
+    )
 
 
-def _get_roxvalues(rox_xyz, realisation=0):  # pragma: no cover
+def _get_roxvalues(rox_xyz: Any, realisation: int = 0) -> list[np.ndarray] | np.ndarray:
     """Return primary values from the Roxar API, numpy (Points) or list (Polygons)."""
     try:
         roxitem = rox_xyz.get_values(realisation)
@@ -553,12 +549,254 @@ def _get_roxvalues(rox_xyz, realisation=0):  # pragma: no cover
     return roxitem
 
 
-def _get_rox_attrvalues(rox_xyz, attrnames, realisation=0) -> dict:  # pragma: no cover
-    """Return attribute values from the Roxar API, numpy (Points) or list (Polygons)."""
-
+def _get_rox_attrvalues(
+    rox_xyz: Any, attrnames: list[str], realisation: int = 0
+) -> dict[str, list[np.ndarray] | np.ndarray]:
+    """Return attributes from the Roxar API, numpy (Points) or list (Polygons)."""
     roxitems = {}
     for attrname in attrnames:
         values = rox_xyz.get_attribute_values(attrname, realisation=realisation)
         roxitems[attrname] = values
-
     return roxitems
+
+
+def _roxapi_import_wellpicks(
+    rox: RoxUtils,
+    well_pick_set: str,
+    wp_category: Literal["fault", "horizon"] = "horizon",
+    attributes: bool | list[str] = False,
+) -> dict[str, str | pd.DataFrame | dict]:
+    """From RMS to XTGeo"""
+
+    rox_wp = rox.project.well_picks
+    rox_wp_set = rox_wp.sets[well_pick_set]
+
+    well_picks = [wp for wp in rox_wp_set if wp.type.name == wp_category]
+    if len(well_picks) == 0:
+        raise ValueError(
+            f"No well picks of type '{wp_category}' found in {well_pick_set=}."
+        )
+
+    attribute_types = {}
+    if attributes:
+        rox_attributes = well_picks[0].attributes  # first one is valid for all
+        for rox_attr in rox_attributes:
+            if isinstance(attributes, list) and rox_attr.name not in attributes:
+                continue
+            attribute_types[rox_attr.name] = rox_attr.type.name
+
+    dfr = _create_dataframe_from_wellpicks(well_picks, wp_category, attribute_types)
+
+    return {
+        "xname": _AttrName.XNAME.value,
+        "yname": _AttrName.YNAME.value,
+        "zname": _AttrName.ZNAME.value,
+        "values": dfr,
+        "attributes": attribute_types,
+    }
+
+
+def _create_dataframe_from_wellpicks(
+    well_picks: list[roxar.well_picks.WellPick],
+    wp_category: Literal["fault", "horizon"],
+    attribute_types: dict[str, str],
+) -> pd.DataFrame:
+    """Create a dataframe from a well pick set, and selected attributes."""
+
+    items = []
+    for wp in well_picks:
+        wp_attributes = {attr.name: val for attr, val in wp.get_values().items()}
+
+        data = {
+            _AttrName.XNAME.value: wp_attributes["East"],
+            _AttrName.YNAME.value: wp_attributes["North"],
+            _AttrName.ZNAME.value: wp_attributes["TVD_MSL"],
+            _AttrName.M_MD_NAME.value: wp_attributes["MD"],
+            "WELLNAME": wp.trajectory.wellbore.well.name,
+            "TRAJECTORY": wp.trajectory.name,
+            wp_category.upper(): wp.intersection_object.name,
+        }
+
+        for attr, dtype in attribute_types.items():
+            if attr in wp_attributes:
+                if wp_attributes[attr] is not None:
+                    data[attr] = wp_attributes[attr]
+                else:
+                    if dtype == "float":
+                        data[attr] = UNDEF
+                    elif dtype == "int":
+                        data[attr] = UNDEF_INT
+                    else:
+                        data[attr] = "UNDEF"
+
+        items.append(data)
+
+    return pd.DataFrame(items)
+
+
+def _roxapi_export_xyz_well_picks(
+    self: points.Points,
+    rox: RoxUtils,
+    well_pick_set: str,
+    wp_category: Literal["horizon", "fault"],
+    attributes: bool,
+    pfilter: dict[str, list] | None,
+) -> None:
+    """
+    Export/store as RMS well picks; this is only valid if points belong to wells
+    """
+
+    df = self.get_dataframe()
+    if df is None or df.empty:
+        logger.warning("Empty dataframe! Skipping object update...")
+        return
+
+    project_attr = getattr(rox.project, f"{wp_category}s")
+    rox_wp_type = getattr(roxar.WellPickType, wp_category)
+
+    df = _apply_pfilter_to_dataframe(df, pfilter)
+    if df.empty:
+        raise ValueError("Empty dataframe, no data left after filtering")
+
+    required_columns = REQUIRED_WELL_PICK_ATTRIBUTES + [wp_category.upper()]
+    for column in required_columns:
+        if column not in df:
+            raise ValueError(f"Required {column=} missing in the dataframe.")
+        if df[column].isnull().any():
+            raise ValueError(f"The required {column=} contains undefined values.")
+
+    if attributes:
+        attr_types = self._attrs
+
+        attr_types = {}
+        for attr in _get_attribute_names_from_dataframe(df):
+            if attr not in required_columns:
+                if attr in self._attrs:
+                    attr_types[attr] = self._attrs[attr]
+                else:
+                    attr_types[attr] = _get_attribute_type_from_values(df[attr])
+
+        rox_wp_attributes = _get_writeable_well_pick_attributes(
+            rox, attr_types, rox_wp_type
+        )
+        for attr in rox_wp_attributes:
+            df[attr] = _replace_undefined_values(
+                values=df[attr].values, dtype=attr_types.get(attr)
+            )
+
+    mypicks = []
+    for well, wp_df in df.groupby("WELLNAME"):
+        rox_well_traj = rox.project.wells[well].wellbore.trajectories
+
+        for _, wp_row in wp_df.iterrows():
+            intersection_object_name = wp_row[wp_category.upper()]
+            if intersection_object_name not in project_attr:
+                raise ValueError(
+                    f"{wp_category} '{intersection_object_name}' not in project"
+                )
+            traj_name = wp_row["TRAJECTORY"]
+            if traj_name not in rox_well_traj:
+                raise ValueError(
+                    f"Trajectory name '{traj_name}' not present for {well=}"
+                )
+            wp = roxar.well_picks.WellPick.create(
+                intersection_object=project_attr[intersection_object_name],
+                trajectory=rox_well_traj[traj_name],
+                md=wp_row[_AttrName.M_MD_NAME.value],
+            )
+            if attributes:
+                for attr, rox_attr in rox_wp_attributes.items():
+                    try:
+                        wp.set_values({rox_attr: wp_row[attr]})
+                    except ValueError as err:
+                        raise ValueError(
+                            f"Could not assign value '{wp_row[attr]}' to attribute "
+                            f"'{attr}'. The value type {type(wp_row[attr])} might be "
+                            f"incompatible with dtype of attribute '{rox_attr.type}'"
+                        ) from err
+
+            mypicks.append(wp)
+
+    rox_wps = _get_well_pick_set(rox, well_pick_set, rox_wp_type)
+    rox_wps.append(mypicks)
+
+
+def _get_well_pick_set(
+    rox: RoxUtils, well_pick_set: str, rox_wp_type: roxar.WellPickType
+) -> roxar.well_picks.WellPickSet:
+    """
+    Function to retrieve a well pick set object. If the given well pick set
+    name is not present, it will be created. Otherwise the current well pick
+    set will be emptied for the given well pick type.
+    """
+    well_pick_sets = rox.project.well_picks.sets
+    if well_pick_set not in well_pick_sets:
+        well_pick_sets.create(well_pick_set)
+
+    rox_wps = well_pick_sets[well_pick_set]
+
+    rox_wps.delete_at([idx for idx, wp in enumerate(rox_wps) if wp.type == rox_wp_type])
+    return rox_wps
+
+
+def _get_writeable_well_pick_attributes(
+    rox: RoxUtils,
+    attribute_types: dict[str, str],
+    rox_wp_type: roxar.WellPickType,
+) -> dict[str, roxar.well_picks.WellPickAttribute]:
+    """
+    Function to retrive a dictionary of regular and user-defined
+    roxar WellPickAttribute's. Only writable attributes are
+    returned (i.e. not read_only). Attributes not present in the
+    project will be created as user-defined attributes.
+    """
+    attributes_with_value_constraints = [
+        "Structural model",
+        "Lock",
+        "Quality",
+        "Wellpick Symbol - Horizon",
+    ]
+    regular_attributes = {x.name: x for x in roxwp.WellPick.get_attributes(rox_wp_type)}
+    user_attributes = {
+        x.name: x
+        for x in rox.project.well_picks.user_attributes.get_subset(rox_wp_type)
+    }
+
+    rox_attributes = {}
+    for attr, dtype in attribute_types.items():
+        rox_dtype = getattr(roxar.WellPickAttributeType, dtype)
+
+        if attr in regular_attributes:
+            if (
+                regular_attributes[attr].read_only
+                or attr in attributes_with_value_constraints
+            ):
+                logger.debug("Skipping read-only attribute %s", attr)
+                continue
+            rox_attributes[attr] = regular_attributes[attr]
+
+        elif attr in user_attributes:
+            if user_attributes[attr].type != rox_dtype:
+                raise ValueError(
+                    f"Attribute type provided for '{attr}': {dtype}, is different "
+                    f" from existing type in project: {user_attributes[attr].type}.\n"
+                    "Either delete user defined attribute up-front, "
+                    "or rename to a new unique attribute name."
+                )
+            rox_attributes[attr] = user_attributes[attr]
+
+        else:
+            # roxar only supports creating string or float attributes
+            if dtype not in ["str", "float"]:
+                raise ValueError(
+                    "Only 'float' or 'str' are valid options for user-defined "
+                    f"attributes. Found type {dtype} for attribute '{attr}'."
+                )
+            logger.info("Creating user-defined attribute %s", attr)
+            rox_attributes[attr] = rox.project.well_picks.user_attributes.create(
+                name=attr,
+                pick_type=rox_wp_type,
+                data_type=rox_dtype,
+            )
+
+    return rox_attributes

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -75,7 +75,7 @@ def _roxar_importer(
     category: str,
     stype: str = "horizons",
     realisation: int = 0,
-    attributes: bool = False,
+    attributes: bool | list[str] = False,
 ):
     return _xyz_roxapi.import_xyz_roxapi(
         project, name, category, stype, realisation, attributes, False
@@ -193,7 +193,7 @@ def points_from_roxar(
     category: str,
     stype: str = "horizons",
     realisation: int = 0,
-    attributes: bool = False,
+    attributes: bool | list[str] = False,
 ):
     """Load a Points instance from Roxar RMS project.
 
@@ -206,13 +206,16 @@ def points_from_roxar(
     Args:
         project: Name of project (as folder) if outside RMS, or just use the
             magic `project` word if within RMS.
-        name: Name of points item
+        name (str): Name of points item, or name of well pick set if
+            well picks.
         category: For horizons/zones/faults: for example 'DL_depth'
             or use a folder notation on clipboard/general2d_data.
+            For well picks it is the well pick type: 'horizon' or 'fault'.
         stype: RMS folder type, 'horizons' (default), 'zones', 'clipboard',
-            'general2d_data'
+            'general2d_data', 'faults' or 'well_picks'
         realisation: Realisation number, default is 0
-        attributes: If True, attributes will be preserved (from RMS 11)
+        attributes (bool): Bool or list with attribute names to collect.
+            If True, all attributes are collected.
 
     Example::
 
@@ -631,7 +634,7 @@ class Points(XYZ):
         category: str,
         stype: str = "horizons",
         realisation: int = 0,
-        attributes: bool = False,
+        attributes: bool | list[str] = False,
     ):  # pragma: no cover
         """Load a points/polygons item from a Roxar RMS project (deprecated).
 
@@ -655,13 +658,16 @@ class Points(XYZ):
         Args:
             project (str or special): Name of project (as folder) if
                 outside RMS, og just use the magic project word if within RMS.
-            name (str): Name of polygons item
-            category (str): For horizons/zones/faults: for example 'DL_depth'
+            name (str): Name of points item, or name of well pick set if
+                well picks.
+            category: For horizons/zones/faults: for example 'DL_depth'
                 or use a folder notation on clipboard/general2d_data.
-
-            stype (str): RMS folder type, 'horizons' (default) or 'zones' etc!
+                For well picks it is the well pick type: 'horizon' or 'fault'.
+            stype: RMS folder type, 'horizons' (default), 'zones', 'clipboard',
+                'general2d_data', 'faults' or 'well_picks'
             realisation (int): Realisation number, default is 0
-            attributes (bool): If True, attributes will be preserved (from RMS 11)
+            attributes (bool): Bool or list with attribute names to collect.
+                If True, all attributes are collected.
 
         Returns:
             Object instance updated
@@ -899,15 +905,17 @@ class Points(XYZ):
         Args:
             project (str or special): Name of project (as folder) if
                 outside RMS, og just use the magic project word if within RMS.
-            name (str): Name of polygons item
+            name (str): Name of points item, or name of well pick set if
+                well picks.
             category (str): For horizons/zones/faults: for example 'DL_depth'
+                or use a folder notation on clipboard/general2d_data.
+                For well picks it is the well pick type: "horizon" or "fault".
             pfilter (dict): Filter on e.g. top name(s) with keys TopName
                 or ZoneName as {'TopName': ['Top1', 'Top2']}
-            stype (str): RMS folder type, 'horizons' (default), 'zones'
-                or 'faults' or 'clipboard', general2d_data (in prep: well picks)
+            stype: RMS folder type, 'horizons' (default), 'zones', 'clipboard',
+                'general2d_data', 'faults' or 'well_picks'
             realisation (int): Realisation number, default is 0
             attributes (bool): If True, attributes will be preserved (from RMS 11)
-
 
         Returns:
             Object instance updated
@@ -918,18 +926,6 @@ class Points(XYZ):
 
         .. versionadded:: 2.19 general2d_data support is added
         """
-
-        valid_stypes = [
-            "horizons",
-            "zones",
-            "faults",
-            "clipboard",
-            "general2d_data",
-            "horizon_picks",
-        ]
-
-        if stype.lower() not in valid_stypes:
-            raise ValueError(f"Invalid stype, only {valid_stypes} stypes is supported.")
 
         _xyz_roxapi.export_xyz_roxapi(
             self,

--- a/tests/test_xyz/test_xyz_roxapi_mock.py
+++ b/tests/test_xyz/test_xyz_roxapi_mock.py
@@ -45,7 +45,7 @@ def polygons_set():
 @pytest.fixture
 def mock_roxutils(mocker):
     mocker.patch("xtgeo.xyz._xyz_roxapi.RoxUtils")
-    mocker.patch("xtgeo.xyz._xyz_roxapi._check_category_etc", return_value=True)
+    mocker.patch("xtgeo.xyz._xyz_roxapi._check_presence_in_project", return_value=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
PR that adds the support of reading `well_picks` from RMS as `xtgeo.Points`, and writing them back. Closes #1108 

- Support well_picks of type "fault" and "horizon" - specified through the category argument
  - no support of "zone" picks yet, it requires a bit more work as it needs entry and exit values for MD/TVD/X/Y.
- Support reading well pick attributes. 
- Support creation of user defined attributes and modifying regular (non read-only) attribute values
- Create well pick set if not present in the project upon export

Also some refactoring of existing code was performed:
- Created separate functions for common functionality between roxar.well_picks and roxar.Points import/export. e.g applying pfilter or replacing undefined values in the dataframe
- Simplified and merged identical functions `get_roxitem()` and `get_roxxyz()` into one
- Restructured and renamed the two existing input validation checks

Other:
- Added new functionality - allow reading only a subset of point attributes by entering a list of attribute names.
- Fixed bug with entering category argument in `to_roxar()` and `from_roxar()` as list.
  - using `category=["My folder", "My subfolder"]` works now and is equal to  `category="My folder/My subfolder"` 
- Fixed bug where only columns after the three first were considered attributes. Resolves #1029
- Type hints added to most functions, however needs more work when we start type hinting the xyz module.


Example usage:
![Snag_5476882](https://github.com/equinor/xtgeo/assets/61694854/00494e95-8aae-43d3-8964-4e5ff0d72e69)

