### PR TITLE
CI: skip --generate-plots on windows due to random TCL install errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,13 @@ jobs:
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
 
-      - name: Set matplotlib backend to avoid potential issues with TCL/TK installation
-        run: echo "MPLBACKEND=Agg" >> $GITHUB_ENV
-
-      - name: Run tests
+      - name: Run tests (Linux/macOS)
+        if: ${{ matrix.os != 'windows-latest' }}
         run: pytest -n 4 tests --disable-warnings --generate-plots
+
+      - name: Run tests (Windows, skip plotting due to random TCL/TK issues)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: pytest -n 4 tests --disable-warnings
 
   hypothesis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Needed to reopen #1239 

This PR tries to solve this matter by just disabling `--generate-plots` when running windows-latest in Github actions.