### PR TITLE
ENH: add Grid() function get_heights_above_ffl.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            python-version: 3.8
+            python-version: "3.10"
           - os: macos-latest
             python-version: 3.12
           - os: windows-latest
@@ -33,7 +33,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix macos HDF5 library for pytables install (works for python >= 3.10)
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          brew update
+          brew install hdf5
+
       - name: Setup xtgeo
+        env:
+          # relevant for macos builds only
+          HDF5_DIR: /opt/homebrew
         uses: "./.github/actions/setup_xtgeo"
         with:
           python-version: ${{ matrix.python-version }}

--- a/src/lib/include/xtgeo/grid3d.hpp
+++ b/src/lib/include/xtgeo/grid3d.hpp
@@ -19,7 +19,15 @@ grid_cell_volumes(const size_t ncol,
                   const py::array_t<int> &actnumsv,
                   const int precision,
                   const bool asmasked);
-
+std::tuple<py::array_t<double>, py::array_t<double>, py::array_t<double>>
+grid_height_above_ffl(const size_t ncol,
+                      const size_t nrow,
+                      const size_t nlay,
+                      const py::array_t<double> &coordsv,
+                      const py::array_t<float> &zcornsv,
+                      const py::array_t<int> &actnumsv,
+                      const py::array_t<float> &ffl,
+                      const size_t option);
 std::vector<double>
 cell_corners(const size_t i,
              const size_t j,
@@ -38,6 +46,8 @@ init(py::module &m)
 
     m_grid3d.def("grid_cell_volumes", &grid_cell_volumes,
                  "Compute the bulk volume of cell.");
+    m_grid3d.def("grid_height_above_ffl", &grid_height_above_ffl,
+                 "Compute the height above a FFL (free fluid level).");
     m_grid3d.def("cell_corners", &cell_corners,
                  "Get a vector containing the corners of a cell.");
 }

--- a/src/lib/src/grid3d/grid.cpp
+++ b/src/lib/src/grid3d/grid.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>  // Include for std::max
 #include <cstddef>
+#include <tuple>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
@@ -53,6 +55,78 @@ grid_cell_volumes(const size_t ncol,
         }
     }
     return cellvols;
+}
+
+/*
+ * Compute cell height above ffl (free fluid level), as input to water saturation. Will
+ * return hbot, htop, hmid (bottom of cell, top of cell, midpoint), but compute method
+ * depends on option: 1: cell center above ffl, 2: cell corners above ffl
+ *
+ * @param ncol Grid dimensions ncol/nx
+ * @param nrow Grid dimensions nrow/ny
+ * @param nlay Grid dimensions nlay/nz
+ * @param coordsv Grid Z coordinates vector
+ * @param zcornsv Grid Z corners vector
+ * @param actumsv Active cells vector
+ * @param ffl Free fluid level per cell
+ * @param option 1: Use cell centers, 2 use cell corners
+ * @return 3 arrays, top, bot, mid; all delta heights above ffl
+ */
+
+std::tuple<py::array_t<double>, py::array_t<double>, py::array_t<double>>
+grid_height_above_ffl(const size_t ncol,
+                      const size_t nrow,
+                      const size_t nlay,
+                      const py::array_t<double> &coordsv,
+                      const py::array_t<float> &zcornsv,
+                      const py::array_t<int> &actnumsv,
+                      const py::array_t<float> &ffl,
+                      const size_t option)
+{
+    pybind11::array_t<double> htop({ ncol, nrow, nlay });
+    pybind11::array_t<double> hbot({ ncol, nrow, nlay });
+    pybind11::array_t<double> hmid({ ncol, nrow, nlay });
+    auto htop_ = htop.mutable_data();
+    auto hbot_ = hbot.mutable_data();
+    auto hmid_ = hmid.mutable_data();
+    auto actnumsv_ = actnumsv.data();
+    auto ffl_ = ffl.data();
+
+    for (size_t i = 0; i < ncol; i++) {
+        for (size_t j = 0; j < nrow; j++) {
+            for (size_t k = 0; k < nlay; k++) {
+                size_t idx = i * nrow * nlay + j * nlay + k;
+                if (actnumsv_[idx] == 0) {
+                    htop_[idx] = UNDEF;
+                    hbot_[idx] = UNDEF;
+                    hmid_[idx] = UNDEF;
+                    continue;
+                }
+                auto cr =
+                  grid3d::cell_corners(i, j, k, ncol, nrow, nlay, coordsv, zcornsv);
+                if (option == 1) {
+                    htop_[idx] = ffl_[idx] - 0.25 * (cr[2] + cr[5] + cr[8] + cr[11]);
+                    hbot_[idx] = ffl_[idx] - 0.25 * (cr[14] + cr[17] + cr[20] + cr[23]);
+                } else if (option == 2) {
+                    double upper = cr[2];
+                    for (size_t indx = 5; indx <= 11; indx += 3) {
+                        upper = std::min(upper, cr[indx]);
+                    }
+                    htop_[idx] = ffl_[idx] - upper;
+
+                    double lower = cr[14];
+                    for (size_t indx = 17; indx <= 23; indx += 3) {
+                        lower = std::max(lower, cr[indx]);
+                    }
+                    hbot_[idx] = ffl_[idx] - lower;
+                }
+                htop_[idx] = std::max(htop_[idx], 0.0);
+                hbot_[idx] = std::max(hbot_[idx], 0.0);
+                hmid_[idx] = 0.5 * (htop_[idx] + hbot_[idx]);
+            }
+        }
+    }
+    return std::make_tuple(htop, hbot, hmid);
 }
 
 }  // namespace xtgeo::grid3d

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -235,6 +235,61 @@ def get_bulk_volume(
     )
 
 
+def get_heights_above_ffl(
+    grid: Grid,
+    ffl: GridProperty,
+    option: Literal[
+        "cell_center_above_ffl", "cell_corners_above_ffl"
+    ] = "cell_center_above_ffl",
+) -> tuple[GridProperty, GridProperty, GridProperty]:
+    """Compute delta heights for cell top, bottom and midpoints above a given level."""
+
+    valid_options = ("cell_center_above_ffl", "cell_corners_above_ffl")
+    if option not in valid_options:
+        raise ValueError(
+            f"The option key <{option}> is invalid, must be one of {valid_options}"
+        )
+
+    grid._xtgformat2()
+
+    htop_arr, hbot_arr, hmid_arr = _internal.grid3d.grid_height_above_ffl(
+        grid.ncol,
+        grid.nrow,
+        grid.nlay,
+        grid._coordsv.ravel(),
+        grid._zcornsv.ravel(),
+        grid._actnumsv.ravel(),
+        ffl.values.ravel(),
+        1 if option == "cell_center_above_ffl" else 2,
+    )
+
+    htop = GridProperty(
+        ncol=grid.ncol,
+        nrow=grid.nrow,
+        nlay=grid.nlay,
+        name="htop",
+        values=htop_arr,
+        discrete=False,
+    )
+    hbot = GridProperty(
+        ncol=grid.ncol,
+        nrow=grid.nrow,
+        nlay=grid.nlay,
+        name="hbot",
+        values=hbot_arr,
+        discrete=False,
+    )
+    hmid = GridProperty(
+        ncol=grid.ncol,
+        nrow=grid.nrow,
+        nlay=grid.nlay,
+        name="hmid",
+        values=hmid_arr,
+        discrete=False,
+    )
+    return htop, hbot, hmid
+
+
 def get_ijk(
     self: Grid,
     names: tuple[str, str, str] = ("IX", "JY", "KZ"),

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -2008,6 +2008,32 @@ class Grid(_Grid3D):
             self, name=name, asmasked=asmasked, precision=precision
         )
 
+    def get_heights_above_ffl(
+        self,
+        ffl: GridProperty,
+        option: str = "cell_center_above_ffl",
+    ) -> tuple[GridProperty, GridProperty, GridProperty]:
+        """Returns 3 properties: htop, hbot and hmid, primarely for use in Sw models."
+
+        Args:
+            ffl: Free fluid level e.g. FWL (or level whatever is required; a level from
+                which cells above will be shown as delta heights (positive), while
+                cells below will have 0.0 values.
+            option: How to compute values, as either "cell_center_above_ffl" or
+                "cell_corners_above_ffl". The first one looks at cell Z centerlines, and
+                compute the top, the bottom and the midpoint. The second will look at
+                cell corners, using the uppermost corner for top, and the lowermost
+                corner for bottom. In both cases, values are modified if cell is
+                intersected with the provided ffl.
+
+        Returns:
+            (htop, hbot, hmid) delta heights, as xtgeo GridProperty objects
+
+        .. versionadded:: 3.9
+
+        """
+        return _grid_etc1.get_heights_above_ffl(self, ffl=ffl, option=option)
+
     def get_ijk(
         self,
         names: tuple[str, str, str] = ("IX", "JY", "KZ"),

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -528,6 +528,26 @@ def test_benchmark_bulkvol(benchmark):
     benchmark(run)
 
 
+def test_cell_height_above_ffl(testdata_path):
+    """Test cell heights above ffl."""
+    grd = xtgeo.grid_from_file(testdata_path / GRIDQC1)
+
+    ffl = xtgeo.GridProperty(grd, values=1700)
+
+    htop, hbot, hmid = grd.get_heights_above_ffl(ffl, option="cell_center_above_ffl")
+
+    assert htop.values[6, 4, 0] == pytest.approx(65.8007)
+    assert hbot.values[6, 4, 0] == pytest.approx(54.1729)
+    assert hmid.values[6, 4, 0] == pytest.approx(59.9868)
+    assert hbot.values[4, 0, 0] == pytest.approx(0.0)
+
+    htop, hbot, hmid = grd.get_heights_above_ffl(ffl, option="cell_corners_above_ffl")
+
+    assert htop.values[4, 5, 0] == pytest.approx(44.8110)
+    assert hbot.values[4, 5, 0] == pytest.approx(0.0)
+    assert hmid.values[4, 5, 0] == pytest.approx(22.4055)
+
+
 def test_bad_egrid_ends_before_kw(tmp_path):
     egrid_file = tmp_path / "test.egrid"
     with open(egrid_file, "wb") as fh:


### PR DESCRIPTION
This is a PR to address an urgent need in am ongoing top-prioritized project, where current solutions using numpy operations combined with existing `xtgeo` functionality become too memory demanding. The C++ function here in this PR will solve this in a much more lean and memory and CPU friendly manner. 

There is also a commit that modifies the macos tests. They fail initially due installation issues with pytables and HDF5. 