### PR TITLE
CLN: Use `FileFormat` for exports

### DIFF
--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -923,14 +923,18 @@ class Cube:
 
         fobj.check_folder(raiseerror=OSError)
 
-        if fformat == "segy":
+        if fformat in FileFormat.SEGY.value:
             _cube_export.export_segy(self, fobj.name, pristine=pristine, engine=engine)
         elif fformat == "rms_regular":
             _cube_export.export_rmsreg(self, fobj.name)
         elif fformat == "xtgregcube":
             _cube_export.export_xtgregcube(self, fobj.name)
         else:
-            raise ValueError(f"File format fformat={fformat} is not supported")
+            extensions = FileFormat.extensions_string([FileFormat.SEGY])
+            raise InvalidFileFormatError(
+                f"File format {fformat} is invalid for type Cube. "
+                f"Supported formats are {extensions}."
+            )
 
     @deprecation.deprecated(
         deprecated_in="3.6",

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -14,6 +14,7 @@ import numpy.ma as ma
 
 import xtgeo
 from xtgeo.common import XTGDescription, null_logger
+from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.common.sys import generic_hash
 from xtgeo.common.types import Dimensions
 from xtgeo.common.version import __version__
@@ -848,31 +849,38 @@ class Grid(_Grid3D):
         if not _gfile.memstream:
             _gfile.check_folder(raiseerror=OSError)
 
-        valid_formats = {
-            "roff": ["roff", "roff_binary", "roff_bin", "roffbin"],
-            "roff_ascii": ["roff_ascii", "roff_asc", "roffasc"],
-            "grdecl": ["grdecl"],
-            "bgrdecl": ["bgrdecl"],
-            "egrid": ["egrid"],
-            "fegrid": ["fegrid"],
-        }
-
-        if fformat in valid_formats["roff"]:
+        if fformat in FileFormat.ROFF_BINARY.value:
             _grid_export.export_roff(self, _gfile.name, "binary")
-        elif fformat in valid_formats["roff_ascii"]:
+        elif fformat in FileFormat.ROFF_ASCII.value:
             _grid_export.export_roff(self, _gfile.name, "ascii")
-        elif fformat in valid_formats["grdecl"]:
+        elif fformat in FileFormat.GRDECL.value:
             _grid_export.export_grdecl(self, _gfile.name, 1)
-        elif fformat in valid_formats["bgrdecl"]:
+        elif fformat in FileFormat.BGRDECL.value:
             _grid_export.export_grdecl(self, _gfile.name, 0)
-        elif fformat in valid_formats["egrid"]:
+        elif fformat in FileFormat.EGRID.value:
             _grid_export.export_egrid(self, _gfile.name)
-        elif fformat in valid_formats["fegrid"]:
+        elif fformat in FileFormat.FEGRID.value:
             _grid_export.export_fegrid(self, _gfile.name)
+        elif fformat in FileFormat.HDF.value:
+            self.to_hdf(gfile)
+        elif fformat in FileFormat.XTG.value:
+            self.to_xtgf(gfile)
         else:
-            raise ValueError(
-                f"Invalid file format: {fformat}, valid options are: "
-                f"{', '.join(v for vv in valid_formats.values() for v in vv)}"
+            extensions = FileFormat.extensions_string(
+                [
+                    FileFormat.ROFF_BINARY,
+                    FileFormat.ROFF_ASCII,
+                    FileFormat.EGRID,
+                    FileFormat.FEGRID,
+                    FileFormat.GRDECL,
+                    FileFormat.BGRDECL,
+                    FileFormat.XTG,
+                    FileFormat.HDF,
+                ]
+            )
+            raise InvalidFileFormatError(
+                f"File format {fformat} is invalid for type Grid. "
+                f"Supported formats are {extensions}."
             )
 
     def to_hdf(

--- a/src/xtgeo/io/_file.py
+++ b/src/xtgeo/io/_file.py
@@ -58,11 +58,27 @@ class FileFormat(Enum):
     FUNRST = ["funrst"]
     GRDECL = ["grdecl"]
     BGRDECL = ["bgrdecl"]
-    IRAP_BINARY = ["irap_binary", "irap_bin", "rms_binary", "irapbin", "gri"]
-    IRAP_ASCII = ["irap_ascii", "irap_asc", "rms_ascii", "irapasc", "fgr"]
+    IRAP_BINARY = [
+        "irap_binary",
+        "irap_bin",
+        "irapbinary",
+        "irap",
+        "rms_binary",
+        "irapbin",
+        "gri",
+    ]
+    IRAP_ASCII = [
+        "irapascii",
+        "irap_txt",
+        "irap_ascii",
+        "irap_asc",
+        "rms_ascii",
+        "irapasc",
+        "fgr",
+    ]
     HDF = ["hdf", "hdf5", "h5"]
     SEGY = ["segy", "sgy", "segy.*"]
-    STORM = ["storm"]
+    STORM = ["storm", "storm_binary"]
     ZMAP_ASCII = ["zmap", "zmap+", "zmap_ascii", "zmap-ascii", "zmap-asc", "zmap.*"]
     IJXYZ = ["ijxyz"]
     PETROMOD = ["pmd", "petromod"]

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -1186,30 +1186,43 @@ class RegularSurface:
         else:
             engine = "python"
 
-        if fformat in ("irap_ascii", "irapascii", "irap_txt", "irapasc"):
+        if fformat in FileFormat.IRAP_ASCII.value:
             _regsurf_export.export_irap_ascii(self, mfile, engine=engine)
 
-        elif fformat in ("irap_binary", "irapbinary", "irapbin", "irap", "gri"):
+        elif fformat in FileFormat.IRAP_BINARY.value:
             _regsurf_export.export_irap_binary(self, mfile, engine=engine)
 
-        elif "zmap" in fformat:
+        elif fformat in FileFormat.ZMAP_ASCII.value:
             _regsurf_export.export_zmap_ascii(self, mfile, engine=engine)
 
-        elif fformat == "storm_binary":
+        elif fformat in FileFormat.STORM.value:
             _regsurf_export.export_storm_binary(self, mfile)
 
-        elif fformat == "petromod":
+        elif fformat in FileFormat.PETROMOD.value:
             _regsurf_export.export_petromod_binary(self, mfile, pmd_dataunits)
 
-        elif fformat == "ijxyz":
+        elif fformat in FileFormat.IJXYZ.value:
             _regsurf_export.export_ijxyz_ascii(self, mfile)
 
-        # developing, in prep and experimental!
         elif fformat == "xtgregsurf":
             _regsurf_export.export_xtgregsurf(self, mfile)
 
         else:
-            raise ValueError(f"Invalid file format: {fformat}")
+            extensions = FileFormat.extensions_string(
+                [
+                    FileFormat.IRAP_BINARY,
+                    FileFormat.IRAP_ASCII,
+                    FileFormat.IJXYZ,
+                    FileFormat.PETROMOD,
+                    FileFormat.ZMAP_ASCII,
+                    FileFormat.XTG,
+                    FileFormat.HDF,
+                ]
+            )
+            raise InvalidFileFormatError(
+                f"File format {fformat} is invalid for type RegularSurface. "
+                f"Supported formats are {extensions}."
+            )
 
         logger.info("Export RegularSurface to file or memstream... done")
 

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -13,10 +13,11 @@ import pandas as pd
 from xtgeo import _cxtgeo
 from xtgeo.common._xyz_enum import _AttrType
 from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_LIMIT
+from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.common.log import null_logger
 from xtgeo.common.version import __version__
 from xtgeo.common.xtgeo_dialog import XTGDescription
-from xtgeo.io._file import FileWrapper
+from xtgeo.io._file import FileFormat, FileWrapper
 from xtgeo.metadata.metadata import MetaDataWell
 from xtgeo.xyz import _xyz_data
 from xtgeo.xyz.polygons import Polygons
@@ -580,11 +581,25 @@ class Well:
 
         self._ensure_consistency()
 
-        if fformat in (None, "rms_ascii", "rms_asc", "rmsasc", "rmswell"):
+        if not fformat or fformat in (
+            None,
+            "rms_ascii",
+            "rms_asc",
+            "rmsasc",
+            "rmswell",
+        ):
             _well_io.export_rms_ascii(self, wfile.name)
 
-        elif fformat in ("hdf", "hdf5", "h5"):
+        elif fformat in FileFormat.HD5.value:
             self.to_hdf(wfile)
+
+        else:
+            extensions = FileFormat.extensions_string([FileFormat.HDF])
+            raise InvalidFileFormatError(
+                f"File format {fformat} is invalid for a well type. "
+                f"Supported formats are {extensions}, 'rms_ascii', 'rms_asc', "
+                "'rmsasc', 'rmswell'."
+            )
 
         return wfile.file
 

--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -4,8 +4,9 @@ import numpy as np
 import pandas as pd
 
 from xtgeo.common.constants import UNDEF, UNDEF_INT
+from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.common.log import null_logger
-from xtgeo.io._file import FileWrapper
+from xtgeo.io._file import FileFormat, FileWrapper
 
 logger = null_logger(__name__)
 
@@ -219,14 +220,14 @@ def to_file(
         logger.warning("Nothing to export!")
         return ncount
 
-    if fformat is None or fformat in ["xyz", "poi", "pol"]:
+    if fformat is None or fformat in FileFormat.XYZ.value:
         # NB! reuse export_rms_attr function, but no attributes
         # are possible
         ncount = export_rms_attr(
             xyz, pfile.name, attributes=False, pfilter=pfilter, ispolygons=ispolygons
         )
 
-    elif fformat == "rms_attr":
+    elif fformat in FileFormat.RMS_ATTR.value:
         ncount = export_rms_attr(
             xyz,
             pfile.name,
@@ -236,6 +237,12 @@ def to_file(
         )
     elif fformat == "rms_wellpicks":
         ncount = export_rms_wpicks(xyz, pfile.name, hcolumn, wcolumn, mdcolumn=mdcolumn)
+    else:
+        extensions = FileFormat.extensions_string([FileFormat.XYZ, FileFormat.RMS_ATTR])
+        raise InvalidFileFormatError(
+            f"File format {fformat} is invalid for type Points or Polygons. "
+            f"Supported formats are {extensions}, 'rms_wellpicks'."
+        )
 
     if ncount is None:
         ncount = 0


### PR DESCRIPTION
Resolves #1146 

This checks more against the enumerated file formats that xtgeo supports and removes most of the string comparisons. It also adds some extra file formats found along the way, but not all of them. Some formats were left as strings due to some ambiguity.

This is still a bit messy but should be cleaned up further, and in a more unified/centralized way, when importing and exporting is moved to `xtgeo.io`.