### PR TITLE
CI: propose timeout in forks and pure python i/o for test robustness

### DIFF
--- a/examples/multiprocess_surfs.py
+++ b/examples/multiprocess_surfs.py
@@ -58,7 +58,7 @@ def _get_regsurff(i):
     sfile = TESTFILE
 
     logger.info("File is %s", sfile)
-    rf = xtgeo.surface_from_file(sfile)
+    rf = xtgeo.surface_from_file(sfile, fformat="irap_binary", engine="python")
     logger.info("End %s", i)
     return rf
 


### PR DESCRIPTION
The described problem is Windows Python 3.12 test timeouts #1229 but it appears to occur randomly.  This solution is a bit of a "fumbling in the dark, and cross fingers".

Propose:

1. Timeouts in the actual tests
2. Change surface_from_file() to use pure python code, not "cxtgeo". It *may* be that the C binding are causing the issues we see here.

