### PR TITLE
TST: Fix various warnings emitted from tests

### DIFF
--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -424,7 +424,7 @@ def get_ijk_from_points(
     proplist[columnnames[2]] = karr
 
     mydataframe = pd.DataFrame.from_dict(proplist)
-    mydataframe.replace(UNDEF_INT, -1, inplace=True)
+    mydataframe = mydataframe.replace(UNDEF_INT, -1)
 
     if fmt == "float":
         mydataframe[columnnames[0]] = mydataframe[columnnames[0]].astype("float")
@@ -432,9 +432,9 @@ def get_ijk_from_points(
         mydataframe[columnnames[2]] = mydataframe[columnnames[2]].astype("float")
 
     if undef != -1:
-        mydataframe[columnnames[0]].replace(-1, undef, inplace=True)
-        mydataframe[columnnames[1]].replace(-1, undef, inplace=True)
-        mydataframe[columnnames[2]].replace(-1, undef, inplace=True)
+        mydataframe[columnnames[0]] = mydataframe[columnnames[0]].replace(-1, undef)
+        mydataframe[columnnames[1]] = mydataframe[columnnames[1]].replace(-1, undef)
+        mydataframe[columnnames[2]] = mydataframe[columnnames[2]].replace(-1, undef)
 
     if dataframe:
         return mydataframe

--- a/src/xtgeo/grid3d/_grid_wellzone.py
+++ b/src/xtgeo/grid3d/_grid_wellzone.py
@@ -102,11 +102,11 @@ def report_zone_mismatch(
 
     for zname in (zonelogname, zmodel):
         if skiprange:  # needed check; du to a bug in pandas version 0.21 .. 0.23
-            df[zname].replace(skiprange, -888, inplace=True)
-        df[zname].fillna(-999, inplace=True)
+            df[zname] = df[zname].replace(skiprange, -888)
+        df[zname] = df[zname].fillna(-999)
         if perflogname:
             if perflogname in df.columns:
-                df[perflogname].replace(np.nan, -1, inplace=True)
+                df[perflogname] = df[perflogname].replace(np.nan, -1)
                 pfr1, pfr2 = perflogrange
                 df[zname] = np.where(df[perflogname] < pfr1, -899, df[zname])
                 df[zname] = np.where(df[perflogname] > pfr2, -899, df[zname])
@@ -114,7 +114,7 @@ def report_zone_mismatch(
                 return None
         if filterlogname:
             if filterlogname in df.columns:
-                df[filterlogname].replace(np.nan, -1, inplace=True)
+                df[filterlogname] = df[filterlogname].replace(np.nan, -1)
                 ffr1, ffr2 = filterlogrange
                 df[zname] = np.where(df[filterlogname] < ffr1, -919, df[zname])
                 df[zname] = np.where(df[filterlogname] > ffr2, -919, df[zname])

--- a/src/xtgeo/well/_well_io.py
+++ b/src/xtgeo/well/_well_io.py
@@ -109,7 +109,7 @@ def import_rms_ascii(
 
     dfr = pd.read_csv(
         wfile.file,
-        delim_whitespace=True,
+        sep=r"\s+",
         skiprows=lnum,
         header=None,
         names=xlognames_all,
@@ -220,8 +220,7 @@ def export_rms_ascii(self, wfile, precision=4):
             print(f"{lname} {self.get_logtype(lname)} {usewrec}", file=fwell)
 
     # now export all logs as pandas framework
-    tmpdf = self._wdata.data.copy()
-    tmpdf.fillna(value=-999, inplace=True)
+    tmpdf = self._wdata.data.copy().fillna(value=-999)
 
     # make the disc as is np.int
     for lname in self.wlogtypes:

--- a/src/xtgeo/xyz/_xyz_data.py
+++ b/src/xtgeo/xyz/_xyz_data.py
@@ -300,15 +300,14 @@ class _XYZData:
         for name, attr_type in self._attr_types.items():
             if attr_type == _AttrType.CONT.value:
                 logger.debug("Replacing CONT undef...")
-                self._df[name].replace(
+                self._df.loc[:, name] = self._df[name].replace(
                     self._undef_cont,
                     np.float64(UNDEF_CONT).astype(self._floatbits),
-                    inplace=True,
                 )
             else:
                 logger.debug("Replacing INT undef...")
-                self._df[name].replace(
-                    self._undef_disc, np.int32(UNDEF_DISC), inplace=True
+                self._df.loc[:, name] = self._df[name].replace(
+                    self._undef_disc, np.int32(UNDEF_DISC)
                 )
         logger.info("Processed dataframe: %s", list(self._df.dtypes))
 
@@ -579,7 +578,7 @@ class _XYZData:
             distance.append(math.hypot((previous_x - x), (y - previous_y)))
             previous_x, previous_y = x, y
 
-        self._df[_AttrName.R_HLEN_NAME.value] = pd.Series(
+        self._df.loc[:, _AttrName.R_HLEN_NAME.value] = pd.Series(
             np.cumsum(distance), index=self._df.index
         )
         self.ensure_consistency()

--- a/src/xtgeo/xyz/_xyz_oper.py
+++ b/src/xtgeo/xyz/_xyz_oper.py
@@ -147,18 +147,18 @@ def operation_polygons_v2(self, poly, value, opname="add", inside=True, where=Tr
     dataframe = self.get_dataframe()
 
     if opname == "add":
-        dataframe[self.zname][tmpdf._TMP == 1] += value
+        dataframe.loc[tmpdf._TMP == 1, self.zname] += value
     elif opname == "sub":
-        dataframe[self.zname][tmpdf._TMP == 1] -= value
+        dataframe.loc[tmpdf._TMP == 1, self.zname] -= value
     elif opname == "mul":
-        dataframe[self.zname][tmpdf._TMP == 1] *= value
+        dataframe.loc[tmpdf._TMP == 1, self.zname] *= value
     elif opname == "div":
         if value != 0.0:
-            dataframe[self.zname][tmpdf._TMP == 1] /= value
+            dataframe.loc[tmpdf._TMP == 1, self.zname] /= value
         else:
-            dataframe[self.zname][tmpdf._TMP == 1] = 0.0
+            dataframe.loc[tmpdf._TMP == 1, self.zname] = 0.0
     elif opname == "set":
-        dataframe[self.zname][tmpdf._TMP == 1] = value
+        dataframe.loc[tmpdf._TMP == 1, self.zname] = value
     elif opname == "eli":
         dataframe = dataframe[tmpdf._TMP == 0]
         dataframe.reset_index(inplace=True, drop=True)
@@ -561,7 +561,14 @@ def extend(self, distance, nsamples, addhlen=True):
 
         # setting row0[2] as row1[2] is intentional, as this shall be a 2D lenght!
         ier, newx, newy, _ = _cxtgeo.x_vector_linint2(
-            row1[0], row1[1], row1[2], row0[0], row0[1], row1[2], distance, 12
+            row1.iloc[0],
+            row1.iloc[1],
+            row1.iloc[2],
+            row0.iloc[0],
+            row0.iloc[1],
+            row1.iloc[2],
+            distance,
+            12,
         )
 
         if ier != 0:
@@ -582,7 +589,14 @@ def extend(self, distance, nsamples, addhlen=True):
 
         # setting row1[2] as row0[2] is intentional, as this shall be a 2D lenght!
         ier, newx, newy, _ = _cxtgeo.x_vector_linint2(
-            row0[0], row0[1], row0[2], row1[0], row1[1], row0[2], distance, 11
+            row0.iloc[0],
+            row0.iloc[1],
+            row0.iloc[2],
+            row1.iloc[0],
+            row1.iloc[1],
+            row0.iloc[2],
+            distance,
+            11,
         )
 
         rown[self.xname] = newx

--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -174,7 +174,6 @@ def _add_well_pick_to_project(project: Any, well_pick_data: dict, trajectory: st
     rox_wps.append(mypicks)
 
 
-@pytest.mark.requires_roxar
 @pytest.fixture(name="rms_project_path", scope="module")
 def fixture_create_project(tmp_data_dir, roxinstance, testdata_path) -> str:
     """Create a temporary RMS project for testing, populate with basic data.
@@ -256,7 +255,6 @@ def fixture_create_project(tmp_data_dir, roxinstance, testdata_path) -> str:
     return tmp_project_path
 
 
-@pytest.mark.requires_roxar
 @pytest.fixture(scope="module")
 def wells_from_rms(rms_project_path) -> list[xtgeo.Well]:
     """Read wells from roxar project and return a list."""
@@ -279,7 +277,6 @@ def wells_from_rms(rms_project_path) -> list[xtgeo.Well]:
     return wlist
 
 
-@pytest.mark.requires_roxar
 @pytest.fixture(scope="function")
 def rms_project(rms_project_path) -> Any:
     """Get the 'magic' project object from RMS (similar when being inside RMS).

--- a/tests/test_surface/test_forks.py
+++ b/tests/test_surface/test_forks.py
@@ -19,6 +19,4 @@ def test_surface_forks():
     )
     stdout, stderr = process.communicate()
     ret_code = process.wait()
-    if ret_code:
-        raise Exception(stderr)
-    return stdout
+    assert ret_code == 0, stderr

--- a/tests/test_well/test_well.py
+++ b/tests/test_well/test_well.py
@@ -872,8 +872,8 @@ def test_create_surf_distance_log_more(tmp_path, loadwell1, testdata_path):
 
     for zname in (zonelogname, zmodel):
         if skiprange:  # needed check; du to a bug in pandas version 0.21 .. 0.23
-            dfr[zname].replace(skiprange, -888, inplace=True)
-        dfr[zname].fillna(-999, inplace=True)
+            dfr[zname] = dfr[zname].replace(skiprange, -888)
+        dfr[zname] = dfr[zname].fillna(-999)
     # now there are various variotions on how to count mismatch:
     # dfuse 1: count matches when zonelogname is valid (exclude -888)
     # dfuse 2: count matches when zonelogname OR zmodel are valid (exclude < -888


### PR DESCRIPTION
Resolves #1216 

Reduces the number of warnings from 4000 to 1500. The remaining ones are mostly self-emitted for xtgeo 4.0 deprecations, with a few numpy ones.

A big-looking change is the removal of `inplace=` arguments. See the commit comment for a longer description, but tl;dr this didn't actually do things inplace but on a copy internally. See https://github.com/pandas-dev/pandas/pull/51466