### PR TITLE
MAINT: resolve import roxar vs import rmsapi

### DIFF
--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -35,11 +35,6 @@ def _xprint(msg):
 
 _xprint("XTGEO __init__ ...")
 
-ROXAR = True
-try:
-    import roxar
-except ImportError:
-    ROXAR = False
 
 try:
     from xtgeo.common.version import __version__, version
@@ -159,7 +154,7 @@ warnings.filterwarnings("default", category=DeprecationWarning, module="xtgeo")
 _xprint("XTGEO __init__ done")
 
 # Remove symbols imported for internal use
-del os, platform, sys, timeit, warnings, TIME0, DEBUG, ROXAR, _timer, _xprint
+del os, platform, sys, timeit, warnings, TIME0, DEBUG, _timer, _xprint
 
 # Let type-checkers know what is exported
 __all__ = [

--- a/src/xtgeo/cube/_cube_roxapi.py
+++ b/src/xtgeo/cube/_cube_roxapi.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.roxutils import RoxUtils
+from xtgeo.roxutils._roxar_loader import roxar
 
 xtg = XTGeoDialog()
 
@@ -132,11 +133,6 @@ def export_cube_roxapi(
 def _roxapi_export_cube(
     self, proj, rox, name, folder=None, domain="time", compression=("wavelet", 5)
 ):  # type: ignore # pragma: no cover
-    try:
-        import roxar  # type: ignore
-    except ImportError:
-        roxar = None
-
     logger.info(
         "There are issues with compression %s, hence it is ignored", compression
     )

--- a/src/xtgeo/roxutils/_roxar_loader.py
+++ b/src/xtgeo/roxutils/_roxar_loader.py
@@ -1,0 +1,54 @@
+"""Loading rmsapi or roxar module based on availability"""
+
+import importlib
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
+
+# Roxar*Type are placeholders for the actual types which are not known at this point,
+# and these may be replaced in modules by e.g:
+# ---------
+#     from xtgeo.roxutils._roxar_loader import roxar
+#     if TYPE_CHECKING:
+#         from xtgeo.grid3d.grid_property import GridProperty
+#         if roxar is not None:
+#            from roxar.grids import Grid3D as RoxarGridType
+# ---------
+
+
+def load_module(module_name: str) -> Optional[Any]:
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return None
+
+
+rmsapi = load_module("rmsapi")
+roxar = rmsapi if rmsapi else load_module("roxar")
+
+if rmsapi:
+    roxar_well_picks = load_module("rmsapi.well_picks")
+    roxar_jobs = load_module("rmsapi.jobs")
+    roxar_grids = load_module("rmsapi.grids")
+else:
+    roxar_well_picks = load_module("roxar.well_picks")
+    roxar_jobs = load_module("roxar.jobs")
+    roxar_grids = load_module("roxar.grids")
+
+# Use TypeVar correctly
+RoxarType = TypeVar("RoxarType")
+RoxarGridType = TypeVar("RoxarGridType")
+RoxarGrid3DType = TypeVar("RoxarGrid3DType")
+RoxarWellpicksType = TypeVar("RoxarWellpicksType")
+RoxarJobsType = TypeVar("RoxarJobsType")
+
+if TYPE_CHECKING:
+    if roxar is not None:
+        import roxar.grids as RoxarGridType  # noqa  # type: ignore
+        from roxar.grids import Grid3D as RoxarGrid3DType  # noqa  # type: ignore
+        from roxar.jobs import Jobs as RoxarJobsType  # noqa  # type: ignore
+        from roxar.well_picks import WellPicks as RoxarWellpicksType  # noqa  # type: ignore
+
+# Explicitly type the roxar* as Optional to indicate it may be None
+roxar: Optional[Any] = roxar
+roxar_grids: Optional[Any] = roxar_grids
+roxar_well_picks: Optional[Any] = roxar_well_picks
+roxar_jobs: Optional[Any] = roxar_jobs

--- a/src/xtgeo/roxutils/_roxutils_etc.py
+++ b/src/xtgeo/roxutils/_roxutils_etc.py
@@ -1,11 +1,8 @@
 """Private module for etc functions"""
 
-import contextlib
-
-with contextlib.suppress(ImportError):
-    import roxar
-
 from xtgeo.common.log import null_logger
+
+from ._roxar_loader import roxar
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/roxutils/roxutils.py
+++ b/src/xtgeo/roxutils/roxutils.py
@@ -1,16 +1,12 @@
 """Module for simplifying various operation in the Roxar python interface."""
 
-import contextlib
-
 from packaging.version import parse as versionparse
-
-with contextlib.suppress(ImportError):
-    import roxar
 
 from xtgeo.common.log import null_logger
 from xtgeo.common.xtgeo_dialog import XTGeoDialog
 
 from . import _roxutils_etc
+from ._roxar_loader import roxar
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)

--- a/src/xtgeo/surface/_regsurf_roxapi.py
+++ b/src/xtgeo/surface/_regsurf_roxapi.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from xtgeo.common.log import null_logger
 from xtgeo.roxutils import RoxUtils
+from xtgeo.roxutils._roxar_loader import roxar
 
 logger = null_logger(__name__)
 
@@ -214,12 +215,6 @@ def _roxapi_export_surface(
             )
         # here a workound; trends.surfaces are read-only in Roxar API, but is seems
         # that load() in RMS is an (undocumented?) workaround...
-        try:
-            import roxar
-        except ImportError as err:
-            raise ImportError(
-                "roxar not available, this functionality is not available"
-            ) from err
 
         roxsurf = proj.trends.surfaces[name]
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -234,12 +229,6 @@ def _roxapi_export_surface(
 
 def _xtgeo_to_roxapi_grid(self):  # pragma: no cover
     # Create a 2D grid
-    try:
-        import roxar
-    except ImportError as err:
-        raise ImportError(
-            "roxar not available, this functionality is not available"
-        ) from err
 
     return roxar.RegularGrid2D.create(
         x_origin=self.xori,

--- a/src/xtgeo/well/_blockedwell_roxapi.py
+++ b/src/xtgeo/well/_blockedwell_roxapi.py
@@ -9,11 +9,7 @@ from xtgeo.common.constants import INT_MIN
 from xtgeo.common.exceptions import WellNotFoundError
 from xtgeo.common.log import null_logger
 from xtgeo.roxutils import RoxUtils
-
-try:
-    import roxar  # type: ignore
-except ImportError:
-    roxar = None
+from xtgeo.roxutils._roxar_loader import roxar
 
 logger = null_logger(__name__)
 

--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -11,17 +11,16 @@ from typing import Any, Literal, Type, cast
 import numpy as np
 import pandas as pd
 
-from xtgeo import ROXAR  # type: ignore
 from xtgeo.common._xyz_enum import _AttrName
 from xtgeo.common.constants import UNDEF, UNDEF_INT, UNDEF_INT_LIMIT, UNDEF_LIMIT
 from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileWrapper
 from xtgeo.roxutils import RoxUtils
+from xtgeo.roxutils._roxar_loader import RoxarType, roxar, roxar_well_picks
 from xtgeo.xyz import _xyz_io, points, polygons
 
-if ROXAR:
-    import roxar
-    import roxar.well_picks as roxwp
+if roxar:
+    roxwp = roxar_well_picks
 
 logger = null_logger(__name__)
 
@@ -127,7 +126,7 @@ def _check_presence_in_project(
 
 
 def import_xyz_roxapi(
-    project: roxar.project,
+    project: RoxarType.project,
     name: str,
     category: str | list[str],
     stype: str = "horizons",
@@ -190,13 +189,6 @@ def _roxapi_import_xyz_viafile(
     However, attributes will be present in Roxar API from RMS version 12, and this
     routine should be replaced!
     """
-
-    try:
-        import roxar
-    except ImportError as err:
-        raise ImportError(
-            "roxar not available, this functionality is not available"
-        ) from err
 
     rox_xyz = _get_roxitem(
         rox,
@@ -328,7 +320,7 @@ def _add_attributes_to_dataframe(
 
 def export_xyz_roxapi(
     self: points.Points | polygons.Polygons,
-    project: roxar.Project,
+    project: RoxarType.Project,
     name: str,
     category: str | list[str] | None,
     stype: str,
@@ -378,13 +370,6 @@ def _roxapi_export_xyz_viafile(
     """Set points/polys within RMS with attributes, using file workaround"""
 
     logger.warning("Realisation %s not in use", realisation)
-
-    try:
-        import roxar
-    except ImportError as err:
-        raise ImportError(
-            "roxar not available, this functionality is not available"
-        ) from err
 
     is_polygons = isinstance(self, polygons.Polygons)
     roxxyz = _get_roxitem(
@@ -622,7 +607,7 @@ def _roxapi_import_wellpicks(
 
 
 def _create_dataframe_from_wellpicks(
-    well_picks: list[roxar.well_picks.WellPick],
+    well_picks: list[RoxarType.well_picks.WellPick],
     wp_category: Literal["fault", "horizon"],
     attribute_types: dict[str, str],
 ) -> pd.DataFrame:
@@ -748,8 +733,8 @@ def _roxapi_export_xyz_well_picks(
 
 
 def _get_well_pick_set(
-    rox: RoxUtils, well_pick_set: str, rox_wp_type: roxar.WellPickType
-) -> roxar.well_picks.WellPickSet:
+    rox: RoxUtils, well_pick_set: str, rox_wp_type: RoxarType.WellPickType
+) -> RoxarType.well_picks.WellPickSet:
     """
     Function to retrieve a well pick set object. If the given well pick set
     name is not present, it will be created. Otherwise the current well pick
@@ -768,8 +753,8 @@ def _get_well_pick_set(
 def _get_writeable_well_pick_attributes(
     rox: RoxUtils,
     attribute_types: dict[str, str],
-    rox_wp_type: roxar.WellPickType,
-) -> dict[str, roxar.well_picks.WellPickAttribute]:
+    rox_wp_type: RoxarType.WellPickType,
+) -> dict[str, RoxarType.well_picks.WellPickAttribute]:
     """
     Function to retrive a dictionary of regular and user-defined
     roxar WellPickAttribute's. Only writable attributes are

--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -11,7 +11,6 @@ ran in e.g. public Github actions.
 
 from __future__ import annotations
 
-import contextlib
 import pathlib
 from typing import Any
 
@@ -20,9 +19,7 @@ import pytest
 
 import xtgeo
 from xtgeo.common import XTGeoDialog, null_logger
-
-with contextlib.suppress(ImportError):
-    import roxar
+from xtgeo.roxutils._roxar_loader import roxar, roxar_jobs, roxar_well_picks
 
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
@@ -94,10 +91,9 @@ def _run_blocked_wells_job(
 
     The log names (Poro, Perm, etc) are here hardcoded in params dictionary.
     """
-    import roxar.jobs
 
     # create the block well job and add it to the grid
-    bw_job = roxar.jobs.Job.create(
+    bw_job = roxar_jobs.Job.create(
         ["Grid models", gmname, "Grid"], "Block Wells", "API_BW_Job"
     )
 
@@ -161,7 +157,7 @@ def _run_blocked_wells_job(
 
 def _add_well_pick_to_project(project: Any, well_pick_data: dict, trajectory: str):
     """Add well picks to the project."""
-    import roxar.well_picks as wp
+    wp = roxar_well_picks
 
     mypicks = [
         wp.WellPick.create(


### PR DESCRIPTION
Closes #1258 

This would allow to import `rmsapi as roxar` when present, i.e. alias it to `roxar` without `DeprecationWarning`.

I have kept the wording `roxar`, although it may be more optimal at a later stage to refer to `rmsapi`. However this will also trigger a debate if e.g. `xtgeo.surface_from_roxar()` should be replaced with `xtgeo.surface_from_rmsapi()` or `...rms()`. But we can take that later.  