### PR TITLE
FIX: Raise on bad GridProperty values

### DIFF
--- a/src/xtgeo/grid3d/_gridprop_value_init.py
+++ b/src/xtgeo/grid3d/_gridprop_value_init.py
@@ -1,4 +1,5 @@
 """GridProperty (not GridProperies) some etc functions"""
+
 from __future__ import annotations
 
 import numbers
@@ -40,6 +41,11 @@ def gridproperty_non_dummy_values(
         _values = initial_gridprop_values_from_scalar(dimensions, values, isdiscrete)
     elif isinstance(values, np.ndarray):
         _values = initial_gridprop_values_from_array(dimensions, values, isdiscrete)
+    else:
+        raise ValueError(
+            f"Cannot create GridProperty with values type '{type(values).__name__}.' "
+            "Expected an nd.array, float, int, or None"
+        )
 
     if gridlike:
         if isinstance(gridlike, xtgeo.grid3d.Grid):

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -133,6 +133,11 @@ def test_create_actnum():
     assert x.nactive < x.ntotal
 
 
+def test_gridprop_init_unknown_values():
+    with pytest.raises(ValueError, match="Cannot create GridProperty with values type"):
+        GridProperty(ncol=3, nrow=2, nlay=1, values={1, 2, 3})
+
+
 def test_undef():
     """Test getting UNDEF value"""
     xx = GridProperty(ncol=3, nrow=2, nlay=1, values=np.array([1, 2, 3, 4, 5, 6]))


### PR DESCRIPTION
Resolves #1115 

When a GridProperty was created with values of an unsupported type it would try to return `_values`, which was unbound due to being unhandled.