### PR TITLE
Remove bare `xtgeo` imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,8 @@ select = [
     "RET",
     "RSE",
     "SIM",
+    "TCH",
+    "TID",
     "W",
 ]
 

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -80,12 +80,44 @@ _xprint("Import common... done")
 
 _xprint("Import various XTGeo modules...")
 
+from xtgeo.metadata.metadata import (
+    MetaDataCPGeometry,
+    MetaDataCPProperty,
+    MetaDataRegularCube,
+    MetaDataRegularSurface,
+    MetaDataWell,
+)
+
+_xprint("Import various XTGeo modules... metadata...")
+
+
 from xtgeo.roxutils import roxutils
 from xtgeo.roxutils.roxutils import RoxUtils
 
+from xtgeo.well import blocked_well, blocked_wells, well1, wells
+from xtgeo.well.blocked_well import (
+    BlockedWell,
+    blockedwell_from_file,
+    blockedwell_from_roxar,
+)
+from xtgeo.well.blocked_wells import (
+    BlockedWells,
+    blockedwells_from_files,
+    blockedwells_from_roxar,
+)
+from xtgeo.well.well1 import Well, well_from_file, well_from_roxar
+from xtgeo.well.wells import Wells, wells_from_files
+from xtgeo.xyz.points import (
+    points_from_file,
+    points_from_roxar,
+    points_from_surface,
+    points_from_wells,
+    points_from_wells_dfrac,
+)
+
 _xprint("Import various XTGeo modules... wells...")
 
-from xtgeo.grid3d import GridRelative, Units, grid, grid_properties, grid_property
+from xtgeo.grid3d._ecl_grid import GridRelative, Units
 from xtgeo.grid3d.grid import Grid
 from xtgeo.grid3d.grid_properties import (
     GridProperties,
@@ -118,16 +150,6 @@ from xtgeo.cube.cube1 import Cube
 
 _xprint("Import various XTGeo modules... cube...")
 
-from xtgeo.metadata.metadata import (
-    MetaDataCPGeometry,
-    MetaDataCPProperty,
-    MetaDataRegularCube,
-    MetaDataRegularSurface,
-    MetaDataWell,
-)
-
-_xprint("Import various XTGeo modules... metadata...")
-
 from xtgeo.xyz import points, polygons
 from xtgeo.xyz.points import Points
 from xtgeo.xyz.polygons import Polygons
@@ -143,26 +165,6 @@ from xtgeo.grid3d.grid import (
     grid_from_cube,
     grid_from_file,
     grid_from_roxar,
-)
-from xtgeo.well import blocked_well, blocked_wells, well1, wells
-from xtgeo.well.blocked_well import (
-    BlockedWell,
-    blockedwell_from_file,
-    blockedwell_from_roxar,
-)
-from xtgeo.well.blocked_wells import (
-    BlockedWells,
-    blockedwells_from_files,
-    blockedwells_from_roxar,
-)
-from xtgeo.well.well1 import Well, well_from_file, well_from_roxar
-from xtgeo.well.wells import Wells, wells_from_files
-from xtgeo.xyz.points import (
-    points_from_file,
-    points_from_roxar,
-    points_from_surface,
-    points_from_wells,
-    points_from_wells_dfrac,
 )
 from xtgeo.xyz.polygons import (
     polygons_from_file,

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -90,7 +90,6 @@ from xtgeo.metadata.metadata import (
 
 _xprint("Import various XTGeo modules... metadata...")
 
-
 from xtgeo.roxutils import roxutils
 from xtgeo.roxutils.roxutils import RoxUtils
 

--- a/src/xtgeo/common/__init__.py
+++ b/src/xtgeo/common/__init__.py
@@ -1,14 +1,10 @@
 """The XTGeo common package"""
 
-
-from xtgeo.common._xyz_enum import _AttrName, _AttrType, _XYZType
-from xtgeo.common.exceptions import WellNotFoundError
-from xtgeo.common.log import null_logger
-from xtgeo.common.sys import inherit_docstring
-
-# flake8: noqa
-from xtgeo.common.xtgeo_dialog import XTGDescription, XTGeoDialog, XTGShowProgress
-from xtgeo.xyz._xyz_data import _XYZData
+from ._xyz_enum import _AttrName, _AttrType, _XYZType
+from .exceptions import WellNotFoundError
+from .log import null_logger
+from .sys import inherit_docstring
+from .xtgeo_dialog import XTGDescription, XTGeoDialog, XTGShowProgress
 
 __all__ = [
     "inherit_docstring",
@@ -19,6 +15,5 @@ __all__ = [
     "XTGShowProgress",
     "_AttrName",
     "_AttrType",
-    "_XYZData",
     "_XYZType",
 ]

--- a/src/xtgeo/common/calc.py
+++ b/src/xtgeo/common/calc.py
@@ -7,8 +7,12 @@ from typing import Any, Literal
 
 import numpy as np
 
-from xtgeo import XTGeoCLibError, _cxtgeo
-from xtgeo.common import XTGeoDialog, _angles, null_logger
+from xtgeo import _cxtgeo
+from xtgeo._cxtgeo import XTGeoCLibError
+
+from . import _angles
+from .log import null_logger
+from .xtgeo_dialog import XTGeoDialog
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)

--- a/src/xtgeo/common/calc.py
+++ b/src/xtgeo/common/calc.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
@@ -13,6 +12,9 @@ from xtgeo._cxtgeo import XTGeoCLibError
 from . import _angles
 from .log import null_logger
 from .xtgeo_dialog import XTGeoDialog
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)

--- a/src/xtgeo/common/sys.py
+++ b/src/xtgeo/common/sys.py
@@ -14,8 +14,8 @@ import numpy as np
 from xtgeo import _cxtgeo
 from xtgeo.io._file import FileWrapper
 
-from . import null_logger
 from ._xyz_enum import _AttrType
+from .log import null_logger
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/src/xtgeo/common/sys.py
+++ b/src/xtgeo/common/sys.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import io
 import pathlib
-from collections.abc import Callable
 from types import BuiltinFunctionType
 from typing import TYPE_CHECKING, Literal
 
@@ -18,6 +17,8 @@ from ._xyz_enum import _AttrType
 from .log import null_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import numpy.typing as npt
     import pandas as pd
 

--- a/src/xtgeo/common/xtgeo_dialog.py
+++ b/src/xtgeo/common/xtgeo_dialog.py
@@ -47,8 +47,8 @@ import warnings
 from datetime import datetime as dtime
 from typing import Any, Literal
 
-import xtgeo
-from xtgeo.common.log import null_logger
+from .log import null_logger
+from .version import __version__
 
 DEBUG = 0
 MLS = 10000000.0
@@ -344,7 +344,7 @@ class XTGeoDialog:
 
         if variant == "clibinfo":
             return (
-                f"XTGeo version {xtgeo.__version__} (Python "
+                f"XTGeo version {__version__} (Python "
                 f"{platform.python_version()} on {platform.system()})"
             )
 
@@ -380,7 +380,7 @@ class XTGeoDialog:
         print(f"#{app.center(77)}#")
         print("#" * 79)
         nowtime = dtime.now().strftime("%Y-%m-%d %H:%M:%S")
-        ver = "Using XTGeo version " + xtgeo.__version__
+        ver = f"Using XTGeo version {__version__}"
         cur_version += f" @ {nowtime} on {platform.node()} by {getpass.getuser()}"
         print(f"#{ver.center(77)}#")
         print(f"#{cur_version.center(77)}#")

--- a/src/xtgeo/cube/__init__.py
+++ b/src/xtgeo/cube/__init__.py
@@ -1,3 +1,9 @@
 """The XTGeo cube package."""
 
-from xtgeo.cube.cube1 import Cube  # type: ignore # noqa
+from .cube1 import Cube, cube_from_file, cube_from_roxar
+
+__all__ = [
+    "Cube",
+    "cube_from_file",
+    "cube_from_roxar",
+]

--- a/src/xtgeo/cube/_cube_export.py
+++ b/src/xtgeo/cube/_cube_export.py
@@ -1,4 +1,5 @@
 """Export Cube data via SegyIO library or XTGeo CLIB."""
+
 import json
 import shutil
 import struct
@@ -6,8 +7,8 @@ import struct
 import numpy as np
 import segyio
 
-import xtgeo
-from xtgeo import XTGeoCLibError, _cxtgeo
+from xtgeo import _cxtgeo
+from xtgeo._cxtgeo import XTGeoCLibError
 from xtgeo.common import XTGeoDialog, null_logger
 
 logger = null_logger(__name__)
@@ -25,9 +26,6 @@ def export_segy(self, sfile, template=None, pristine=False, engine="xtgeo"):
             existing SEGY file.
         engine (str): Use 'xtgeo' or (later?) 'segyio'
     """
-    if not isinstance(self, xtgeo.cube.Cube):
-        raise ValueError("first argument is not a Cube instance")
-
     if engine == "segyio":
         _export_segy_segyio(self, sfile, template=template, pristine=pristine)
     else:

--- a/src/xtgeo/cube/_cube_import.py
+++ b/src/xtgeo/cube/_cube_import.py
@@ -33,6 +33,7 @@ import json
 from collections import defaultdict
 from copy import deepcopy
 from struct import unpack
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
@@ -44,8 +45,10 @@ import xtgeo.common.constants as const
 import xtgeo.common.sys as xsys
 from xtgeo import _cxtgeo
 from xtgeo.common import XTGeoDialog, null_logger
-from xtgeo.io._file import FileWrapper
 from xtgeo.metadata.metadata import MetaDataRegularCube
+
+if TYPE_CHECKING:
+    from xtgeo.io._file import FileWrapper
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)

--- a/src/xtgeo/cube/_cube_import.py
+++ b/src/xtgeo/cube/_cube_import.py
@@ -26,6 +26,7 @@ Indices is fastest along "J" (C order), and xlines and ilines spacing may vary (
 xline, 1 for iline in this example) but shall be constant per axis
 
 """
+
 from __future__ import annotations
 
 import json
@@ -38,12 +39,13 @@ import numpy as np
 import segyio
 from segyio import TraceField as TF
 
-import xtgeo
 import xtgeo.common.calc as xcalc
+import xtgeo.common.constants as const
 import xtgeo.common.sys as xsys
 from xtgeo import _cxtgeo
 from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.io._file import FileWrapper
+from xtgeo.metadata.metadata import MetaDataRegularCube
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
@@ -202,7 +204,7 @@ def _import_segy_incomplete_traces(segyfile: segyio.segy.SegyFile) -> dict:
     nrow = int(abs(xlines_case.min() - xlines_case.max()) / xspacing) + 1
     nlay = data.shape[1]
 
-    values = np.full((ncol, nrow, nlay), xtgeo.UNDEF, dtype=np.float32)
+    values = np.full((ncol, nrow, nlay), const.UNDEF, dtype=np.float32)
     traceidcodes = np.full((ncol, nrow), 2, dtype=np.int64)
 
     ilines_shifted = (ilines_case / ispacing).astype(np.int64)
@@ -600,7 +602,7 @@ def import_xtgregcube(mfile, values=True):
     meta = json.loads(jmeta, object_pairs_hook=dict)
     req = meta["_required_"]
 
-    reqattrs = xtgeo.MetaDataRegularCube.REQUIRED
+    reqattrs = MetaDataRegularCube.REQUIRED
 
     results = {myattr: req[myattr] for myattr in reqattrs}
 
@@ -608,7 +610,7 @@ def import_xtgregcube(mfile, values=True):
     # although we do not support initializing with any other value.
     # As xtgeo-format is only written/read by xtgeo as far as we know, this should
     # be unproblematic for now.
-    if results.pop("undef", None) != xtgeo.UNDEF:
+    if results.pop("undef", None) != const.UNDEF:
         raise ValueError(
             f"File {mfile.file} has non-standard undef, not supported by xtgeo"
         )

--- a/src/xtgeo/cube/_cube_roxapi.py
+++ b/src/xtgeo/cube/_cube_roxapi.py
@@ -16,8 +16,8 @@ Seems like self._rotation == roxar.orientation * -1 anyway @ reverse engineering
 
 import numpy as np
 
-from xtgeo import RoxUtils
 from xtgeo.common import XTGeoDialog, null_logger
+from xtgeo.roxutils import RoxUtils
 
 xtg = XTGeoDialog()
 

--- a/src/xtgeo/cube/_cube_utils.py
+++ b/src/xtgeo/cube/_cube_utils.py
@@ -4,11 +4,11 @@ import warnings
 
 import numpy as np
 
-import xtgeo.common.constants as const
 from xtgeo import _cxtgeo
 from xtgeo._cxtgeo import XTGeoCLibError
-from xtgeo.common import null_logger
 from xtgeo.common.calc import _swap_axes
+from xtgeo.common.constants import UNDEF_LIMIT
+from xtgeo.common.log import null_logger
 from xtgeo.xyz.polygons import Polygons
 
 logger = null_logger(__name__)
@@ -264,7 +264,7 @@ def get_randomline(
         option,
     )
 
-    values[values > const.UNDEF_LIMIT] = np.nan
+    values[values > UNDEF_LIMIT] = np.nan
     arr = values.reshape((xcoords.shape[0], nzsam)).T
 
     return (hcoords[0], hcoords[-1], zmin, zmax, arr)

--- a/src/xtgeo/cube/_cube_utils.py
+++ b/src/xtgeo/cube/_cube_utils.py
@@ -1,12 +1,15 @@
 """Cube utilities (basic low level)"""
+
 import warnings
 
 import numpy as np
 
-import xtgeo
-from xtgeo import XTGeoCLibError, _cxtgeo
+import xtgeo.common.constants as const
+from xtgeo import _cxtgeo
+from xtgeo._cxtgeo import XTGeoCLibError
 from xtgeo.common import null_logger
 from xtgeo.common.calc import _swap_axes
+from xtgeo.xyz.polygons import Polygons
 
 logger = null_logger(__name__)
 
@@ -205,7 +208,7 @@ def get_randomline(
 ):
     """Get a random line from a fence spesification"""
 
-    if isinstance(fencespec, xtgeo.Polygons):
+    if isinstance(fencespec, Polygons):
         logger.info("Estimate hincrement from Polygons instance...")
         fencespec = _get_randomline_fence(self, fencespec, hincrement, atleast, nextend)
         logger.info("Estimate hincrement from Polygons instance... DONE")
@@ -261,7 +264,7 @@ def get_randomline(
         option,
     )
 
-    values[values > xtgeo.UNDEF_LIMIT] = np.nan
+    values[values > const.UNDEF_LIMIT] = np.nan
     arr = values.reshape((xcoords.shape[0], nzsam)).T
 
     return (hcoords[0], hcoords[-1], zmin, zmax, arr)

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -13,11 +13,12 @@ from typing import TYPE_CHECKING, Any
 import deprecation
 import numpy as np
 
-import xtgeo.common.constants as const
-from xtgeo.common import XTGDescription, null_logger
+from xtgeo.common.constants import UNDEF
+from xtgeo.common.log import null_logger
 from xtgeo.common.sys import generic_hash
 from xtgeo.common.types import Dimensions
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGDescription
 from xtgeo.grid3d.grid import grid_from_cube
 from xtgeo.io._file import FileFormat, FileWrapper
 from xtgeo.metadata.metadata import MetaDataRegularCube
@@ -278,7 +279,7 @@ class Cube:
         else:
             self._traceidcodes = traceidcodes
         self._segyfile = segyfile
-        self.undef = const.UNDEF
+        self.undef = UNDEF
 
         self._metadata = MetaDataRegularCube()
         self._metadata.required = self

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -1,4 +1,5 @@
 """Module for a seismic (or whatever) cube."""
+
 from __future__ import annotations
 
 import functools
@@ -12,13 +13,17 @@ from typing import TYPE_CHECKING, Any
 import deprecation
 import numpy as np
 
-import xtgeo
+import xtgeo.common.constants as const
 from xtgeo.common import XTGDescription, null_logger
 from xtgeo.common.sys import generic_hash
 from xtgeo.common.types import Dimensions
 from xtgeo.common.version import __version__
-from xtgeo.cube import _cube_export, _cube_import, _cube_roxapi, _cube_utils
+from xtgeo.grid3d.grid import grid_from_cube
 from xtgeo.io._file import FileFormat, FileWrapper
+from xtgeo.metadata.metadata import MetaDataRegularCube
+from xtgeo.xyz.polygons import Polygons
+
+from . import _cube_export, _cube_import, _cube_roxapi, _cube_utils
 
 logger = null_logger(__name__)
 
@@ -273,9 +278,9 @@ class Cube:
         else:
             self._traceidcodes = traceidcodes
         self._segyfile = segyfile
-        self.undef = xtgeo.UNDEF
+        self.undef = const.UNDEF
 
-        self._metadata = xtgeo.MetaDataRegularCube()
+        self._metadata = MetaDataRegularCube()
         self._metadata.required = self
 
     def __repr__(self):
@@ -300,7 +305,7 @@ class Cube:
     def metadata(self, obj):
         # The current metadata object can be replaced. This is a bit dangerous so
         # further check must be done to validate. TODO.
-        if not isinstance(obj, xtgeo.MetaDataRegularCube):
+        if not isinstance(obj, MetaDataRegularCube):
             raise ValueError("Input obj not an instance of MetaDataRegularCube")
 
         self._metadata = obj  # checking is currently missing! TODO
@@ -814,7 +819,7 @@ class Cube:
               used to pregenerate `fencespec`
 
         """
-        if not isinstance(fencespec, (np.ndarray, xtgeo.Polygons)):
+        if not isinstance(fencespec, (np.ndarray, Polygons)):
             raise ValueError(
                 "fencespec must be a numpy or a Polygons() object. "
                 f"Current type is {type(fencespec)}"
@@ -994,7 +999,7 @@ class Cube:
         """
 
         if "grid" in target.lower():
-            _tmpgrd = xtgeo.grid_from_cube(self, propname=name)
+            _tmpgrd = grid_from_cube(self, propname=name)
             _tmpprop = _tmpgrd.props[0]
             _tmpprop.name = propname if propname else "seismic_attribute"
             _tmpgrd.to_roxar(project, name)

--- a/src/xtgeo/grid3d/__init__.py
+++ b/src/xtgeo/grid3d/__init__.py
@@ -1,14 +1,15 @@
-# flake8: noqa
 """The XTGeo grid3d package"""
-
-
-from xtgeo.common.exceptions import (
-    DateNotFoundError,
-    KeywordFoundNoDateError,
-    KeywordNotFoundError,
-)
 
 from ._ecl_grid import GridRelative, Units
 from .grid import Grid
 from .grid_properties import GridProperties, list_gridproperties
 from .grid_property import GridProperty
+
+__all__ = [
+    "GridRelative",
+    "Units",
+    "Grid",
+    "GridProperties",
+    "list_gridproperties",
+    "GridProperty",
+]

--- a/src/xtgeo/grid3d/_egrid.py
+++ b/src/xtgeo/grid3d/_egrid.py
@@ -48,14 +48,14 @@ GridHead(type_of_grid=<TypeOfGrid.COMPOSITE...
 >>> head.to_egrid().tolist() == grid_head_contents
 True
 """
+
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum, unique
 from itertools import chain
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import resfo
@@ -73,6 +73,9 @@ from ._ecl_grid import (
     Units,
 )
 from ._ecl_output_file import TypeOfGrid
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
 
 
 class EGridFileFormatError(ValueError):

--- a/src/xtgeo/grid3d/_grdecl_format.py
+++ b/src/xtgeo/grid3d/_grdecl_format.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from xtgeo.common import null_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from io import TextIOWrapper
 
     from xtgeo.common.types import FileLike

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -15,7 +15,6 @@ from xtgeo import _cxtgeo
 from xtgeo.common import null_logger
 from xtgeo.common.calc import find_flip
 from xtgeo.common.constants import UNDEF_INT, UNDEF_LIMIT
-from xtgeo.common.types import Dimensions
 from xtgeo.grid3d.grid_properties import GridProperties
 from xtgeo.xyz.polygons import Polygons
 
@@ -23,11 +22,13 @@ from . import _gridprop_lowlevel
 from ._grid3d_fence import _update_tmpvars
 from .grid_property import GridProperty
 
-logger = null_logger(__name__)
 if TYPE_CHECKING:
+    from xtgeo.common.types import Dimensions
     from xtgeo.grid3d import Grid
     from xtgeo.grid3d.types import METRIC
     from xtgeo.xyz.points import Points
+
+logger = null_logger(__name__)
 
 
 def create_box(

--- a/src/xtgeo/grid3d/_grid_roxapi.py
+++ b/src/xtgeo/grid3d/_grid_roxapi.py
@@ -1,7 +1,7 @@
 """Roxar API functions for XTGeo Grid Geometry."""
+
 from __future__ import annotations
 
-import contextlib
 import os
 import tempfile
 from typing import TYPE_CHECKING, Any, Literal
@@ -18,6 +18,8 @@ xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
+    import contextlib
+
     from xtgeo.grid3d.grid import Grid
 
     with contextlib.suppress(ImportError):

--- a/src/xtgeo/grid3d/_gridprop_import_xtgcpprop.py
+++ b/src/xtgeo/grid3d/_gridprop_import_xtgcpprop.py
@@ -1,8 +1,8 @@
 """GridProperty import function of xtgcpprop format."""
+
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -19,6 +19,8 @@ from xtgeo.metadata.metadata import MetaDataCPProperty
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from numpy.typing import DTypeLike
 
     from xtgeo.io._file import FileWrapper

--- a/src/xtgeo/grid3d/_roff_grid.py
+++ b/src/xtgeo/grid3d/_roff_grid.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import pathlib
 from collections import defaultdict
-from collections.abc import MutableMapping, Sequence
 from dataclasses import dataclass
 from typing import IO, TYPE_CHECKING, Any
 
@@ -12,6 +10,9 @@ import roffio
 from xtgeo import _cxtgeo
 
 if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import MutableMapping, Sequence
+
     from xtgeo.grid3d import Grid
 
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -1,11 +1,11 @@
 """Module/class for 3D grids (corner point geometry) with XTGeo."""
+
 from __future__ import annotations
 
 import functools
 import json
 import pathlib
 import warnings
-from collections.abc import Callable, Hashable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, NoReturn
 
 import deprecation
@@ -32,21 +32,24 @@ from . import (
     _grid_wellzone,
     _gridprop_lowlevel,
 )
-from ._ecl_grid import Units
 from ._grid3d import _Grid3D
-from .grid_properties import GridProperties, GridProperty
-
-xtg = xtgeo.common.XTGeoDialog()
-logger = null_logger(__name__)
+from .grid_properties import GridProperties
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Hashable, Sequence
+
     import pandas as pd
 
     from xtgeo import Polygons, Well
     from xtgeo.common.types import FileLike
-    from xtgeo.grid3d.types import METRIC
     from xtgeo.xyz.points import Points
 
+    from ._ecl_grid import Units
+    from .grid_property import GridProperty
+    from .types import METRIC
+
+xtg = xtgeo.common.XTGeoDialog()
+logger = null_logger(__name__)
 
 # --------------------------------------------------------------------------------------
 # Comment on "asmasked" vs "activeonly:

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -1,9 +1,9 @@
 """Module for Grid Properties."""
+
 from __future__ import annotations
 
 import hashlib
 import warnings
-from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any, List, Literal, Tuple, Union
 
 import deprecation
@@ -23,14 +23,17 @@ from ._gridprops_import_eclrun import (
     read_eclrun_properties,
 )
 from ._gridprops_import_roff import import_roff_gridproperties, read_roff_properties
-from .grid_property import GridProperty
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
     from xtgeo import Grid
     from xtgeo.common.types import FileLike
+
+    from .grid_property import GridProperty
 
 KeywordTuple = Tuple[str, str, int, int]
 KeywordDateTuple = Tuple[str, str, int, int, Union[str, int]]

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -5,7 +5,6 @@ import functools
 import hashlib
 import pathlib
 import warnings
-from collections.abc import Callable
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -40,6 +39,7 @@ xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from typing import Union
 
     import numpy.typing as npt
@@ -1114,8 +1114,9 @@ class GridProperty(_Grid3D):
         gridname: str,
         propertyname: str,
         realisation: int = 0,
-        casting: Literal["no", "equiv", "safe", "same_kind", "unsafe"]
-        | None = "unsafe",
+        casting: (
+            Literal["no", "equiv", "safe", "same_kind", "unsafe"] | None
+        ) = "unsafe",
     ) -> None:
         """
         Store a grid model property into a RMS project.

--- a/src/xtgeo/io/_file.py
+++ b/src/xtgeo/io/_file.py
@@ -15,9 +15,7 @@ from tempfile import mkstemp
 from typing import TYPE_CHECKING, Literal, Union
 
 import xtgeo._cxtgeo
-from xtgeo.common import null_logger
-
-logger = null_logger(__name__)
+from xtgeo.common.log import null_logger
 
 if TYPE_CHECKING:
     from xtgeo.common.types import FileLike
@@ -42,6 +40,7 @@ if TYPE_CHECKING:
         Wells,
     ]
 
+logger = null_logger(__name__)
 
 VALID_FILE_ALIASES = ["$fmu-v1", "$md5sum", "$random"]
 

--- a/src/xtgeo/io/_file.py
+++ b/src/xtgeo/io/_file.py
@@ -1,4 +1,5 @@
 """A FileWrapper class to wrap around files and streams representing files."""
+
 from __future__ import annotations
 
 import io
@@ -15,13 +16,11 @@ from typing import TYPE_CHECKING, Literal, Union
 
 import xtgeo._cxtgeo
 from xtgeo.common import null_logger
-from xtgeo.common.types import FileLike
 
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
-    import pathlib.Path
-
+    from xtgeo.common.types import FileLike
     from xtgeo.cube import Cube
     from xtgeo.grid3d import Grid, GridProperties, GridProperty
     from xtgeo.surface import RegularSurface, Surfaces

--- a/src/xtgeo/metadata/__init__.py
+++ b/src/xtgeo/metadata/__init__.py
@@ -1,4 +1,17 @@
-# flake8: noqa
 """XTGeo metadata package."""
 
-from xtgeo.metadata.metadata import MetaDataRegularCube, MetaDataRegularSurface
+from .metadata import (
+    MetaDataCPGeometry,
+    MetaDataCPProperty,
+    MetaDataRegularCube,
+    MetaDataRegularSurface,
+    MetaDataWell,
+)
+
+__all__ = [
+    "MetaDataRegularCube",
+    "MetaDataRegularSurface",
+    "MetaDataCPGeometry",
+    "MetaDataCPProperty",
+    "MetaDataWell",
+]

--- a/src/xtgeo/metadata/metadata.py
+++ b/src/xtgeo/metadata/metadata.py
@@ -10,8 +10,8 @@ The metadata works through the various datatypes in XTGeo. For example::
 
 """
 
-# from datetime import date
 import xtgeo
+import xtgeo.common.constants as const
 from xtgeo.common import null_logger
 
 logger = null_logger(__name__)
@@ -235,7 +235,7 @@ class MetaDataRegularSurface(MetaData):
         "yinc": 1.0,
         "yflip": 1,
         "rotation": 0.0,
-        "undef": xtgeo.UNDEF,
+        "undef": const.UNDEF,
     }
 
     def __init__(self):
@@ -282,7 +282,7 @@ class MetaDataRegularCube(MetaData):
         "yflip": 1,
         "zflip": 1,
         "rotation": 0.0,
-        "undef": xtgeo.UNDEF,
+        "undef": const.UNDEF,
     }
 
     def __init__(self):

--- a/src/xtgeo/metadata/metadata.py
+++ b/src/xtgeo/metadata/metadata.py
@@ -11,8 +11,8 @@ The metadata works through the various datatypes in XTGeo. For example::
 """
 
 import xtgeo
-import xtgeo.common.constants as const
-from xtgeo.common import null_logger
+from xtgeo.common.constants import UNDEF
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 
@@ -110,7 +110,7 @@ class _OptionalMetaData:
             raise ValueError("The description length must less or equal 64 letters.")
         invalids = r"/$<>[]:\&%"
         if set(invalids).intersection(newstr):
-            raise ValueError("The description constains invalid characters such as /.")
+            raise ValueError("The description contains invalid characters such as /.")
 
         self._description = newstr
 
@@ -235,7 +235,7 @@ class MetaDataRegularSurface(MetaData):
         "yinc": 1.0,
         "yflip": 1,
         "rotation": 0.0,
-        "undef": const.UNDEF,
+        "undef": UNDEF,
     }
 
     def __init__(self):
@@ -282,7 +282,7 @@ class MetaDataRegularCube(MetaData):
         "yflip": 1,
         "zflip": 1,
         "rotation": 0.0,
-        "undef": const.UNDEF,
+        "undef": UNDEF,
     }
 
     def __init__(self):

--- a/src/xtgeo/plot/__init__.py
+++ b/src/xtgeo/plot/__init__.py
@@ -1,11 +1,10 @@
 """The XTGeo plot package"""
-# flake8: noqa
 
 import warnings
 
-from xtgeo.plot.grid3d_slice import Grid3DSlice
-from xtgeo.plot.xsection import XSection
-from xtgeo.plot.xtmap import Map
+from .grid3d_slice import Grid3DSlice
+from .xsection import XSection
+from .xtmap import Map
 
 warnings.warn(
     "xtgeo.plot is deprecated and will be removed in xtgeo 4.0. "
@@ -13,3 +12,9 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+__all__ = [
+    "Grid3DSlice",
+    "XSection",
+    "Map",
+]

--- a/src/xtgeo/plot/_colortables.py
+++ b/src/xtgeo/plot/_colortables.py
@@ -3,7 +3,7 @@
 import os
 import random
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/plot/baseplot.py
+++ b/src/xtgeo/plot/baseplot.py
@@ -1,7 +1,9 @@
 """The baseplot module."""
+
 from packaging.version import parse as versionparse
 
-from xtgeo.common import XTGeoDialog, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 from . import _colortables as _ctable
 

--- a/src/xtgeo/plot/grid3d_slice.py
+++ b/src/xtgeo/plot/grid3d_slice.py
@@ -1,7 +1,8 @@
 """Module for 3D Grid slice plots, using matplotlib."""
 
-from xtgeo.common import null_logger
-from xtgeo.plot.baseplot import BasePlot
+from xtgeo.common.log import null_logger
+
+from .baseplot import BasePlot
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/plot/xsection.py
+++ b/src/xtgeo/plot/xsection.py
@@ -1,6 +1,5 @@
 """Module for fast XSection plots of wells/surfaces etc, using matplotlib."""
 
-
 import math
 import warnings
 
@@ -9,9 +8,10 @@ import numpy.ma as ma
 import pandas as pd
 from scipy.ndimage import gaussian_filter
 
-from xtgeo.common import XTGeoDialog, null_logger
-from xtgeo.well import Well
-from xtgeo.xyz import Polygons
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
+from xtgeo.well.well1 import Well
+from xtgeo.xyz.polygons import Polygons
 
 from .baseplot import BasePlot, _get_colormap
 

--- a/src/xtgeo/plot/xtmap.py
+++ b/src/xtgeo/plot/xtmap.py
@@ -3,7 +3,7 @@
 import numpy as np
 import numpy.ma as ma
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 from .baseplot import BasePlot
 

--- a/src/xtgeo/roxutils/__init__.py
+++ b/src/xtgeo/roxutils/__init__.py
@@ -1,5 +1,7 @@
-# flake8: noqa
 """XTGeo roxutils package"""
 
+from .roxutils import RoxUtils
 
-from xtgeo.roxutils.roxutils import RoxUtils
+__all__ = [
+    "RoxUtils",
+]

--- a/src/xtgeo/roxutils/_roxutils_etc.py
+++ b/src/xtgeo/roxutils/_roxutils_etc.py
@@ -1,10 +1,11 @@
 """Private module for etc functions"""
+
 import contextlib
 
 with contextlib.suppress(ImportError):
     import roxar
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/roxutils/roxutils.py
+++ b/src/xtgeo/roxutils/roxutils.py
@@ -1,16 +1,14 @@
 """Module for simplifying various operation in the Roxar python interface."""
 
-
 import contextlib
 
 from packaging.version import parse as versionparse
 
-# from pkg_resources import parse_version as pver (ALT)
-
 with contextlib.suppress(ImportError):
     import roxar
 
-from xtgeo.common import XTGeoDialog, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 from . import _roxutils_etc
 
@@ -19,7 +17,6 @@ logger = null_logger(__name__)
 
 
 class RoxUtils(object):
-
     """Class RoxUtils, for accessing project level methods::
 
      import xtgeo

--- a/src/xtgeo/surface/__init__.py
+++ b/src/xtgeo/surface/__init__.py
@@ -1,5 +1,18 @@
-# ruff: noqa: F401
 """XTGeo surface package"""
 
-from .regular_surface import RegularSurface
-from .surfaces import Surfaces
+from .regular_surface import (
+    RegularSurface,
+    surface_from_file,
+    surface_from_grid3d,
+    surface_from_roxar,
+)
+from .surfaces import Surfaces, surfaces_from_grid
+
+__all__ = [
+    "RegularSurface",
+    "surface_from_file",
+    "surface_from_roxar",
+    "surface_from_grid3d",
+    "Surfaces",
+    "surfaces_from_grid",
+]

--- a/src/xtgeo/surface/_regsurf_boundary.py
+++ b/src/xtgeo/surface/_regsurf_boundary.py
@@ -1,18 +1,19 @@
 import math
 
-import xtgeo
+from xtgeo.xyz.points import points_from_surface
+from xtgeo.xyz.polygons import Polygons
 
 
 def create_boundary(self, alpha_factor, is_convex, simplify):
     """Create boundary polygons for a surface."""
 
     # make into points
-    points = xtgeo.points_from_surface(self)
+    points = points_from_surface(self)
 
     # compute minimum alpha based on surface resolution
     alpha = math.ceil(math.sqrt(self.xinc**2 + self.yinc**2) / 2)
 
-    pol = xtgeo.Polygons.boundary_from_points(points, alpha_factor, alpha, is_convex)
+    pol = Polygons.boundary_from_points(points, alpha_factor, alpha, is_convex)
 
     if pol is None:
         raise RuntimeError("Could not create a valid Polygons instance for boundary.")

--- a/src/xtgeo/surface/_regsurf_cube.py
+++ b/src/xtgeo/surface/_regsurf_cube.py
@@ -1,11 +1,10 @@
 """Regular surface vs Cube"""
 
-
 import numpy as np
 
-import xtgeo
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.constants import UNDEF
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 
@@ -13,6 +12,7 @@ logger = null_logger(__name__)
 def slice_cube(
     self,
     cube,
+    scube,
     zsurf=None,
     sampling="nearest",
     mask=True,
@@ -35,6 +35,7 @@ def slice_cube(
         return _slice_cube_v2_resample(
             self,
             cube,
+            scube,
             zsurf=zsurf,
             sampling=sampling,
             mask=mask,
@@ -75,7 +76,7 @@ def _slice_cube_v1(
 
     if deadtraces:
         # set dead traces to cxtgeo UNDEF -> special treatment in the C code
-        olddead = cube.values_dead_traces(xtgeo.UNDEF)
+        olddead = cube.values_dead_traces(UNDEF)
 
     cubeval1d = np.ravel(cube.values, order="C")
 
@@ -145,7 +146,7 @@ def _slice_cube_v2(
 
     if deadtraces:
         # set dead traces to cxtgeo UNDEF -> special treatment in the C code
-        olddead = cube.values_dead_traces(xtgeo.UNDEF)
+        olddead = cube.values_dead_traces(UNDEF)
 
     optnearest = 1
     if sampling == "trilinear":
@@ -177,16 +178,13 @@ def _slice_cube_v2(
 
 
 def _slice_cube_v2_resample(
-    self, cube, zsurf=None, sampling="nearest", mask=True, deadtraces=True
+    self, cube, scube, zsurf=None, sampling="nearest", mask=True, deadtraces=True
 ):
     """Slicing with surfaces that not match the cube geometry, snapxy=False
 
     The idea here is to resample the surface to the cube, then afterwards
     do an inverse sampling
     """
-
-    scube = xtgeo.surface_from_cube(cube, 0)
-
     if self.compare_topology(scube, strict=False):
         return _slice_cube_v2(self, cube, zsurf, sampling, mask, deadtraces)
 

--- a/src/xtgeo/surface/_regsurf_cube_window.py
+++ b/src/xtgeo/surface/_regsurf_cube_window.py
@@ -1,10 +1,10 @@
 """Regular surface vs Cube, slice a window interval"""
 
-
 import numpy as np
 import numpy.ma as ma
 
-from xtgeo.common import XTGShowProgress, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGShowProgress
 
 from . import _regsurf_cube_window_v2 as cwv2, _regsurf_cube_window_v3 as cwv3
 
@@ -32,6 +32,7 @@ ALLATTRS = [
 def slice_cube_window(
     self,
     cube,
+    scube,
     zsurf=None,
     other=None,
     other_position="below",
@@ -71,6 +72,7 @@ def slice_cube_window(
         attrs = cwv2.slice_cube_window(
             self,
             cube,
+            scube,
             zsurf=zsurf,
             other=other,
             other_position=other_position,
@@ -88,6 +90,7 @@ def slice_cube_window(
         attrs = cwv3.slice_cube_window(
             self,
             cube,
+            scube,
             zsurf=zsurf,
             other=other,
             other_position=other_position,

--- a/src/xtgeo/surface/_regsurf_cube_window_v2.py
+++ b/src/xtgeo/surface/_regsurf_cube_window_v2.py
@@ -1,11 +1,10 @@
 """Regular surface vs Cube, slice a window interval v2"""
 
-
 import numpy as np
 
-import xtgeo
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.constants import UNDEF
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 
@@ -31,6 +30,7 @@ ALLATTRS = [
 def slice_cube_window(
     self,
     cube,
+    scube,
     zsurf=None,
     other=None,
     other_position="below",
@@ -48,6 +48,7 @@ def slice_cube_window(
         attrs = _slice_cube_window_resample(
             self,
             cube,
+            scube,
             zsurf,
             other,
             other_position,
@@ -112,7 +113,7 @@ def _slice_cube_window(
 
     olddead = None
     if deadtraces:
-        olddead = cube.values_dead_traces(xtgeo.UNDEF)
+        olddead = cube.values_dead_traces(UNDEF)
 
     optprogress = 0
     if showprogress:
@@ -242,6 +243,7 @@ def _attributes_betw_surfaces(
 def _slice_cube_window_resample(
     self,
     cube,
+    scube,
     zsurf,
     other,
     other_position,
@@ -257,8 +259,6 @@ def _slice_cube_window_resample(
     """Makes a resample from original surfaces first to fit cube topology"""
 
     logger.info("Attributes between surfaces, resampling version")
-
-    scube = xtgeo.surface_from_cube(cube, 0.0)
 
     scube.resample(self)
 

--- a/src/xtgeo/surface/_regsurf_export.py
+++ b/src/xtgeo/surface/_regsurf_export.py
@@ -1,4 +1,5 @@
 """Export RegularSurface data."""
+
 from __future__ import annotations
 
 import json
@@ -9,10 +10,9 @@ import h5py
 import hdf5plugin
 import numpy as np
 
-import xtgeo
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
-from xtgeo.common.constants import UNDEF_MAP_IRAPA, UNDEF_MAP_IRAPB
+from xtgeo.common.constants import UNDEF, UNDEF_MAP_IRAPA, UNDEF_MAP_IRAPB
+from xtgeo.common.log import null_logger
 
 if TYPE_CHECKING:
     from xtgeo.io._file import FileWrapper
@@ -90,7 +90,7 @@ def _export_irap_ascii_purepy(self, mfile):
 
 def _export_irap_ascii(self, mfile):
     """Export to Irap RMS ascii format using cxtgeo."""
-    vals = self.get_values1d(fill_value=xtgeo.UNDEF)
+    vals = self.get_values1d(fill_value=UNDEF)
 
     ier = _cxtgeo.surf_export_irap_ascii(
         mfile.get_cfhandle(),
@@ -247,7 +247,7 @@ def _export_ijxyz_ascii_cxtgeo(self: RegularSurface, mfile: FileWrapper) -> None
     Keep this for while since it was the original solution, and faster,
     but consider remove in e.g. 4.0."""
 
-    vals = self.get_values1d(fill_value=xtgeo.UNDEF)
+    vals = self.get_values1d(fill_value=UNDEF)
     ier = _cxtgeo.surf_export_ijxyz(
         mfile.get_cfhandle(),
         self._ncol,
@@ -349,7 +349,7 @@ def _export_zmap_ascii(self, mfile):
 
     yinc = scopy._yinc * scopy._yflip
 
-    vals = scopy.get_values1d(order="C", asmasked=False, fill_value=xtgeo.UNDEF)
+    vals = scopy.get_values1d(order="C", asmasked=False, fill_value=UNDEF)
 
     ier = _cxtgeo.surf_export_zmap_ascii(
         mfile.get_cfhandle(),

--- a/src/xtgeo/surface/_regsurf_grid3d.py
+++ b/src/xtgeo/surface/_regsurf_grid3d.py
@@ -1,12 +1,11 @@
 """Regular surface vs Grid3D"""
 
-
 import numpy as np
 import numpy.ma as ma
 
-import xtgeo
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.constants import UNDEF, UNDEF_LIMIT
+from xtgeo.common.log import null_logger
 from xtgeo.grid3d import _gridprop_lowlevel
 
 logger = null_logger(__name__)
@@ -92,9 +91,9 @@ def from_grid3d(grid, template=None, where="top", mode="depth", rfactor=1):
     # call C function to make a map
     val = args["values"]
     val = val.ravel()
-    val = ma.filled(val, fill_value=xtgeo.UNDEF)
+    val = ma.filled(val, fill_value=UNDEF)
 
-    svalues = val * 0.0 + xtgeo.UNDEF
+    svalues = val * 0.0 + UNDEF
     ivalues = svalues.copy()
     jvalues = svalues.copy()
 
@@ -121,9 +120,9 @@ def from_grid3d(grid, template=None, where="top", mode="depth", rfactor=1):
     )
 
     logger.info("Extracted surfaces from 3D grid...")
-    svalues = np.ma.masked_greater(svalues, xtgeo.UNDEF_LIMIT)
-    ivalues = np.ma.masked_greater(ivalues, xtgeo.UNDEF_LIMIT)
-    jvalues = np.ma.masked_greater(jvalues, xtgeo.UNDEF_LIMIT)
+    svalues = np.ma.masked_greater(svalues, UNDEF_LIMIT)
+    ivalues = np.ma.masked_greater(ivalues, UNDEF_LIMIT)
+    jvalues = np.ma.masked_greater(jvalues, UNDEF_LIMIT)
 
     if mode == "i":
         ivalues = ivalues.reshape((args["ncol"], args["nrow"]))

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -10,8 +10,8 @@ import numpy.ma as ma
 import scipy.interpolate
 import scipy.ndimage
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.constants import UNDEF, UNDEF_LIMIT
+from xtgeo.common.log import null_logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -101,7 +101,7 @@ def avgsum_from_3dprops_gridding(
     gnlay = xprop.shape[2]
 
     # avoid artifacts from inactive cells that slips through somehow...(?)
-    if dzprop.max() > xtgeo.UNDEF_LIMIT:
+    if dzprop.max() > UNDEF_LIMIT:
         raise RuntimeError("Bug: DZ with unphysical values present")
 
     trimbydz = False
@@ -286,8 +286,8 @@ def _zone_averaging(
         mpr = ma.dstack(newm)
         zpr.astype(np.int32)
 
-    xpr = ma.filled(xpr, fill_value=xtgeo.UNDEF)
-    ypr = ma.filled(ypr, fill_value=xtgeo.UNDEF)
+    xpr = ma.filled(xpr, fill_value=UNDEF)
+    ypr = ma.filled(ypr, fill_value=UNDEF)
     zpr = ma.filled(zpr, fill_value=0)
     dpr = ma.filled(dpr, fill_value=0.0)
 

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -1,8 +1,8 @@
 """Do gridding from 3D parameters"""
+
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -14,6 +14,8 @@ import xtgeo
 from xtgeo.common import null_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from xtgeo.surface import RegularSurface
 
 logger = null_logger(__name__)

--- a/src/xtgeo/surface/_regsurf_ijxyz_parser.py
+++ b/src/xtgeo/surface/_regsurf_ijxyz_parser.py
@@ -63,17 +63,22 @@ This seems to lack obvious patterns (mostly due to many undefied cells?). Hence 
 need to detect minimum spacing and min/max of both ilines and xlines, unless a template
 is applied.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 import numpy as np
 from numpy.ma import MaskedArray
 
-import xtgeo
 from xtgeo.common.calc import find_flip, xyori_from_ij
 from xtgeo.common.log import null_logger
+
+if TYPE_CHECKING:
+    from xtgeo.cube.cube1 import Cube
+
+    from .regular_surface import RegularSurface
 
 logger = null_logger(__name__)
 
@@ -96,7 +101,7 @@ class SurfaceIJXYZ:
     values_in: MaskedArray
     ilines_in: np.ndarray
     xlines_in: np.ndarray
-    template: Optional[xtgeo.RegularSurface | xtgeo.Cube] = None
+    template: Optional[RegularSurface | Cube] = None
 
     ncol: int = field(default=1, init=False)
     nrow: int = field(default=1, init=False)
@@ -168,7 +173,13 @@ class SurfaceIJXYZ:
     def _map_on_template(self) -> None:
         """An existing RegularSurface or Cube forms the geometrical template."""
         logger.debug("Parse ijxyz with template")
-        if not isinstance(self.template, (xtgeo.RegularSurface, xtgeo.Cube)):
+
+        # TODO: Remove these when moved to xtgeo.io
+        from xtgeo.cube.cube1 import Cube
+
+        from .regular_surface import RegularSurface
+
+        if not isinstance(self.template, (RegularSurface, Cube)):
             raise ValueError(
                 "The provided template is not of type RegularSurface or Cube"
             )

--- a/src/xtgeo/surface/_regsurf_import.py
+++ b/src/xtgeo/surface/_regsurf_import.py
@@ -10,13 +10,15 @@ import h5py
 import numpy as np
 import numpy.ma as ma
 
-import xtgeo
 import xtgeo.common.sys as xsys
 from xtgeo import _cxtgeo
-from xtgeo.common import XTGeoDialog, null_logger
-from xtgeo.common.constants import UNDEF_MAP_IRAPA, UNDEF_MAP_IRAPB
-from xtgeo.surface._regsurf_ijxyz_parser import parse_ijxyz
-from xtgeo.surface._zmap_parser import parse_zmap
+from xtgeo.common.constants import UNDEF, UNDEF_LIMIT, UNDEF_MAP_IRAPA, UNDEF_MAP_IRAPB
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
+from xtgeo.metadata.metadata import MetaDataRegularSurface
+
+from ._regsurf_ijxyz_parser import parse_ijxyz
+from ._zmap_parser import parse_zmap
 
 if TYPE_CHECKING:
     from xtgeo.cube.cube1 import Cube
@@ -148,7 +150,7 @@ def _import_irap_binary(mfile, values=True):
 
         val = np.reshape(val, (args["ncol"], args["nrow"]), order="C")
 
-        val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
+        val = ma.masked_greater(val, UNDEF_LIMIT)
 
         if np.isnan(val).any():
             logger.info("NaN values are found, will mask...")
@@ -233,7 +235,7 @@ def _import_irap_ascii(mfile):
 
     val = np.reshape(val, (ncol, nrow), order="C")
 
-    val = ma.masked_greater(val, xtgeo.UNDEF_LIMIT)
+    val = ma.masked_greater(val, UNDEF_LIMIT)
 
     if np.isnan(val).any():
         logger.info("NaN values are found, will mask...")
@@ -332,7 +334,7 @@ def import_petromod(mfile, **_):
         cfhandle, 1, undef, args["ncol"], args["nrow"], args["ncol"] * args["nrow"]
     )
 
-    values = np.ma.masked_greater(values, xtgeo.UNDEF_LIMIT)
+    values = np.ma.masked_greater(values, UNDEF_LIMIT)
 
     args["values"] = values.reshape(args["ncol"], args["nrow"])
 
@@ -405,7 +407,7 @@ def import_xtg(mfile, values=True, **kwargs):
     meta = json.loads(jmeta, object_pairs_hook=dict)
     req = meta["_required_"]
 
-    reqattrs = xtgeo.MetaDataRegularSurface.REQUIRED
+    reqattrs = MetaDataRegularSurface.REQUIRED
 
     args = {}
     for myattr in reqattrs:
@@ -413,7 +415,7 @@ def import_xtg(mfile, values=True, **kwargs):
 
     if values:
         args["values"] = np.ma.masked_equal(
-            vals.reshape(args["ncol"], args["nrow"]), xtgeo.UNDEF
+            vals.reshape(args["ncol"], args["nrow"]), UNDEF
         )
 
     return args
@@ -421,7 +423,7 @@ def import_xtg(mfile, values=True, **kwargs):
 
 def import_hdf5_regsurf(mfile, values=True, **_):
     """Importing h5/hdf5 storage."""
-    reqattrs = xtgeo.MetaDataRegularSurface.REQUIRED
+    reqattrs = MetaDataRegularSurface.REQUIRED
 
     invalues = None
     with h5py.File(mfile.name, "r") as h5h:
@@ -446,7 +448,7 @@ def import_hdf5_regsurf(mfile, values=True, **_):
 
     if values:
         args["values"] = np.ma.masked_equal(
-            invalues.reshape(args["ncol"], args["nrow"]), xtgeo.UNDEF
+            invalues.reshape(args["ncol"], args["nrow"]), UNDEF
         )
 
     return args

--- a/src/xtgeo/surface/_regsurf_import.py
+++ b/src/xtgeo/surface/_regsurf_import.py
@@ -1,4 +1,5 @@
 """Import RegularSurface data."""
+
 from __future__ import annotations
 
 import json
@@ -14,12 +15,12 @@ import xtgeo.common.sys as xsys
 from xtgeo import _cxtgeo
 from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.common.constants import UNDEF_MAP_IRAPA, UNDEF_MAP_IRAPB
-from xtgeo.io._file import FileWrapper
 from xtgeo.surface._regsurf_ijxyz_parser import parse_ijxyz
 from xtgeo.surface._zmap_parser import parse_zmap
 
 if TYPE_CHECKING:
     from xtgeo.cube.cube1 import Cube
+    from xtgeo.io._file import FileWrapper
     from xtgeo.surface.regular_surface import RegularSurface
 
 xtg = XTGeoDialog()

--- a/src/xtgeo/surface/_regsurf_lowlevel.py
+++ b/src/xtgeo/surface/_regsurf_lowlevel.py
@@ -1,7 +1,7 @@
 """RegularSurface utilities (low level)"""
 
 from xtgeo import _cxtgeo
-from xtgeo.common import XTGeoDialog
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 xtg = XTGeoDialog()
 

--- a/src/xtgeo/surface/_regsurf_roxapi.py
+++ b/src/xtgeo/surface/_regsurf_roxapi.py
@@ -5,8 +5,8 @@ import tempfile
 
 import numpy as np
 
-from xtgeo import RoxUtils
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.roxutils import RoxUtils
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/surface/_regsurf_utils.py
+++ b/src/xtgeo/surface/_regsurf_utils.py
@@ -1,11 +1,10 @@
 """RegularSurface utilities"""
 
-
 import numpy as np
 
-import xtgeo
-from xtgeo.common import null_logger
 from xtgeo.common.calc import _swap_axes
+from xtgeo.common.constants import UNDEF
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 
@@ -15,7 +14,7 @@ def swapaxes(self):
     self._rotation, self._yflip, swapped_values = _swap_axes(
         self._rotation,
         self._yflip,
-        values=self.values.filled(xtgeo.UNDEF),
+        values=self.values.filled(UNDEF),
     )
     self._ncol, self._nrow = self._nrow, self._ncol
     self._xinc, self._yinc = self._yinc, self._xinc

--- a/src/xtgeo/surface/_surfs_import.py
+++ b/src/xtgeo/surface/_surfs_import.py
@@ -1,7 +1,8 @@
 """Import multiple surfaces"""
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
+
+from .regular_surface import surface_from_grid3d
 
 logger = null_logger(__name__)
 
@@ -33,9 +34,7 @@ def from_grid3d(grid, subgrids, rfactor):
     # next extract these layers
     layerstack = []
     for inum, lay in enumerate(layers):
-        layer = xtgeo.surface_from_grid3d(
-            grid, template=None, where=lay, rfactor=rfactor
-        )
+        layer = surface_from_grid3d(grid, template=None, where=lay, rfactor=rfactor)
         layer.name = names[inum]
         layerstack.append(layer)
 

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -20,6 +20,7 @@ or::
  mysurf = xtgeo.surface_from_roxar('some_rms_project', 'TopX', 'DepthSurface')
 
 """
+
 # --------------------------------------------------------------------------------------
 # Comment on 'asmasked' vs 'activeonly:
 # 'asmasked'=True will return a np.ma array, with some fill_value if
@@ -35,14 +36,12 @@ or::
 from __future__ import annotations
 
 import functools
-import io
 import math
 import numbers
-import pathlib
 import warnings
 from copy import deepcopy
 from types import FunctionType
-from typing import Dict, List, Literal, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Type, Union
 
 import deprecation
 import numpy as np
@@ -69,6 +68,11 @@ from . import (
     _regsurf_roxapi,
     _regsurf_utils,
 )
+
+if TYPE_CHECKING:
+    import io
+    import pathlib
+
 
 xtg = xtgeo.common.XTGeoDialog()
 logger = null_logger(__name__)

--- a/src/xtgeo/surface/surfaces.py
+++ b/src/xtgeo/surface/surfaces.py
@@ -8,13 +8,14 @@ from typing import Literal
 import deprecation
 import numpy as np
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGDescription, XTGeoDialog
 
 from . import _surfs_import
+from .regular_surface import RegularSurface, surface_from_file
 
-xtg = xtgeo.common.XTGeoDialog()
+xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 
@@ -46,7 +47,7 @@ class Surfaces:
 
     def __init__(
         self,
-        surfaces: list[xtgeo.RegularSurface] | None = None,
+        surfaces: list[RegularSurface] | None = None,
         subtype: Literal["tops", "isochores"] | None = None,
         order: Literal["same", "stratigraphic"] | None = None,
     ):
@@ -67,7 +68,7 @@ class Surfaces:
             raise ValueError("Input not a list")
 
         for elem in slist:
-            if not isinstance(elem, xtgeo.RegularSurface):
+            if not isinstance(elem, RegularSurface):
                 raise ValueError("Element in list not a valid type of Surface")
 
         self._surfaces = slist
@@ -76,11 +77,11 @@ class Surfaces:
         """Append surfaces from either a list of RegularSurface objects,
         a list of files, or a mix."""
         for item in slist:
-            if isinstance(item, xtgeo.RegularSurface):
+            if isinstance(item, RegularSurface):
                 self.surfaces.append(item)
             else:
                 try:
-                    sobj = xtgeo.surface_from_file(item, fformat="guess")
+                    sobj = surface_from_file(item, fformat="guess")
                     self.surfaces.append(sobj)
                 except OSError:
                     xtg.warnuser(f"Cannot read as file, skip: {item}")
@@ -88,7 +89,7 @@ class Surfaces:
     def describe(self, flush=True):
         """Describe an instance by printing to stdout"""
 
-        dsc = xtgeo.common.XTGDescription()
+        dsc = XTGDescription()
         dsc.title(f"Description of {self.__class__.__name__} instance")
         dsc.txt("Object ID", id(self))
 

--- a/src/xtgeo/well/__init__.py
+++ b/src/xtgeo/well/__init__.py
@@ -1,7 +1,24 @@
-# ruff: noqa: F401
 """The XTGeo well package"""
 
-from .blocked_well import BlockedWell
-from .blocked_wells import BlockedWells
-from .well1 import Well
-from .wells import Wells
+from .blocked_well import BlockedWell, blockedwell_from_file, blockedwell_from_roxar
+from .blocked_wells import (
+    BlockedWells,
+    blockedwells_from_files,
+    blockedwells_from_roxar,
+)
+from .well1 import Well, well_from_file, well_from_roxar
+from .wells import Wells, wells_from_files
+
+__all__ = [
+    "BlockedWell",
+    "blockedwell_from_file",
+    "blockedwell_from_roxar",
+    "BlockedWells",
+    "blockedwells_from_files",
+    "blockedwells_from_roxar",
+    "Well",
+    "well_from_file",
+    "well_from_roxar",
+    "Wells",
+    "wells_from_files",
+]

--- a/src/xtgeo/well/_blockedwell_roxapi.py
+++ b/src/xtgeo/well/_blockedwell_roxapi.py
@@ -4,10 +4,10 @@ import numpy as np
 import numpy.ma as npma
 import pandas as pd
 
-from xtgeo.common import null_logger
 from xtgeo.common._xyz_enum import _AttrName, _AttrType
 from xtgeo.common.constants import INT_MIN
 from xtgeo.common.exceptions import WellNotFoundError
+from xtgeo.common.log import null_logger
 from xtgeo.roxutils import RoxUtils
 
 try:

--- a/src/xtgeo/well/_blockedwells_roxapi.py
+++ b/src/xtgeo/well/_blockedwells_roxapi.py
@@ -1,6 +1,7 @@
 """Well input and output, private module for ROXAPI"""
 
-from xtgeo.common import XTGeoDialog, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 from xtgeo.roxutils import RoxUtils
 
 from .blocked_well import blockedwell_from_roxar

--- a/src/xtgeo/well/_blockedwells_roxapi.py
+++ b/src/xtgeo/well/_blockedwells_roxapi.py
@@ -1,6 +1,5 @@
 """Well input and output, private module for ROXAPI"""
 
-
 from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.roxutils import RoxUtils
 

--- a/src/xtgeo/well/_well_aux.py
+++ b/src/xtgeo/well/_well_aux.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import functools
 import warnings
-from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
@@ -18,6 +18,9 @@ from xtgeo.common._xyz_enum import _AttrName
 from xtgeo.io._file import FileFormat, FileWrapper
 
 from . import _well_io
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/well/_well_aux.py
+++ b/src/xtgeo/well/_well_aux.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from xtgeo.common import null_logger
 from xtgeo.common._xyz_enum import _AttrName
+from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileFormat, FileWrapper
 
 from . import _well_io

--- a/src/xtgeo/well/_well_io.py
+++ b/src/xtgeo/well/_well_io.py
@@ -6,8 +6,8 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 
-from xtgeo.common import null_logger
 from xtgeo.common._xyz_enum import _AttrName, _AttrType
+from xtgeo.common.log import null_logger
 from xtgeo.metadata.metadata import MetaDataWell
 
 logger = null_logger(__name__)

--- a/src/xtgeo/well/_well_io.py
+++ b/src/xtgeo/well/_well_io.py
@@ -1,13 +1,14 @@
 """Well input and ouput, private module"""
+
 import json
 from copy import deepcopy
 
 import numpy as np
 import pandas as pd
 
-import xtgeo
 from xtgeo.common import null_logger
 from xtgeo.common._xyz_enum import _AttrName, _AttrType
+from xtgeo.metadata.metadata import MetaDataWell
 
 logger = null_logger(__name__)
 
@@ -301,7 +302,7 @@ def import_wlogs(wlogs: dict):
 def import_hdf5_well(wfile, **kwargs):
     """Load from HDF5 format."""
     logger.debug("The kwargs may be unused: %s", kwargs)
-    reqattrs = xtgeo.MetaDataWell.REQUIRED
+    reqattrs = MetaDataWell.REQUIRED
 
     with pd.HDFStore(wfile.file, "r") as store:
         data = store.get("Well")

--- a/src/xtgeo/well/_well_oper.py
+++ b/src/xtgeo/well/_well_oper.py
@@ -6,8 +6,9 @@ import numpy as np
 import pandas as pd
 
 from xtgeo import _cxtgeo
-from xtgeo.common import constants as const, null_logger
 from xtgeo.common._xyz_enum import _AttrType
+from xtgeo.common.constants import UNDEF_INT, UNDEF_INT_LIMIT
+from xtgeo.common.log import null_logger
 from xtgeo.common.sys import _get_carray
 from xtgeo.xyz.points import Points
 
@@ -122,7 +123,7 @@ def make_zone_qual_log(self, zqname):
         else:
             prev_ = seq[ind - 1]
             next_ = seq[ind + 1]
-            if prev_ > const.UNDEF_INT_LIMIT or next_ > const.UNDEF_INT_LIMIT:
+            if prev_ > UNDEF_INT_LIMIT or next_ > UNDEF_INT_LIMIT:
                 code.append(9)
             elif next_ > iseq > prev_:
                 code.append(1)
@@ -357,32 +358,32 @@ def report_zonation_holes(self, threshold=5):
     xvv = self._wdata.data[self.xname].values
     yvv = self._wdata.data[self.yname].values
     zvv = self._wdata.data[self.zname].values
-    zlog[np.isnan(zlog)] = const.UNDEF_INT
+    zlog[np.isnan(zlog)] = UNDEF_INT
 
     ncv = 0
     first = True
     hole = False
     for ind, zone in np.ndenumerate(zlog):
         ino = ind[0]
-        if zone > const.UNDEF_INT_LIMIT and first:
+        if zone > UNDEF_INT_LIMIT and first:
             continue
 
-        if zone < const.UNDEF_INT_LIMIT and first:
+        if zone < UNDEF_INT_LIMIT and first:
             first = False
             continue
 
-        if zone > const.UNDEF_INT_LIMIT:
+        if zone > UNDEF_INT_LIMIT:
             ncv += 1
             hole = True
 
-        if zone > const.UNDEF_INT_LIMIT and ncv > threshold:
+        if zone > UNDEF_INT_LIMIT and ncv > threshold:
             logger.debug("Restart first (bigger hole)")
             hole = False
             first = True
             ncv = 0
             continue
 
-        if hole and zone < const.UNDEF_INT_LIMIT and ncv <= threshold:
+        if hole and zone < UNDEF_INT_LIMIT and ncv <= threshold:
             # here we have a hole that fits criteria
             if mdlog is not None:
                 entry = (
@@ -403,7 +404,7 @@ def report_zonation_holes(self, threshold=5):
             hole = False
             ncv = 0
 
-        if hole and zone < const.UNDEF_INT_LIMIT and ncv > threshold:
+        if hole and zone < UNDEF_INT_LIMIT and ncv > threshold:
             hole = False
             ncv = 0
 
@@ -531,11 +532,11 @@ def _get_bseries_by_distance(depth, inseries, distance):
 
     bseries = pd.Series(np.zeros(inseries.values.size), dtype="int32").values
     try:
-        inseries = np.nan_to_num(inseries.values, nan=const.UNDEF_INT).astype("int32")
+        inseries = np.nan_to_num(inseries.values, nan=UNDEF_INT).astype("int32")
     except TypeError:
         # for older numpy version
         inseries = inseries.values
-        inseries[np.isnan(inseries)] = const.UNDEF_INT
+        inseries[np.isnan(inseries)] = UNDEF_INT
         inseries = inseries.astype("int32")
 
     res = _cxtgeo.well_mask_shoulder(

--- a/src/xtgeo/well/_well_roxapi.py
+++ b/src/xtgeo/well/_well_roxapi.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
 import numpy.ma as npma
 import pandas as pd
 
-import xtgeo
 from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.common._xyz_enum import _AttrName, _AttrType
 from xtgeo.common.constants import UNDEF_INT_LIMIT, UNDEF_LIMIT
 from xtgeo.roxutils import RoxUtils
+
+if TYPE_CHECKING:
+    from .well1 import Well
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
@@ -153,7 +155,7 @@ def _get_roxlog(wlogtypes, wlogrecords, roxlrun, lname):  # pragma: no cover
 
 
 def export_well_roxapi(
-    self: xtgeo.Well,
+    self: Well,
     project,
     wname,
     lognames: str | list[str] = "all",
@@ -228,7 +230,7 @@ def _store_log_in_roxapi(self, lrun: Any, logname: str) -> None:
 
 
 def _roxapi_update_well(
-    self: xtgeo.Well,
+    self: Well,
     rox: Any,
     wname: str,
     lognames: str | list[str],

--- a/src/xtgeo/well/_wellmarkers.py
+++ b/src/xtgeo/well/_wellmarkers.py
@@ -3,9 +3,15 @@
 import numpy as np
 import pandas as pd
 
-import xtgeo.common.constants as const
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.constants import (
+    UNDEF,
+    UNDEF_DISC,
+    UNDEF_INT,
+    UNDEF_INT_LIMIT,
+    UNDEF_LIMIT,
+)
+from xtgeo.common.log import null_logger
 from xtgeo.xyz.points import Points
 
 logger = null_logger(__name__)
@@ -27,7 +33,7 @@ def get_zonation_points(self, tops, incl_limit, top_prefix, zonelist, use_undef)
         if use_undef:
             dataframe.dropna(subset=[scopy.zonelogname], inplace=True)
         zlog = dataframe[scopy.zonelogname].values
-        zlog[np.isnan(zlog)] = const.UNDEF_DISC
+        zlog[np.isnan(zlog)] = UNDEF_DISC
         zlog = np.rint(zlog).astype(int)
     else:
         return None
@@ -139,8 +145,8 @@ def _extract_ztops(
             f" was {usezonerange}"
         )
 
-    iundef = const.UNDEF_INT
-    iundeflimit = const.UNDEF_INT_LIMIT
+    iundef = UNDEF_INT
+    iundeflimit = UNDEF_INT_LIMIT
     pzone = iundef
 
     if use_undef:
@@ -382,7 +388,7 @@ def get_fraction_per_zone(
             if dseries.size < count_limit:  # interval too short for fraction
                 logger.debug("Skipped due to too few values %s", dseries.size)
                 continue
-            if dseries.max() > const.UNDEF_INT_LIMIT:
+            if dseries.max() > UNDEF_INT_LIMIT:
                 logger.debug("Skipped due to too missing/undef value(s)")
                 continue
 
@@ -422,7 +428,7 @@ def get_surface_picks(self, surf):
     if self.mdlogname:
         mcor = dataframe[self.mdlogname].values
     else:
-        mcor = np.zeros(xcor.size, dtype=np.float64) + const.UNDEF
+        mcor = np.zeros(xcor.size, dtype=np.float64) + UNDEF
 
     nval, xres, yres, zres, mres, dres = _cxtgeo.well_surf_picks(
         xcor,
@@ -448,7 +454,7 @@ def get_surface_picks(self, surf):
     if nval > 0:
         poi = Points()
 
-        mres[mres > const.UNDEF_LIMIT] = np.nan
+        mres[mres > UNDEF_LIMIT] = np.nan
 
         res = {}
         res[poi.xname] = xres[:nval]

--- a/src/xtgeo/well/_wellmarkers.py
+++ b/src/xtgeo/well/_wellmarkers.py
@@ -1,13 +1,12 @@
 """Well marker data; private module"""
 
-
 import numpy as np
 import pandas as pd
 
-import xtgeo
 import xtgeo.common.constants as const
 from xtgeo import _cxtgeo
 from xtgeo.common import null_logger
+from xtgeo.xyz.points import Points
 
 logger = null_logger(__name__)
 
@@ -423,7 +422,7 @@ def get_surface_picks(self, surf):
     if self.mdlogname:
         mcor = dataframe[self.mdlogname].values
     else:
-        mcor = np.zeros(xcor.size, dtype=np.float64) + xtgeo.UNDEF
+        mcor = np.zeros(xcor.size, dtype=np.float64) + const.UNDEF
 
     nval, xres, yres, zres, mres, dres = _cxtgeo.well_surf_picks(
         xcor,
@@ -447,9 +446,9 @@ def get_surface_picks(self, surf):
     )
 
     if nval > 0:
-        poi = xtgeo.Points()
+        poi = Points()
 
-        mres[mres > xtgeo.UNDEF_LIMIT] = np.nan
+        mres[mres > const.UNDEF_LIMIT] = np.nan
 
         res = {}
         res[poi.xname] = xres[:nval]

--- a/src/xtgeo/well/_wells_utils.py
+++ b/src/xtgeo/well/_wells_utils.py
@@ -1,13 +1,12 @@
 """Utilities for Wells class"""
 
-
 import logging
 
 import numpy as np
 import pandas as pd
 import shapely.geometry as sg
 
-from xtgeo.common import XTGeoDialog, XTGShowProgress
+from xtgeo.common.xtgeo_dialog import XTGeoDialog, XTGShowProgress
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/src/xtgeo/well/blocked_well.py
+++ b/src/xtgeo/well/blocked_well.py
@@ -1,11 +1,10 @@
 """XTGeo blockedwell module"""
 
-
 import deprecation
 import pandas as pd
 
-from xtgeo.common import null_logger
 from xtgeo.common._xyz_enum import _AttrName
+from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
 
 from . import _blockedwell_roxapi

--- a/src/xtgeo/well/blocked_wells.py
+++ b/src/xtgeo/well/blocked_wells.py
@@ -1,18 +1,16 @@
 """BlockedWells module, (collection of BlockedWell objects)"""
 
-# ======================================================================================
-
-
 import deprecation
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 from . import _blockedwells_roxapi
+from .blocked_well import blockedwell_from_file
 from .wells import Wells
 
-xtg = xtgeo.common.XTGeoDialog()
+xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 
@@ -43,7 +41,7 @@ def blockedwells_from_files(
     """
     return BlockedWells(
         [
-            xtgeo.blockedwell_from_file(
+            blockedwell_from_file(
                 wfile,
                 fformat=fformat,
                 mdlogname=mdlogname,
@@ -141,7 +139,7 @@ class BlockedWells(Wells):
         # file checks are done within the Well() class
         for wfile in filelist:
             try:
-                wll = xtgeo.blockedwell_from_file(
+                wll = blockedwell_from_file(
                     wfile,
                     fformat=fformat,
                     mdlogname=mdlogname,

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import io
 import warnings
 from copy import deepcopy
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import deprecation
 import numpy as np
@@ -13,7 +12,7 @@ import pandas as pd
 
 import xtgeo.common.constants as const
 from xtgeo import _cxtgeo
-from xtgeo.commn._xyz_enum import _AttrType
+from xtgeo.common._xyz_enum import _AttrType
 from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
 from xtgeo.common.xtgeo_dialog import XTGDescription
@@ -23,6 +22,10 @@ from xtgeo.xyz import _xyz_data
 from xtgeo.xyz.polygons import Polygons
 
 from . import _well_aux, _well_io, _well_oper, _well_roxapi, _wellmarkers
+
+if TYPE_CHECKING:
+    import io
+    from pathlib import Path
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -10,9 +10,9 @@ import deprecation
 import numpy as np
 import pandas as pd
 
-import xtgeo.common.constants as const
 from xtgeo import _cxtgeo
 from xtgeo.common._xyz_enum import _AttrType
+from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_LIMIT
 from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
 from xtgeo.common.xtgeo_dialog import XTGDescription
@@ -990,9 +990,7 @@ class Well:
         """
         return self._wdata.get_dataframe(copy=copy)
 
-    def get_filled_dataframe(
-        self, fill_value=const.UNDEF, fill_value_int=const.UNDEF_INT
-    ):
+    def get_filled_dataframe(self, fill_value=UNDEF, fill_value_int=UNDEF_INT):
         """Fill the Nan's in the dataframe with real UNDEF values.
 
         This module returns a copy of the dataframe in the object; it
@@ -1095,7 +1093,7 @@ class Well:
             raise RuntimeError("Unexpected error")
 
         dfr = self.get_dataframe()
-        dfr = dfr[dfr[self.xname] < const.UNDEF_LIMIT]
+        dfr = dfr[dfr[self.xname] < UNDEF_LIMIT]
         self.set_dataframe(dfr)
 
     def may_overlap(self, other):

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -11,13 +11,16 @@ import deprecation
 import numpy as np
 import pandas as pd
 
-import xtgeo
 import xtgeo.common.constants as const
-from xtgeo import _cxtgeo  # type: ignore
-from xtgeo.common import _AttrType, null_logger
+from xtgeo import _cxtgeo
+from xtgeo.commn._xyz_enum import _AttrType
+from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGDescription
 from xtgeo.io._file import FileWrapper
-from xtgeo.xyz import _xyz_data  # type: ignore[attr-defined]
+from xtgeo.metadata.metadata import MetaDataWell
+from xtgeo.xyz import _xyz_data
+from xtgeo.xyz.polygons import Polygons
 
 from . import _well_aux, _well_io, _well_oper, _well_roxapi, _wellmarkers
 
@@ -78,7 +81,7 @@ def well_from_roxar(
     lognames_strict: bool | None = False,
     inclmd: bool | None = False,
     inclsurvey: bool | None = False,
-) -> xtgeo.Well:
+) -> Well:
     """This makes an instance of a Well directly from Roxar RMS.
 
     Note this method works only when inside RMS, or when RMS license is
@@ -198,7 +201,7 @@ class Well:
         self._ensure_consistency()
 
         # additional state variables
-        self._metadata = xtgeo.MetaDataWell()
+        self._metadata = MetaDataWell()
         self._metadata.required = self
 
     _reset = __init__  # workaround until deprecation .from_file(), etc are removed
@@ -277,7 +280,7 @@ class Well:
     def metadata(self, obj):
         # The current metadata object can be replaced. This is a bit dangerous so
         # further check must be done to validate. TODO.
-        if not isinstance(obj, xtgeo.MetaDataWell):
+        if not isinstance(obj, MetaDataWell):
             raise ValueError("Input obj not an instance of MetaDataRegularCube")
 
         self._metadata = obj
@@ -455,7 +458,7 @@ class Well:
 
     def describe(self, flush=True):
         """Describe an instance by printing to stdout."""
-        dsc = xtgeo.common.XTGDescription()
+        dsc = XTGDescription()
 
         dsc.title("Description of Well instance")
         dsc.txt("Object ID", id(self))
@@ -1182,7 +1185,7 @@ class Well:
 
         if not skipname:
             dfr["NAME"] = self.xwellname
-        poly = xtgeo.Polygons()
+        poly = Polygons()
         poly.set_dataframe(dfr)
         poly.name = self.xwellname
 

--- a/src/xtgeo/well/wells.py
+++ b/src/xtgeo/well/wells.py
@@ -1,6 +1,5 @@
 """Wells module, which has the Wells class (collection of Well objects)"""
 
-
 from __future__ import annotations
 
 import functools
@@ -9,14 +8,14 @@ import warnings
 import deprecation
 import pandas as pd
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGDescription, XTGeoDialog
 
 from . import _wells_utils
-from .well1 import Well
+from .well1 import Well, well_from_file
 
-xtg = xtgeo.common.XTGeoDialog()
+xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 
@@ -37,7 +36,7 @@ def wells_from_files(filelist, *args, **kwargs):
             ...     [well_dir + '/OP_1.w', well_dir + '/OP_2.w']
             ... )
     """
-    return Wells([xtgeo.well_from_file(wfile, *args, **kwargs) for wfile in filelist])
+    return Wells([well_from_file(wfile, *args, **kwargs) for wfile in filelist])
 
 
 def _allow_deprecated_init(func):
@@ -56,7 +55,7 @@ def _allow_deprecated_init(func):
                 "mywells = xtgeo.wells_from_files(['some_name.w']) instead",
                 DeprecationWarning,
             )
-            return func(xtgeo.wells_from_files(*args, **kwargs))
+            return func(wells_from_files(*args, **kwargs))
         return func(cls, *args, **kwargs)
 
     return wrapper
@@ -103,7 +102,7 @@ class Wells:
     @wells.setter
     def wells(self, well_list):
         for well in well_list:
-            if not isinstance(well, xtgeo.well.Well):
+            if not isinstance(well, Well):
                 raise ValueError("Well in list not valid Well object")
 
         self._wells = well_list
@@ -111,7 +110,7 @@ class Wells:
     def describe(self, flush=True):
         """Describe an instance by printing to stdout"""
 
-        dsc = xtgeo.common.XTGDescription()
+        dsc = XTGDescription()
         dsc.title(f"Description of {self.__class__.__name__} instance")
         dsc.txt("Object ID", id(self))
 
@@ -164,7 +163,7 @@ class Wells:
         for wfile in filelist:
             try:
                 self._wells.append(
-                    xtgeo.well_from_file(
+                    well_from_file(
                         wfile,
                         fformat=fformat,
                         mdlogname=mdlogname,

--- a/src/xtgeo/xyz/_polygons_oper.py
+++ b/src/xtgeo/xyz/_polygons_oper.py
@@ -8,6 +8,7 @@ First order functions here are:
 
 Functions starting with '_' are local helper functions
 """
+
 from math import ceil
 
 import numpy as np
@@ -17,7 +18,7 @@ from scipy.spatial import Delaunay, cKDTree
 from shapely.ops import polygonize
 
 import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 MINIMUM_NUMBER_POINTS = 4

--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -8,7 +8,8 @@ from warnings import warn
 
 import numpy as np
 
-from xtgeo.common import XTGDescription, XTGeoDialog, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGDescription, XTGeoDialog
 
 from . import _xyz_oper
 

--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -1,16 +1,20 @@
 """XTGeo XYZ module (abstract base class)"""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from warnings import warn
 
 import numpy as np
-import pandas as pd
 
 from xtgeo.common import XTGDescription, XTGeoDialog, null_logger
 
 from . import _xyz_oper
+
+if TYPE_CHECKING:
+    import pandas as pd
+
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)

--- a/src/xtgeo/xyz/_xyz_data.py
+++ b/src/xtgeo/xyz/_xyz_data.py
@@ -41,10 +41,11 @@ import numpy as np
 import pandas as pd
 from joblib import hash as jhash
 
-import xtgeo.common.constants as const
-from xtgeo import XTGeoCLibError, _cxtgeo
-from xtgeo.common import null_logger
+from xtgeo import _cxtgeo
+from xtgeo._cxtgeo import XTGeoCLibError
 from xtgeo.common._xyz_enum import _AttrName, _AttrType, _XYZType
+from xtgeo.common.constants import UNDEF_CONT, UNDEF_DISC
+from xtgeo.common.log import null_logger
 from xtgeo.common.sys import _convert_carr_double_np, _get_carray
 
 if TYPE_CHECKING:
@@ -247,8 +248,8 @@ class _XYZData:
                 codes = {value: str(value) for value in unique}
                 if self._undef_disc in codes:
                     del codes[self._undef_disc]
-                if const.UNDEF_DISC in codes:
-                    del codes[const.UNDEF_DISC]
+                if UNDEF_DISC in codes:
+                    del codes[UNDEF_DISC]
             else:
                 codes = None
 
@@ -301,13 +302,13 @@ class _XYZData:
                 logger.debug("Replacing CONT undef...")
                 self._df[name].replace(
                     self._undef_cont,
-                    np.float64(const.UNDEF_CONT).astype(self._floatbits),
+                    np.float64(UNDEF_CONT).astype(self._floatbits),
                     inplace=True,
                 )
             else:
                 logger.debug("Replacing INT undef...")
                 self._df[name].replace(
-                    self._undef_disc, np.int32(const.UNDEF_DISC), inplace=True
+                    self._undef_disc, np.int32(UNDEF_DISC), inplace=True
                 )
         logger.info("Processed dataframe: %s", list(self._df.dtypes))
 
@@ -438,8 +439,8 @@ class _XYZData:
         self,
         infer_dtype: bool = False,
         filled=False,
-        fill_value=const.UNDEF_CONT,
-        fill_value_int=const.UNDEF_DISC,
+        fill_value=UNDEF_CONT,
+        fill_value_int=UNDEF_DISC,
     ):
         """Get a deep copy of the dataframe, with options.
 

--- a/src/xtgeo/xyz/_xyz_data.py
+++ b/src/xtgeo/xyz/_xyz_data.py
@@ -30,12 +30,12 @@ If a column is added to the dataframe, then the methods here will try to guess t
 attr_type and attr_record, and add those; similarly of a column is removed, the
 corresponding entries in attr_types and attr_records will be deleted.
 """
+
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from copy import deepcopy
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
@@ -44,9 +44,12 @@ from joblib import hash as jhash
 import xtgeo.common.constants as const
 from xtgeo import XTGeoCLibError, _cxtgeo
 from xtgeo.common import null_logger
+from xtgeo.common._xyz_enum import _AttrName, _AttrType, _XYZType
 from xtgeo.common.sys import _convert_carr_double_np, _get_carray
 
-from ..common._xyz_enum import _AttrName, _AttrType, _XYZType
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -1,11 +1,10 @@
 """Private import and export routines for XYZ stuff."""
 
-
 import numpy as np
 import pandas as pd
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.constants import UNDEF, UNDEF_INT
+from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileWrapper
 
 logger = null_logger(__name__)
@@ -159,9 +158,9 @@ def import_rms_attr(pfile, zname="Z_TVDSS"):
     for col in dfr.columns[3:]:
         if col in _attrs:
             if _attrs[col] == "float":
-                dfr[col].replace("UNDEF", xtgeo.UNDEF, inplace=True)
+                dfr[col].replace("UNDEF", UNDEF, inplace=True)
             elif _attrs[col] == "int":
-                dfr[col].replace("UNDEF", xtgeo.UNDEF_INT, inplace=True)
+                dfr[col].replace("UNDEF", UNDEF_INT, inplace=True)
             # cast to numerical if possible
         dfr[col] = pd.to_numeric(dfr[col], errors="ignore")
 
@@ -308,9 +307,9 @@ def export_rms_attr(self, pfile, attributes=True, pfilter=None, ispolygons=False
                 if col in df.columns:
                     fout.write(transl[self._attrs[col]] + " " + col + "\n")
                     if self._attrs[col] == "int":
-                        df[col].replace(xtgeo.UNDEF_INT, "UNDEF", inplace=True)
+                        df[col].replace(UNDEF_INT, "UNDEF", inplace=True)
                     elif self._attrs[col] == "float":
-                        df[col].replace(xtgeo.UNDEF, "UNDEF", inplace=True)
+                        df[col].replace(UNDEF, "UNDEF", inplace=True)
 
     with open(pfile, mode) as fc:
         df.to_csv(fc, sep=" ", header=None, columns=columns, index=False)

--- a/src/xtgeo/xyz/_xyz_lowlevel.py
+++ b/src/xtgeo/xyz/_xyz_lowlevel.py
@@ -1,10 +1,9 @@
 """Private low level routines (SWIG vs C)"""
 
-
 import numpy as np
 
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/xyz/_xyz_oper.py
+++ b/src/xtgeo/xyz/_xyz_oper.py
@@ -9,7 +9,9 @@ from scipy.interpolate import UnivariateSpline, interp1d
 
 import xtgeo
 from xtgeo import _cxtgeo
-from xtgeo.common import XTGeoDialog, null_logger
+from xtgeo.common.constants import UNDEF_LIMIT
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
@@ -105,7 +107,7 @@ def operation_polygons_v1(self, poly, value, opname="add", inside=True, where=Tr
         if ies != 0:
             raise RuntimeError(f"Something went wrong, code {ies}")
 
-    zcor[zcor > xtgeo.UNDEF_LIMIT] = np.nan
+    zcor[zcor > UNDEF_LIMIT] = np.nan
     dataframe = self.get_dataframe()
     dataframe[self.zname] = zcor
     # removing rows where Z column is undefined

--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -11,9 +11,9 @@ import numpy as np
 import pandas as pd
 
 from xtgeo import ROXAR  # type: ignore
-from xtgeo.common import null_logger
 from xtgeo.common._xyz_enum import _AttrName
 from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_INT_LIMIT, UNDEF_LIMIT
+from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileWrapper
 from xtgeo.roxutils import RoxUtils
 from xtgeo.xyz import _xyz_io, points, polygons

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -1,12 +1,12 @@
 """The XTGeo xyz.points module, which contains the Points class."""
+
 from __future__ import annotations
 
 import functools
-import io
 import pathlib
 import warnings
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import deprecation
 import numpy as np
@@ -17,6 +17,9 @@ from xtgeo.common import inherit_docstring, null_logger
 from xtgeo.common.version import __version__
 from xtgeo.io._file import FileFormat, FileWrapper
 from xtgeo.xyz import XYZ, _xyz_io, _xyz_oper, _xyz_roxapi
+
+if TYPE_CHECKING:
+    import io
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -13,7 +13,8 @@ import numpy as np
 import pandas as pd
 
 import xtgeo
-from xtgeo.common import inherit_docstring, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.sys import inherit_docstring
 from xtgeo.common.version import __version__
 from xtgeo.io._file import FileFormat, FileWrapper
 from xtgeo.xyz import XYZ, _xyz_io, _xyz_oper, _xyz_roxapi

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -6,18 +6,16 @@
 from __future__ import annotations
 
 import functools
-import io
 import pathlib
 import warnings
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import deprecation
 import numpy as np
 import pandas as pd
 import shapely.geometry as sg
 
-import xtgeo
 from xtgeo.common import inherit_docstring, null_logger
 from xtgeo.common.version import __version__
 from xtgeo.io._file import FileFormat, FileWrapper
@@ -26,6 +24,11 @@ from xtgeo.xyz import _xyz_io, _xyz_roxapi
 from . import _polygons_oper, _xyz_oper
 from ._xyz import XYZ
 from ._xyz_io import _convert_idbased_xyz
+
+if TYPE_CHECKING:
+    import io
+
+    from xtgeo.well.well1 import Well
 
 logger = null_logger(__name__)
 
@@ -73,7 +76,7 @@ def _roxar_importer(
 
 
 def _wells_importer(
-    wells: list[xtgeo.Well],
+    wells: list[Well],
     zone: int | None = None,
     resample: int | None = 1,
 ):
@@ -167,7 +170,7 @@ def polygons_from_roxar(
 
 
 def polygons_from_wells(
-    wells: list[xtgeo.Well],
+    wells: list[Well],
     zone: int | None = 1,
     resample: int | None = 1,
 ):

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -16,7 +16,8 @@ import numpy as np
 import pandas as pd
 import shapely.geometry as sg
 
-from xtgeo.common import inherit_docstring, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.sys import inherit_docstring
 from xtgeo.common.version import __version__
 from xtgeo.io._file import FileFormat, FileWrapper
 from xtgeo.xyz import _xyz_io, _xyz_roxapi

--- a/tests/test_opm_integration/test_grid_io.py
+++ b/tests/test_opm_integration/test_grid_io.py
@@ -5,7 +5,7 @@ import xtgeo
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
-from ..test_grid3d.grid_generator import xtgeo_grids
+from ..test_grid3d.grid_generator import xtgeo_grids  # noqa
 
 
 def deck_contents(dimensions, load_statement):

--- a/tests/test_opm_integration/test_gridprop_io.py
+++ b/tests/test_opm_integration/test_gridprop_io.py
@@ -11,7 +11,7 @@ from xtgeo.grid3d._ecl_inte_head import InteHead
 from xtgeo.grid3d._ecl_logi_head import LogiHead
 from xtgeo.grid3d._ecl_output_file import Simulator, TypeOfGrid, UnitSystem
 
-from ..test_grid3d.grid_generator import xtgeo_grids
+from ..test_grid3d.grid_generator import xtgeo_grids  # noqa
 
 
 @dataclass

--- a/tests/test_surface/test_ijxyz_spec.py
+++ b/tests/test_surface/test_ijxyz_spec.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface._regsurf_ijxyz_parser import SurfaceIJXYZ
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 xtg = XTGeoDialog()
 logger = xtg.basiclogger(__name__)

--- a/tests/test_well/test_well_xyzdata_class.py
+++ b/tests/test_well/test_well_xyzdata_class.py
@@ -1,7 +1,9 @@
 """Test _XYZData class, in a Well context"""
+
 import pandas as pd
 import pytest
-from xtgeo.common import _AttrType, _XYZData
+from xtgeo.common import _AttrType
+from xtgeo.xyz._xyz_data import _XYZData
 
 
 @pytest.fixture(name="generate_data")


### PR DESCRIPTION
Does most of #1149

The goal of this effort is to work toward increasing the modularity of the code, i.e., decreasing the dependencies the major packages (cube, grid3d, etc) have between them. Being explicit about imports helps to guide us when structuring code such that the package structure is visible when adding, changing, or moving things, rather than being hidden behind `import xtgeo` and putting every sub-package and sub-module into a flat namespace. Using relative imports within subpackages help us see more clearly where we are encapsulating things, or where we might want to encapsulate things, behind a package name (namespace).

This PR adds a few ugly elements, though, namely a few lazy imports when instance checks occur. These will be pulled out in a later PR.

Does not address `xtgeo.xyz` or `xtgeo.grid3d`. No notable change in import time, just a bit shorter.