### PR TITLE
FIX: Ensure cube scanning paths are strings

### DIFF
--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -1055,7 +1055,7 @@ class Cube:
             logger.info("TMP file name is %s", outfile)
             oflag = True
 
-        _cube_import._scan_segy_trace(sfile, outfile=outfile)
+        _cube_import._scan_segy_trace(str(sfile), outfile=str(outfile))
 
         if oflag:
             # pass
@@ -1092,7 +1092,7 @@ class Cube:
             logger.info("TMP file name is %s", outfile)
             flag = True
 
-        _cube_import._scan_segy_header(sfile, outfile=outfile)
+        _cube_import._scan_segy_header(str(sfile), outfile=str(outfile))
 
         if flag:
             logger.info("OUTPUT to screen...")

--- a/tests/test_cube/test_cube.py
+++ b/tests/test_cube/test_cube.py
@@ -118,14 +118,14 @@ def test_import_guess_segy(tmp_path, cube):
 def test_segy_scanheader(tmp_path, smallcube, testdata_path):
     """Scan SEGY and report header, using XTGeo internal reader."""
     smallcube.scan_segy_header(
-        str(testdata_path / SFILE1), outfile=str(tmp_path / "cube_scanheader")
+        testdata_path / SFILE1, outfile=tmp_path / "cube_scanheader"
     )
 
 
 def test_segy_scantraces(tmp_path, smallcube, testdata_path):
     """Scan and report SEGY first and last trace (internal reader)."""
     smallcube.scan_segy_traces(
-        str(testdata_path / SFILE1), outfile=str(tmp_path / "cube_scantraces")
+        testdata_path / SFILE1, outfile=tmp_path / "cube_scantraces"
     )
 
 
@@ -271,11 +271,11 @@ def test_segy_cube_scan(tmp_path, capsys, snapshot):
 
     xcu.to_file(tmp_path / "reek_cube.segy", engine="xtgeo")
 
-    Cube.scan_segy_header(str(tmp_path / "reek_cube.segy"))
+    Cube.scan_segy_header(tmp_path / "reek_cube.segy")
     out, _ = capsys.readouterr()
     snapshot.assert_match(out, "reek_cube_scan_header.txt")
 
-    Cube.scan_segy_traces(str(tmp_path / "reek_cube.segy"))
+    Cube.scan_segy_traces(tmp_path / "reek_cube.segy")
     out, _ = capsys.readouterr()
     snapshot.assert_match(out, "reek_cube_scan_traces.txt")
 


### PR DESCRIPTION
Resolves #1178 

Notably this does not work with streams -- but it never did and requires a larger refactor in order to do so. Fixing that is probably not worth while for code that will soon be deprecated.