### PR TITLE
BLD: skip macos builds for CIBW and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,6 @@ jobs:
         os_arch: 
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]
-          - [macos-latest, macosx_x86_64]
-          - [macos-14, macosx_arm64]
-        exclude:
-          - os_arch: [macos-14, macosx_arm64]
-            cibw_python: cp39
     env:
       CIBW_BUILD: ${{ matrix.cibw_python }}-${{ matrix.os_arch[1] }}
 


### PR DESCRIPTION
There are recurrent problems on building on Macos, which are hard to debug. Need a quite rapid release and propose to skip Mac OS wheels for now.