### PR TITLE
FIX: Inrease robustness in boundary polygons

### DIFF
--- a/src/xtgeo/surface/_regsurf_boundary.py
+++ b/src/xtgeo/surface/_regsurf_boundary.py
@@ -15,9 +15,6 @@ def create_boundary(self, alpha_factor, is_convex, simplify):
 
     pol = Polygons.boundary_from_points(points, alpha_factor, alpha, is_convex)
 
-    if pol is None:
-        raise RuntimeError("Could not create a valid Polygons instance for boundary.")
-
     if simplify:
         if isinstance(simplify, bool):
             pol.simplify(tolerance=0.1)

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -1321,10 +1321,10 @@ def test_get_boundary_polygons_complex(show_plot):
     # for some reasons, macos tests gives slightly different result; that is why a large
     # tolerance is given
     assert boundary.get_dataframe()[boundary.xname].mean() == pytest.approx(
-        462392.0, abs=3.0
+        462230.0, abs=3.0
     )
     assert boundary.get_dataframe()[boundary.yname].mean() == pytest.approx(
-        5933152.0, abs=4.0
+        5933457.0, abs=4.0
     )
 
     # get the first (largest) polygon
@@ -1342,6 +1342,26 @@ def test_get_boundary_polygons_complex(show_plot):
                 "linewidth": 2,
             },
         )
+
+
+def test_boundary_polygons_are_sorted():
+    """Test that boundary polygons are sorted from largest to smallest."""
+    xs = xtgeo.surface_from_file(TESTSET1)
+    xs.values = np.ma.masked_less(xs.values, 1700)
+    xs.values = np.ma.masked_greater(xs.values, 1800)
+
+    boundary = xs.get_boundary_polygons(simplify=False)
+
+    df = boundary.get_dataframe(copy=False)
+
+    # check that we have 7 unique boundaries for this surface
+    assert df["POLY_ID"].nunique() == 7
+
+    # check that the boundary are sorted from largest to smallest polygon
+    pol_lengths = [len(poldf) for _, poldf in df.groupby("POLY_ID")]
+    assert all(
+        pol_lengths[i] >= pol_lengths[i + 1] for i in range(len(pol_lengths) - 1)
+    )
 
 
 def test_regsurface_get_dataframe(default_surface):


### PR DESCRIPTION
PR to address #1160. 
After changing to using shapely to create boundary polygons for surfaces in #1140, it seems shapely in some cases fails to create the polygons. Leading to the "POLY_ID" error which derives from an empty polygon and hence an empty dataframe.

This PR should add more robustness to the boundary polygons method by:
1. Added noding of the linestrings before running the polygonize function to handle potensial crossing lines. See https://github.com/shapely/shapely/issues/1736

2. Fixing a bug that sometimes created small triangular polygons along the boundary. This cleans up the dataset before running the shapely polygonize function. (This was the case for our complex test case, hence some adjustment was needed there.) 

   -    <img src="https://github.com/equinor/xtgeo/assets/61694854/14f95e93-600b-4bb2-a7bb-7c278e62f6f7" width=70% >

4. Lastly if in case the dataset is truly unfit for creating a boundary and the polygon returns empty, a more proper error massage is returned before coming to the confusing "POLY_ID" one.

