### PR TITLE
TST: Fix tests broken with pytest 8.0

### DIFF
--- a/tests/test_cube/test_cube_deprecations.py
+++ b/tests/test_cube/test_cube_deprecations.py
@@ -19,7 +19,7 @@ def test_cube_from_file_warns(any_cube, any_cube_file):
 
 
 def test_cube_from_file_engine_warns(any_cube, any_cube_file):
-    with pytest.warns(DeprecationWarning, match="The engine parameter"):
+    with pytest.warns(DeprecationWarning):
         any_cube.from_file(any_cube_file, engine="segyio")
 
 

--- a/tests/test_grid3d/test_grid_ecl_grid.py
+++ b/tests/test_grid3d/test_grid_ecl_grid.py
@@ -154,7 +154,7 @@ def test_transform_map_relative_no_double(egrid):
 
 @given(xtgeo_compatible_egrids())
 def test_conversion_warning(egrid):
-    with pytest.warns(None) as warnlog:
+    with pytest.warns(UserWarning) as warnlog:
         egrid.xtgeo_coord(relative_to=xtgeo.GridRelative.MAP)
 
     axis_unit_warnings = [w for w in warnlog if "Axis units" in str(w.message)]


### PR DESCRIPTION
`pytest.warns(None)` was deprecated with pytest 8.0. Additionally I think pytest has an error with respect to catch the `test_cube_from_file_warns` `DeprecationWarning` and does a wrong instantiation of a DeprecationWarning to catch it. The message specificity was removed because if `from_file()` is deprecated then by definition so is any additional arguments that method takes.