### PR TITLE
TST: Set MPLBACKEND=Agg on test invocations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,6 @@ jobs:
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
 
-      # Windows sporadically fails on tkinter pyplots
-      - name: Set MPLBACKEND=Agg on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: echo "MPLBACKEND=Agg" >> $GITHUB_ENV
-
       - name: Run tests
         run: pytest -n 4 tests --disable-warnings --generate-plots
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 """Setup common stuff for pytests."""
+
 import os
 
 import pytest
@@ -63,6 +64,15 @@ def pytest_addoption(parser):
         action="store_true",
         default=False,
     )
+
+
+def pytest_configure(config):
+    # Set the Agg backend for all test runs. This should be removed once
+    # xtgeo.plot is removed. This is to ensure that CI runs do not fail
+    # on Windows and macOS.
+    import matplotlib as mpl
+
+    mpl.use("Agg")
 
 
 @pytest.fixture(name="generate_plot")


### PR DESCRIPTION
We do not need to use a gui method of plotting for test runs, and other backends may fail on CI.

The previous solution of setting the environment variable did not work: despite numerous other ways of setting this, Windows seems to ignore it and continues to use TkAgg over Agg, causing sporadic failures in CI.