### PR TITLE
BLD: Build against numpy >= 2.0.0rc1

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,7 +16,7 @@ jobs:
   mypy:
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python: 
-          - ['3.8', cp38] 
           - ['3.9', cp39]
           - ['3.10', cp310]
           - ['3.11', cp311]
@@ -26,8 +25,6 @@ jobs:
           - [macos-13, macosx_x86_64]  # macos-13 is the last x86-64 runner
           - [macos-latest, macosx_arm64]  # macos-latest is always arm64 going forward
         exclude:
-          - os_arch: [macos-latest, macosx_arm64]
-            python: ['3.8', cp38]
           - os_arch: [macos-latest, macosx_arm64]
             python: ['3.9', cp39]
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,13 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
             python-version: "3.10"
           - os: macos-latest
             python-version: 3.12
-          - os: windows-latest
-            python-version: 3.8
           - os: windows-latest
             python-version: 3.12
 
@@ -82,18 +80,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {
-              name: "RMS 12.1.4, 13.0.3, 13.1.0, 14.1.1",
-              os: ubuntu-20.04,
-              python: 3.8.6,
-              pip: 23.2.1,
-              wheel: 0.37.1,
-              setuptools: 63.4.3,
-              matplotlib: 3.3.2,
-              numpy: 1.19.2,
-              pandas: 1.1.3,
-              scipy: 1.5.3,
-            }
           - {
               name: "RMS 14.2",
               os: ubuntu-latest,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,7 @@ requires = [
     "pybind11",
     "scikit-build-core[pyproject]>=0.10",
     "swig",
-    "numpy==1.19.2; python_version == '3.8'",
-    "numpy==1.19.5; python_version == '3.9'",
-    "numpy==1.21.6; python_version == '3.10'",
-    "numpy==1.23.5; python_version == '3.11'",
-    "numpy==1.26.2; python_version == '3.12'",
+    "numpy>=2.0.0rc1",
 ]
 build-backend = "scikit_build_core.build"
 
@@ -53,7 +49,7 @@ dependencies = [
     "hdf5plugin>=2.3",
     "joblib",
     "matplotlib>=3.3",
-    "numpy<2",
+    "numpy",
     "pandas>=1.1",
     "resfo>=4.0.0",
     "roffio>=0.0.2",

--- a/src/xtgeo/grid3d/_ecl_inte_head.py
+++ b/src/xtgeo/grid3d/_ecl_inte_head.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Any, Literal, cast
 
 import numpy as np
+import numpy.typing as npt
 
 from ._ecl_output_file import Phases, Simulator, TypeOfGrid, UnitSystem
 
@@ -29,7 +30,7 @@ class InteHead:
     True
     """
 
-    def __init__(self, values: np.ndarray[np.int_, Any]) -> None:
+    def __init__(self, values: npt.NDArray[np.int_]) -> None:
         """Create an InteHead from the corresponding array.
 
         Args:

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -116,7 +116,12 @@ def test_assign():
     # this shall now broadcast the value 33 to all activecells
     x.isdiscrete = True
     x.values = 33
-    assert x.dtype == np.int32
+
+    numpy_version = tuple(map(int, np.__version__.split(".")))
+    if numpy_version >= (2, 0, 0):
+        assert x.dtype == np.int64
+    else:
+        assert x.dtype == np.int32
 
     x.isdiscrete = False
     x.values = 44.0221


### PR DESCRIPTION
Resolves #1209

This unpins numpy<2 and builds the SWIG C library against numpy >= 2.0.0rc1. Versions of numpy major 2 are backward compatible with numpy 1 with respect to the C api. Hence we should not see issues in environments where numpy<2 may be maintained for years to come, i.e. RMS environments.

The numpy SWIG bindings committed in this repository are not out-of-date in a way that would break compatibility. The last update to them in numpy's repository was two years ago from the time of this commit.

As a consequence of supporting numpy>=2 this PR deprecates support for Python 3.8, which hits EOL on October 2024.