### PR TITLE
CLN: Remove bare xtgeo imports

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -36,6 +36,16 @@ jobs:
         if: ${{ always() }}
         run: ruff format . --check
 
+      - name: Check bare xtgeo imports
+        if: ${{ always() }}
+        run: |
+          if ! grep -rE '^import xtgeo(\s*#.*)?$' src; then
+              echo "✅ No 'import xtgeo' used"
+          else
+              echo "⛔️ Bare 'import xtgeo' used."
+              echo "Use a more specific import, e.g. 'import xtgeo.something'"
+          fi
+
       - name: cmake-format
         if: ${{ always() }}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ write_to = "src/xtgeo/common/version.py"
 
 [tool.ruff]
 line-length = 88
+exclude = ["examples"]
 
 [tool.ruff.lint]
 ignore = [
@@ -159,3 +160,13 @@ select = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+
+[tool.ruff.lint.flake8-import-conventions.aliases]
+# Enforce `import numpy as np`
+numpy = "np"
+pandas = "pd"
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Ban certain modules from being imported at module level, instead requiring
+# that they're imported lazily (e.g., within a function definition).
+banned-module-level-imports = ["matplotlib", "xtgeoviz"]

--- a/src/xtgeo/grid3d/_find_gridprop_in_eclrun.py
+++ b/src/xtgeo/grid3d/_find_gridprop_in_eclrun.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Literal, Optional, Union
 import numpy as np
 import resfo
 
-import xtgeo
+from xtgeo.common.constants import UNDEF, UNDEF_INT
 
 from ._ecl_inte_head import InteHead
 from ._ecl_logi_head import LogiHead
@@ -300,7 +300,7 @@ def match_values_to_active_cells(
             f"number of active cells {len(actind)}"
         )
 
-    undef = xtgeo.UNDEF_INT if np.issubdtype(values.dtype, np.integer) else xtgeo.UNDEF
+    undef = UNDEF_INT if np.issubdtype(values.dtype, np.integer) else UNDEF
     result = np.full(fill_value=undef, shape=num_cells, dtype=values.dtype)
     result[actind] = values
     return result

--- a/src/xtgeo/grid3d/_grdecl_format.py
+++ b/src/xtgeo/grid3d/_grdecl_format.py
@@ -4,7 +4,7 @@ import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 if TYPE_CHECKING:
     from collections.abc import Generator

--- a/src/xtgeo/grid3d/_grid3d.py
+++ b/src/xtgeo/grid3d/_grid3d.py
@@ -1,6 +1,6 @@
 """Private baseclass for Grid and GridProperties, not to be used by itself."""
 
-from xtgeo.common import XTGeoDialog
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 xtg = XTGeoDialog()
 

--- a/src/xtgeo/grid3d/_grid3d_fence.py
+++ b/src/xtgeo/grid3d/_grid3d_fence.py
@@ -1,4 +1,5 @@
 """Some grid utilities, file scanning etc."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,15 +7,17 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
 from xtgeo.common.constants import UNDEF_LIMIT
-from xtgeo.grid3d import _gridprop_lowlevel as gl
+from xtgeo.common.log import null_logger
 from xtgeo.surface import _regsurf_lowlevel as rl
 from xtgeo.surface.regular_surface import surface_from_grid3d
-from xtgeo.xyz import Polygons
+from xtgeo.xyz.polygons import Polygons
+
+from . import _gridprop_lowlevel as gl
 
 if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid, GridProperty
+    from .grid import Grid
+    from .grid_property import GridProperty
 
 
 logger = null_logger(__name__)

--- a/src/xtgeo/grid3d/_grid3d_utils.py
+++ b/src/xtgeo/grid3d/_grid3d_utils.py
@@ -9,8 +9,8 @@ import pandas as pd
 import resfo
 import roffio
 
-from xtgeo.common import null_logger
 from xtgeo.common.constants import MAXDATES, MAXKEYWORDS
+from xtgeo.common.log import null_logger
 
 if TYPE_CHECKING:
     from xtgeo.io._file import FileWrapper

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -12,21 +12,22 @@ from packaging.version import parse as versionparse
 
 import xtgeo._internal as _internal
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
 from xtgeo.common.calc import find_flip
 from xtgeo.common.constants import UNDEF_INT, UNDEF_LIMIT
-from xtgeo.grid3d.grid_properties import GridProperties
+from xtgeo.common.log import null_logger
 from xtgeo.xyz.polygons import Polygons
 
 from . import _gridprop_lowlevel
 from ._grid3d_fence import _update_tmpvars
+from .grid_properties import GridProperties
 from .grid_property import GridProperty
 
 if TYPE_CHECKING:
     from xtgeo.common.types import Dimensions
-    from xtgeo.grid3d import Grid
-    from xtgeo.grid3d.types import METRIC
     from xtgeo.xyz.points import Points
+
+    from .grid import Grid
+    from .types import METRIC
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_grid_export.py
+++ b/src/xtgeo/grid3d/_grid_export.py
@@ -11,7 +11,7 @@ import h5py
 import hdf5plugin
 import roffio
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 from ._egrid import EGrid
 from ._grdecl_grid import GrdeclGrid

--- a/src/xtgeo/grid3d/_grid_hybrid.py
+++ b/src/xtgeo/grid3d/_grid_hybrid.py
@@ -5,13 +5,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
 from xtgeo.common.constants import UNDEF_INT
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid, GridProperty
+    from .grid import Grid
+    from .grid_property import GridProperty
 
 
 def make_hybridgrid(

--- a/src/xtgeo/grid3d/_grid_import.py
+++ b/src/xtgeo/grid3d/_grid_import.py
@@ -1,14 +1,14 @@
 """Grid import functions for various formats."""
+
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
-from xtgeo.common import null_logger
-from xtgeo.grid3d import _grid_import_ecl, _grid_import_roff
+from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileFormat, FileWrapper
 
-from . import _grid_import_xtgcpgeom
+from . import _grid_import_ecl, _grid_import_roff, _grid_import_xtgcpgeom
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_grid_import_ecl.py
+++ b/src/xtgeo/grid3d/_grid_import_ecl.py
@@ -1,13 +1,15 @@
 """Grid import functions for Eclipse, new approach (i.e. version 2)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from xtgeo.common import null_logger
-from xtgeo.grid3d._egrid import EGrid, RockModel
-from xtgeo.grid3d._grdecl_grid import GrdeclGrid, GridRelative
-from xtgeo.grid3d.grid_properties import GridProperties, gridproperties_from_file
+from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileFormat, FileWrapper
+
+from ._egrid import EGrid, RockModel
+from ._grdecl_grid import GrdeclGrid, GridRelative
+from .grid_properties import GridProperties, gridproperties_from_file
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_grid_import_roff.py
+++ b/src/xtgeo/grid3d/_grid_import_roff.py
@@ -1,4 +1,5 @@
 """Private module, Grid Import private functions for ROFF format."""
+
 from __future__ import annotations
 
 import pathlib
@@ -8,7 +9,7 @@ from contextlib import contextmanager
 from io import BufferedReader, BytesIO
 from typing import TYPE_CHECKING, Generator
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 from ._roff_grid import RoffGrid
 

--- a/src/xtgeo/grid3d/_grid_import_xtgcpgeom.py
+++ b/src/xtgeo/grid3d/_grid_import_xtgcpgeom.py
@@ -1,4 +1,5 @@
 """Private module, Grid Import private functions for xtgeo based formats."""
+
 from __future__ import annotations
 
 import json
@@ -10,8 +11,9 @@ import numpy as np
 from typing_extensions import NotRequired, TypeAlias
 
 import xtgeo.common.sys as xsys
-from xtgeo.common import null_logger
-from xtgeo.grid3d._gridprop_import_xtgcpprop import _read_filelike
+from xtgeo.common.log import null_logger
+
+from ._gridprop_import_xtgcpprop import _read_filelike
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_grid_refine.py
+++ b/src/xtgeo/grid3d/_grid_refine.py
@@ -1,4 +1,5 @@
 """Private module for refinement of a grid."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -6,13 +7,15 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from xtgeo import _cxtgeo
-from xtgeo.common import XTGeoDialog, null_logger
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid, GridProperty
+    from .grid import Grid
+    from .grid_property import GridProperty
 
 
 def refine_vertically(

--- a/src/xtgeo/grid3d/_grid_roxapi.py
+++ b/src/xtgeo/grid3d/_grid_roxapi.py
@@ -9,8 +9,9 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 
 from xtgeo import _cxtgeo
-from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.common.constants import UNDEF_LIMIT
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 from xtgeo.roxutils.roxutils import RoxUtils
 
 xtg = XTGeoDialog()
@@ -20,7 +21,7 @@ logger = null_logger(__name__)
 if TYPE_CHECKING:
     import contextlib
 
-    from xtgeo.grid3d.grid import Grid
+    from .grid import Grid
 
     with contextlib.suppress(ImportError):
         import roxar

--- a/src/xtgeo/grid3d/_grid_wellzone.py
+++ b/src/xtgeo/grid3d/_grid_wellzone.py
@@ -1,16 +1,19 @@
 """Private module for grid vs well zonelog checks."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
-from xtgeo.common import XTGeoDialog, null_logger
-from xtgeo.grid3d.grid_property import GridProperty
-from xtgeo.well import Well
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
+from xtgeo.well.well1 import Well
+
+from .grid_property import GridProperty
 
 if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid
+    from .grid import Grid
 
 
 xtg = XTGeoDialog()

--- a/src/xtgeo/grid3d/_gridprop_import_grdecl.py
+++ b/src/xtgeo/grid3d/_gridprop_import_grdecl.py
@@ -1,4 +1,5 @@
 """Importing grid props from GRDECL, ascii or binary"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -7,8 +8,8 @@ import numpy as np
 import numpy.ma as ma
 import resfo
 
-from xtgeo.common import null_logger
 from xtgeo.common.exceptions import KeywordNotFoundError
+from xtgeo.common.log import null_logger
 
 from ._grdecl_format import match_keyword, open_grdecl
 

--- a/src/xtgeo/grid3d/_gridprop_import_roff.py
+++ b/src/xtgeo/grid3d/_gridprop_import_roff.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
 
 from ._roff_parameter import RoffParameter
 
 if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid
     from xtgeo.io._file import FileWrapper
+
+    from .grid import Grid
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_gridprop_import_xtgcpprop.py
+++ b/src/xtgeo/grid3d/_gridprop_import_xtgcpprop.py
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING, Any, Generator
 import numpy as np
 
 import xtgeo.common.sys as xsys
-from xtgeo.common import null_logger
 from xtgeo.common.constants import UNDEF, UNDEF_INT
+from xtgeo.common.log import null_logger
 from xtgeo.metadata.metadata import MetaDataCPProperty
 
 logger = null_logger(__name__)

--- a/src/xtgeo/grid3d/_gridprop_lowlevel.py
+++ b/src/xtgeo/grid3d/_gridprop_lowlevel.py
@@ -1,4 +1,5 @@
 """GridProperty (not GridProperies) low level functions"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
@@ -7,8 +8,8 @@ import numpy as np
 import numpy.ma as ma
 
 from xtgeo import _cxtgeo
-from xtgeo.common import null_logger
 from xtgeo.common.constants import UNDEF, UNDEF_INT
+from xtgeo.common.log import null_logger
 
 logger = null_logger(__name__)
 
@@ -17,7 +18,8 @@ if TYPE_CHECKING:
 
     from numpy.typing import DTypeLike
 
-    from xtgeo.grid3d import Grid, GridProperty
+    from .grid import Grid
+    from .grid_property import GridProperty
 
 
 def f2c_order(obj: Grid | GridProperty, values1d: np.ndarray) -> np.ndarray:

--- a/src/xtgeo/grid3d/_gridprop_op1.py
+++ b/src/xtgeo/grid3d/_gridprop_op1.py
@@ -1,21 +1,22 @@
 """Various grid property operations"""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np
 
-import xtgeo
 from xtgeo import _cxtgeo
-from xtgeo.common import XTGeoDialog, null_logger
-from xtgeo.grid3d import _gridprop_lowlevel as gl
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
+from xtgeo.xyz.polygons import Polygons
+
+from . import _gridprop_lowlevel as gl
+from .grid import Grid
+from .grid_property import GridProperty
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
-
-if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid, GridProperty
-    from xtgeo.xyz import Polygons
 
 _CoordOrValue = Union[float, int]
 _XYCoordinate = Tuple[_CoordOrValue, _CoordOrValue]
@@ -43,10 +44,10 @@ def get_xy_value_lists(
     if grid is None:
         raise RuntimeError("Missing grid object")
 
-    if not isinstance(grid, xtgeo.grid3d.Grid):
+    if not isinstance(grid, Grid):
         raise RuntimeError("The input grid is not a XTGeo Grid instance")
 
-    if not isinstance(self, xtgeo.grid3d.GridProperty):
+    if not isinstance(self, GridProperty):
         raise RuntimeError("The property is not a XTGeo GridProperty instance")
 
     clist = grid.get_xyz_corners()
@@ -97,7 +98,7 @@ def operation_polygons(
     grid = self.geometry
     grid._xtgformat1()
 
-    if not isinstance(poly, xtgeo.xyz.Polygons):
+    if not isinstance(poly, Polygons):
         raise ValueError("The poly input is not a Polygons instance")
 
     # make a copy of the array which is used a "filter" or "proxy"

--- a/src/xtgeo/grid3d/_gridprop_roxapi.py
+++ b/src/xtgeo/grid3d/_gridprop_roxapi.py
@@ -8,15 +8,15 @@ from typing import TYPE_CHECKING, Any, Literal
 import numpy as np
 from numpy import ma
 
-from xtgeo.common import null_logger
 from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_INT_LIMIT, UNDEF_LIMIT
+from xtgeo.common.log import null_logger
 from xtgeo.roxutils import RoxUtils
 
 with contextlib.suppress(ImportError):
     import roxar
 
 if TYPE_CHECKING:
-    from xtgeo.grid3d.grid_property import GridProperty
+    from .grid_property import GridProperty
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_gridprop_value_init.py
+++ b/src/xtgeo/grid3d/_gridprop_value_init.py
@@ -1,18 +1,17 @@
 """GridProperty (not GridProperies) some etc functions"""
+
 from __future__ import annotations
 
 import numbers
-from typing import TYPE_CHECKING
 
 import numpy as np
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
+
+from .grid import Grid
+from .grid_property import GridProperty
 
 logger = null_logger(__name__)
-
-if TYPE_CHECKING:
-    from xtgeo.grid3d import Grid, GridProperty
 
 
 def gridproperty_non_dummy_values(
@@ -42,11 +41,11 @@ def gridproperty_non_dummy_values(
         _values = initial_gridprop_values_from_array(dimensions, values, isdiscrete)
 
     if gridlike:
-        if isinstance(gridlike, xtgeo.grid3d.Grid):
+        if isinstance(gridlike, Grid):
             act = gridlike.get_actnum(asmasked=True)
             _values = np.ma.array(_values, mask=np.ma.getmaskarray(act.values))
         else:
-            assert isinstance(gridlike, xtgeo.grid3d.GridProperty)
+            assert isinstance(gridlike, GridProperty)
             _values = np.ma.array(_values, mask=np.ma.getmaskarray(gridlike.values))
 
     return _values

--- a/src/xtgeo/grid3d/_gridprops_import_eclrun.py
+++ b/src/xtgeo/grid3d/_gridprops_import_eclrun.py
@@ -6,9 +6,9 @@ from typing import Generator, Literal
 
 import resfo
 
-import xtgeo
-from xtgeo.common import null_logger
 from xtgeo.common.constants import MAXKEYWORDS
+from xtgeo.common.log import null_logger
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 from xtgeo.io._file import FileWrapper
 
 from . import _grid3d_utils as utils
@@ -20,7 +20,7 @@ from ._find_gridprop_in_eclrun import (
 from ._gridprop_import_eclrun import decorate_name
 from .grid_property import GridProperty
 
-xtg = xtgeo.common.XTGeoDialog()
+xtg = XTGeoDialog()
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/grid3d/_gridprops_import_roff.py
+++ b/src/xtgeo/grid3d/_gridprops_import_roff.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING, Generator, Literal
 
 import roffio
 
-import xtgeo
-from xtgeo.common import null_logger
+from xtgeo.common.log import null_logger
+
+from .grid_property import gridproperty_from_file
 
 if TYPE_CHECKING:
     from xtgeo.io._file import FileWrapper
@@ -58,7 +59,7 @@ def import_roff_gridproperties(
     """
     if names == "all":
         return [
-            xtgeo.gridproperty_from_file(pfile.file, fformat="roff", name=name)
+            gridproperty_from_file(pfile.file, fformat="roff", name=name)
             for name in read_roff_properties(pfile)
         ]
 
@@ -66,9 +67,7 @@ def import_roff_gridproperties(
     props = []
     for name in names:
         if name in prop_names:
-            props.append(
-                xtgeo.gridproperty_from_file(pfile.file, fformat="roff", name=name)
-            )
+            props.append(gridproperty_from_file(pfile.file, fformat="roff", name=name))
         elif strict:
             raise ValueError(
                 f"Requested keyword {name} is not in ROFF file. Valid "

--- a/src/xtgeo/grid3d/_roff_grid.py
+++ b/src/xtgeo/grid3d/_roff_grid.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     import pathlib
     from collections.abc import MutableMapping, Sequence
 
-    from xtgeo.grid3d import Grid
+    from .grid import Grid
 
 
 @dataclass

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -12,12 +12,14 @@ import deprecation
 import numpy as np
 import numpy.ma as ma
 
-import xtgeo
-from xtgeo.common import XTGDescription, null_logger
+from xtgeo.common.log import null_logger
 from xtgeo.common.sys import generic_hash
 from xtgeo.common.types import Dimensions
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGDescription, XTGeoDialog
 from xtgeo.io._file import FileFormat, FileWrapper
+from xtgeo.metadata.metadata import MetaDataCPGeometry
+from xtgeo.xyz.polygons import Polygons
 
 from . import (
     _grid3d_fence,
@@ -34,21 +36,22 @@ from . import (
 )
 from ._grid3d import _Grid3D
 from .grid_properties import GridProperties
+from .grid_property import GridProperty
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Hashable, Sequence
 
     import pandas as pd
 
-    from xtgeo import Polygons, Well
     from xtgeo.common.types import FileLike
+    from xtgeo.cube.cube1 import Cube
+    from xtgeo.well.well1 import Well
     from xtgeo.xyz.points import Points
 
     from ._ecl_grid import Units
-    from .grid_property import GridProperty
     from .types import METRIC
 
-xtg = xtgeo.common.XTGeoDialog()
+xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 # --------------------------------------------------------------------------------------
@@ -220,7 +223,7 @@ def create_box_grid(
 
 
 def grid_from_cube(
-    cube: xtgeo.Cube,
+    cube: Cube,
     propname: str | None = "seismics",
     oricenter: bool = True,
 ) -> Grid:
@@ -252,7 +255,7 @@ def grid_from_cube(
     )
     if propname is not None:
         grd.props = [
-            xtgeo.GridProperty(
+            GridProperty(
                 ncol=cube.ncol,
                 nrow=cube.nrow,
                 nlay=cube.nlay,
@@ -491,7 +494,7 @@ class Grid(_Grid3D):
             acttmp.values[acttmp.values >= 1] = 1
             self.set_actnum(acttmp)
 
-        self._metadata = xtgeo.MetaDataCPGeometry()
+        self._metadata = MetaDataCPGeometry()
         self._metadata.required = self
 
         # Roxar api spesific:
@@ -521,15 +524,15 @@ class Grid(_Grid3D):
     # ==================================================================================
 
     @property
-    def metadata(self) -> xtgeo.MetaDataCPGeometry:
+    def metadata(self) -> MetaDataCPGeometry:
         """obj: Return or set metadata instance of type MetaDataCPGeometry."""
         return self._metadata
 
     @metadata.setter
-    def metadata(self, obj: xtgeo.MetaDataCPGeometry) -> None:
+    def metadata(self, obj: MetaDataCPGeometry) -> None:
         # The current metadata object can be replaced. A bit dangerous so further
         # check must be done to validate. TODO.
-        if not isinstance(obj, xtgeo.MetaDataCPGeometry):
+        if not isinstance(obj, MetaDataCPGeometry):
             raise ValueError("Input obj not an instance of MetaDataCPGeometry")
 
         self._metadata = obj  # checking is currently missing! TODO
@@ -1674,7 +1677,7 @@ class Grid(_Grid3D):
         if dual and self._dualactnum:
             act = self._dualactnum.copy()
         else:
-            act = xtgeo.grid3d.GridProperty(
+            act = GridProperty(
                 ncol=self._ncol,
                 nrow=self._nrow,
                 nlay=self._nlay,
@@ -2725,7 +2728,7 @@ class Grid(_Grid3D):
               used to pregenerate `fencespec`
 
         """
-        if not isinstance(fencespec, (np.ndarray, xtgeo.Polygons)):
+        if not isinstance(fencespec, (np.ndarray, Polygons)):
             raise ValueError("fencespec must be a numpy or a Polygons() object")
         logger.info("Getting randomline...")
 

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -10,9 +10,10 @@ import deprecation
 import numpy as np
 import pandas as pd
 
-from xtgeo.common import XTGDescription, XTGeoDialog, null_logger
 from xtgeo.common.constants import MAXDATES, MAXKEYWORDS
+from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGDescription, XTGeoDialog
 from xtgeo.io._file import FileFormat, FileWrapper
 
 from . import _grid3d_utils as utils, _grid_etc1
@@ -30,9 +31,9 @@ logger = null_logger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
-    from xtgeo import Grid
     from xtgeo.common.types import FileLike
 
+    from .grid import Grid
     from .grid_property import GridProperty
 
 KeywordTuple = Tuple[str, str, int, int]

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING, Any, Literal
 import deprecation
 import numpy as np
 
-import xtgeo
-from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_INT_LIMIT, UNDEF_LIMIT
+from xtgeo.common.log import null_logger
 from xtgeo.common.types import Dimensions
 from xtgeo.common.version import __version__
+from xtgeo.common.xtgeo_dialog import XTGeoDialog
 from xtgeo.io._file import FileFormat, FileWrapper
 from xtgeo.metadata.metadata import MetaDataCPProperty
 
@@ -34,6 +34,7 @@ from ._gridprop_import_eclrun import (
 from ._gridprop_import_grdecl import import_bgrdecl_prop, import_grdecl_prop
 from ._gridprop_import_roff import import_roff
 from ._gridprop_import_xtgcpprop import import_xtgcpprop
+from .grid import Grid
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
@@ -48,7 +49,6 @@ if TYPE_CHECKING:
     from xtgeo.xyz.polygons import Polygons
 
     from ._gridprop_op1 import XYValueLists
-    from .grid import Grid
 
     GridProperty_DType = Union[
         type[np.uint8],
@@ -480,7 +480,7 @@ class GridProperty(_Grid3D):
             gridlike, self.dimensions, values, discrete
         )
 
-        if isinstance(gridlike, xtgeo.grid3d.Grid):
+        if isinstance(gridlike, Grid):
             if linkgeometry:
                 # Associate this grid property with a Grid instance. This is not default
                 # since sunch links may affect garbage collection
@@ -610,7 +610,7 @@ class GridProperty(_Grid3D):
     def geometry(self, grid: Grid | None) -> None:
         if grid is None:
             self._geometry = None
-        elif isinstance(grid, xtgeo.grid3d.Grid) and grid.dimensions == self.dimensions:
+        elif isinstance(grid, Grid) and grid.dimensions == self.dimensions:
             self._geometry = grid
         else:
             raise ValueError("Could not set geometry; wrong type or size")

--- a/src/xtgeo/metadata/metadata.py
+++ b/src/xtgeo/metadata/metadata.py
@@ -10,9 +10,13 @@ The metadata works through the various datatypes in XTGeo. For example::
 
 """
 
-import xtgeo
 from xtgeo.common.constants import UNDEF
 from xtgeo.common.log import null_logger
+from xtgeo.cube.cube1 import Cube
+from xtgeo.grid3d.grid import Grid
+from xtgeo.grid3d.grid_property import GridProperty
+from xtgeo.surface.regular_surface import RegularSurface
+from xtgeo.well.well1 import Well
 
 logger = null_logger(__name__)
 
@@ -251,7 +255,7 @@ class MetaDataRegularSurface(MetaData):
 
     @required.setter
     def required(self, obj):
-        if not isinstance(obj, xtgeo.RegularSurface):
+        if not isinstance(obj, RegularSurface):
             raise ValueError("Input object is not a RegularSurface()")
 
         self._required["ncol"] = obj.ncol
@@ -298,7 +302,7 @@ class MetaDataRegularCube(MetaData):
 
     @required.setter
     def required(self, obj):
-        if not isinstance(obj, xtgeo.Cube):
+        if not isinstance(obj, Cube):
             raise ValueError("Input object is not a regular Cube()")
 
         self._required["ncol"] = obj.ncol
@@ -344,7 +348,7 @@ class MetaDataCPGeometry(MetaData):
 
     @required.setter
     def required(self, obj):
-        if not isinstance(obj, xtgeo.Grid):
+        if not isinstance(obj, Grid):
             raise ValueError("Input object is not a Grid()")
 
         self._required["ncol"] = obj.ncol
@@ -383,7 +387,7 @@ class MetaDataCPProperty(MetaData):
 
     @required.setter
     def required(self, obj):
-        if not isinstance(obj, xtgeo.GridProperty):
+        if not isinstance(obj, GridProperty):
             raise ValueError("Input object is not a GridProperty()")
 
         self._required["ncol"] = obj.ncol
@@ -419,7 +423,7 @@ class MetaDataWell(MetaData):
 
     @required.setter
     def required(self, obj):
-        if not isinstance(obj, xtgeo.Well):
+        if not isinstance(obj, Well):
             raise ValueError("Input object is not a Well() instance!")
 
         self._required["rkb"] = obj.rkb

--- a/src/xtgeo/xyz/__init__.py
+++ b/src/xtgeo/xyz/__init__.py
@@ -1,7 +1,11 @@
 """The XTGeo xyz (points and polygons) package."""
 
+from ._xyz import XYZ
+from .points import Points
+from .polygons import Polygons
 
-# flake8: noqa
-from xtgeo.xyz._xyz import XYZ
-from xtgeo.xyz.points import Points
-from xtgeo.xyz.polygons import Polygons
+__all__ = [
+    "XYZ",
+    "Points",
+    "Polygons",
+]

--- a/src/xtgeo/xyz/_polygons_oper.py
+++ b/src/xtgeo/xyz/_polygons_oper.py
@@ -17,8 +17,9 @@ import shapely.geometry as sg
 from scipy.spatial import Delaunay, cKDTree
 from shapely.ops import polygonize
 
-import xtgeo
 from xtgeo.common.log import null_logger
+
+from .points import Points
 
 logger = null_logger(__name__)
 MINIMUM_NUMBER_POINTS = 4
@@ -30,7 +31,7 @@ class BoundaryError(ValueError):
 
 def boundary_from_points(points, alpha_factor=1.0, alpha=None, concave=False):
     """From a Point instance, make boundary polygons (generic)."""
-    if not isinstance(points, xtgeo.Points):
+    if not isinstance(points, Points):
         raise ValueError("The input points is not an instance of xtgeo.Points")
 
     if points.nrow < MINIMUM_NUMBER_POINTS:

--- a/src/xtgeo/xyz/_xyz_data.py
+++ b/src/xtgeo/xyz/_xyz_data.py
@@ -51,9 +51,7 @@ from xtgeo.common.sys import _convert_carr_double_np, _get_carray
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-
 logger = null_logger(__name__)
-
 
 CONT_DEFAULT_RECORD = ("", "")  # unit and scale, where emptry string indicates ~unknown
 

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -12,15 +12,19 @@ import deprecation
 import numpy as np
 import pandas as pd
 
-import xtgeo
 from xtgeo.common.log import null_logger
 from xtgeo.common.sys import inherit_docstring
 from xtgeo.common.version import __version__
 from xtgeo.io._file import FileFormat, FileWrapper
-from xtgeo.xyz import XYZ, _xyz_io, _xyz_oper, _xyz_roxapi
+from xtgeo.surface.regular_surface import RegularSurface
+
+from . import _xyz_io, _xyz_oper, _xyz_roxapi
+from ._xyz import XYZ
 
 if TYPE_CHECKING:
     import io
+
+    from xtgeo.well.well1 import Well
 
 logger = null_logger(__name__)
 
@@ -85,7 +89,7 @@ def _roxar_importer(
 
 
 def _wells_importer(
-    wells: list[xtgeo.Well],
+    wells: list[Well],
     tops: bool = True,
     incl_limit: float | None = None,
     top_prefix: str = "Top",
@@ -122,7 +126,7 @@ def _wells_importer(
 
 
 def _wells_dfrac_importer(
-    wells: list[xtgeo.Well],
+    wells: list[Well],
     dlogname: str,
     dcodes: list[int],
     incl_limit: float = 90,
@@ -260,7 +264,7 @@ def points_from_surface(
 
 
 def points_from_wells(
-    wells: list[xtgeo.Well],
+    wells: list[Well],
     tops: bool = True,
     incl_limit: float | None = None,
     top_prefix: str = "Top",
@@ -307,7 +311,7 @@ def points_from_wells(
 
 
 def points_from_wells_dfrac(
-    wells: list[xtgeo.Well],
+    wells: list[Well],
     dlogname: str,
     dcodes: list[int],
     incl_limit: float = 90,
@@ -380,7 +384,7 @@ def _allow_deprecated_init(func):
                 fformat = kwargs.get("fformat", "guess")
                 return func(cls, **_file_importer(args[0], fformat))
 
-            if isinstance(args[0], xtgeo.RegularSurface):
+            if isinstance(args[0], RegularSurface):
                 warnings.warn(
                     "Initializing directly from RegularSurface is deprecated "
                     "and will be removed in xtgeo version 4.0. Use: "

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -20,9 +20,8 @@ from xtgeo.common.log import null_logger
 from xtgeo.common.sys import inherit_docstring
 from xtgeo.common.version import __version__
 from xtgeo.io._file import FileFormat, FileWrapper
-from xtgeo.xyz import _xyz_io, _xyz_roxapi
 
-from . import _polygons_oper, _xyz_oper
+from . import _polygons_oper, _xyz_io, _xyz_oper, _xyz_roxapi
 from ._xyz import XYZ
 from ._xyz_io import _convert_idbased_xyz
 


### PR DESCRIPTION
Resolves #1149

I was a bit opinionated with these changes in expanding import paths fully and using relative imports, but I don't particularly believe that needs to be enforced and no linting rules exist to enforce it anyway. I do think that it will be a bit helpful in the near term, with structural refactors ahead, and that we should discuss whether or not to codify it in the style guide. Some major projects, e.g. pandas, do this.

This also adds a manual check in linting ci to make sure no further `import xtgeo`s are added