### PR TITLE
ENH: Add grid boundary polygons

### DIFF
--- a/docs/tutorial/examples_rms.rst
+++ b/docs/tutorial/examples_rms.rst
@@ -277,6 +277,54 @@ Edit a 3D grid porosity inside polygons
    # Save in RMS as a new icon
    myprop.to_roxar(project, "Reek_sim", "NEWPORO_setinside")
 
+   
+Create region polygons from the grid
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   import numpy as np
+   import xtgeo
+
+   GNAME = "Simgrid"
+   REGNAME = "Regions"
+   ZONENAME = "Zone"
+
+   CB_FOLDER = "Region_polygons"
+   
+   ZONE_FILTER = [2, 3]
+
+   # factor that controls the precision of the polygons
+   # higher value gives smoother more convex polygons.
+   ALPHA_FACTOR = 1 
+
+   def create_region_polygons():
+       """Create region polygons and store them on the clipboard"""
+       grid = xtgeo.grid_from_roxar(project, GNAME)
+       reg = xtgeo.gridproperty_from_roxar(project, GNAME, REGNAME)
+       zone = xtgeo.gridproperty_from_roxar(project, GNAME, ZONENAME)
+
+       for regnum, regname in reg.codes.items():
+           print(f"Creating boundary polygon for region {regname}")
+
+           # create a filter array to extract boundaries for the region
+           # zone was used as filter to minimice overlap of the final polygons
+           # Note: a layer filter could have been applied instead
+           filter_array = (reg.values==regnum) & (np.isin(zone.values, [ZONE_FILTER]))
+
+           pol = grid.get_boundary_polygons(ALPHA_FACTOR, filter_array=filter_array)
+
+           # in case of several polygons, keep only the largest (first)
+           pol.filter_byid([0])
+
+           # store polygon to the clipboard
+           pol.to_roxar(project, regname, CB_FOLDER, stype="clipboard")
+
+        print(f"Complete, region polygons are stored under clipboard folder {CB_FOLDER}")
+
+    if __name__ == "__main__":
+        create_region_polygons()
+
 .. _hybrid:
 
 Make a hybrid grid

--- a/src/xtgeo/grid3d/_grid_boundary.py
+++ b/src/xtgeo/grid3d/_grid_boundary.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from xtgeo.xyz.points import Points
+from xtgeo.xyz.polygons import Polygons
+
+if TYPE_CHECKING:
+    from xtgeo.grid3d import Grid
+
+
+def create_boundary(
+    grid: Grid,
+    alpha_factor: float = 1.0,
+    convex: bool = False,
+    simplify: bool | dict[str, Any] = True,
+    filter_array: np.ndarray | None = None,
+) -> Polygons:
+    """Create boundary polygons for a grid."""
+
+    xval, yval, zval = (prop.values for prop in grid.get_xyz())
+
+    if filter_array is not None:
+        if filter_array.shape != grid.dimensions:
+            raise ValueError(
+                "The filter_array needs to have the same dimensions as the grid. "
+                f"Found: {filter_array.shape=} {grid.dimensions=}"
+            )
+        xval = np.ma.masked_where(~filter_array, xval)
+        yval = np.ma.masked_where(~filter_array, yval)
+        zval = np.ma.masked_where(~filter_array, zval)
+
+    # for performance create average points along layers
+    xval = np.ma.mean(xval, axis=2)
+    yval = np.ma.mean(yval, axis=2)
+    zval = np.ma.mean(zval, axis=2)
+
+    xyz_values = np.column_stack(
+        (
+            xval[~xval.mask].ravel(),
+            yval[~yval.mask].ravel(),
+            zval[~zval.mask].ravel(),
+        )
+    )
+
+    pol = Polygons.boundary_from_points(
+        points=Points(xyz_values),
+        alpha_factor=alpha_factor,
+        alpha=_estimate_alpha_for_grid(grid),
+        convex=convex,
+    )
+
+    if simplify:
+        if isinstance(simplify, bool):
+            pol.simplify(tolerance=0.1)
+        elif isinstance(simplify, dict) and "tolerance" in simplify:
+            pol.simplify(**simplify)
+        else:
+            raise ValueError("Invalid values for simplify keyword")
+
+    return pol
+
+
+def _estimate_alpha_for_grid(grid: Grid) -> float:
+    """
+    Estimate an alpha based on grid resolution.
+    Max dx and dy is used as basis for calculation to ensure that the alpha
+    computed is always high enough to prevent polygons appearing around areas
+    of the grid where cells have larger than average dx/dy increments.
+    """
+    dx, dy = grid.get_dx(), grid.get_dy()
+    xinc, yinc = dx.values.max(), dy.values.max()
+    return math.ceil(math.sqrt(xinc**2 + yinc**2) / 2)

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from functools import lru_cache
 from math import atan2, degrees
 from typing import TYPE_CHECKING, Literal
 
@@ -134,6 +135,7 @@ def get_dz(
     )
 
 
+@lru_cache(maxsize=1)
 def get_dx(
     self: Grid, name: str = "dX", asmasked: bool = False, metric: METRIC = "horizontal"
 ) -> GridProperty:
@@ -166,6 +168,7 @@ def get_dx(
     )
 
 
+@lru_cache(maxsize=1)
 def get_dy(
     self: Grid, name: str = "dY", asmasked: bool = False, metric: METRIC = "horizontal"
 ) -> GridProperty:
@@ -384,6 +387,7 @@ def get_ijk_from_points(
     return list(mydataframe.itertuples(index=False, name=None))
 
 
+@lru_cache(maxsize=1)
 def get_xyz(
     self: Grid,
     names: tuple[str, str, str] = ("X_UTME", "Y_UTMN", "Z_TVDSS"),

--- a/tests/test_grid3d/test_grid_operations.py
+++ b/tests/test_grid3d/test_grid_operations.py
@@ -278,3 +278,36 @@ def test_reduce_to_one_layer(grd):
     grd.reduce_to_one_layer()
 
     assert grd.nlay == 1
+
+
+def test_get_boundary_polygons_grid_outline():
+    """Test getting a boundary for a grid."""
+
+    grid = xtgeo.grid_from_file(EMEGFILE)
+
+    boundary = grid.get_boundary_polygons(simplify=False)
+    df = boundary.get_dataframe(copy=False)
+
+    assert df["POLY_ID"].nunique() == 1
+    assert df[boundary.yname].min() == pytest.approx(5930003, abs=2)
+    assert df[boundary.yname].max() == pytest.approx(5937505, abs=2)
+    assert df[boundary.xname].min() == pytest.approx(459078, abs=2)
+    assert df[boundary.xname].max() == pytest.approx(466984, abs=2)
+
+
+def test_get_boundary_polygons_grid_region():
+    """Test getting a boundary for a region in a grid."""
+
+    grid = xtgeo.grid_from_file(EMEGFILE)
+    reg = xtgeo.gridproperty_from_file(EMERFILE, name="REGION")
+
+    boundary = grid.get_boundary_polygons(
+        simplify=False, filter_array=(reg.values == 1)
+    )
+    df = boundary.get_dataframe(copy=False)
+
+    assert df["POLY_ID"].nunique() == 1
+    assert df[boundary.yname].min() == pytest.approx(5932092, abs=2)
+    assert df[boundary.yname].max() == pytest.approx(5936223, abs=2)
+    assert df[boundary.xname].min() == pytest.approx(460344, abs=2)
+    assert df[boundary.xname].max() == pytest.approx(463765, abs=2)


### PR DESCRIPTION
PR which resolves #925 and adds a new method `grid.get_boundary_polygons()` for extracting boundary polygons from a grid instance.

Key notes:
- kept same signature as the `surf.get_boundary_polygons()` except added an optional `filter_array` argument for defining a specific part of the grid that the boundary should be extracted from e.g. a region or around specific conditions.
- estimates an appropriate alpha value using the xinc and yinc from the grid.
- to speed up performance the xy points are averaged over layers in the grid to reduce number of points before doing the triangulation.
- added caching of the `grid.get_xyz()`,  `grid.get_dx()` and `grid.get_dy()` to speed up performance when the method is run multiple times in loop with different filter_array input (e.g. looping over and creating region polygons).
<img src="https://github.com/equinor/xtgeo/assets/61694854/a4bfc09e-62ca-48d9-b64c-21a24fdaef40" width=70%>

This new method forms the basis for a potential future method with a more simplified user-interface for extracting boundaries around unique values in a discrete property. This should be added after adding support for polygon attributes #900, so that we can have a `NAME` attribute that corresponds to the code name. 
