### PR TITLE
ENH: optimize speed for surface_from_grid method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
         uses: "./.github/actions/setup_testdata"
 
       - name: Run just tests marked big
-        run: XTG_BIGTEST=1 pytest -n 4 tests --disable-warnings -m bigtest --generate-plots
+        run: OMP_NUM_THREADS=1 XTG_BIGTEST=1 pytest -n 4 tests --disable-warnings -m bigtest --generate-plots
 
   codecov:
     runs-on: ubuntu-latest

--- a/examples/grid3d_prop_as_map.py
+++ b/examples/grid3d_prop_as_map.py
@@ -16,31 +16,13 @@ def make_map():
     # read grid
     grd = xtgeo.grid_from_file(GNAMEROOT + ".EGRID")
 
-    _ = xtgeo.gridproperty_from_file(GNAMEROOT + ".INIT", name="PORO", grid=grd)
+    poro = xtgeo.gridproperty_from_file(GNAMEROOT + ".INIT", name="PORO", grid=grd)
 
-    df = grd.get_dataframe()
-
-    # make a map from the grid geometry to be used as a template
-
-    surf = xtgeo.surface_from_grid3d(grd)
-
-    # get only bottom layer:
-    lastlayer = df["KZ"].max()
-    df = df[df["KZ"] == lastlayer].reset_index()
-
-    # prepare as input to a Points dataframe (3 columns X Y Z)
-    df = df[["X_UTME", "Y_UTMN", "PORO"]].copy()
-
-    points = xtgeo.Points()
-    points.zname = "PORO"
-    points.set_dataframe(df)
-
-    # do gridding:
-    surf.gridding(points)
+    poro_surface = xtgeo.surface_from_grid3d(grd, property=poro, where="base")
 
     # optional plot
     if "SKIP_PLOT" not in os.environ:
-        surf.quickplot()
+        poro_surface.quickplot()
 
 
 if __name__ == "__main__":

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -12,6 +12,10 @@ find_package(
 include(UseSWIG)
 find_package(pybind11 REQUIRED)
 
+if(UNIX AND NOT APPLE)
+  find_package(OpenMP REQUIRED)
+endif()
+
 message(STATUS "Python executable     : ${Python_EXECUTABLE}")
 message(STATUS "Python include dirs   : ${Python_INCLUDE_DIRS}")
 message(STATUS "numpy include path    : ${Python_NumPy_INCLUDE_DIRS}")
@@ -43,6 +47,13 @@ pybind11_add_module(
   "${SRC}/regsurf/utilities.cpp"
   ${SOURCES})
 target_include_directories(_internal PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include)
+# Link OpenMP
+
+if(UNIX
+   AND NOT APPLE
+   AND OpenMP_CXX_FOUND)
+  target_link_libraries(_internal PRIVATE OpenMP::OpenMP_CXX)
+endif()
 
 message(STATUS "Compiling swig bindings")
 

--- a/src/lib/include/xtgeo/geometry.hpp
+++ b/src/lib/include/xtgeo/geometry.hpp
@@ -65,7 +65,7 @@ constexpr int TETRAHEDRON_VERTICES[4][6][4] = {
 };
 
 inline double
-hexahedron_dz(const std::vector<double> &corners)
+hexahedron_dz(const std::array<double, 24> &corners)
 {
     // TODO: This does not account for overall zflip ala Petrel or cells that
     // are malformed
@@ -86,7 +86,7 @@ triangle_area(const std::array<double, 2> &p1,
 }
 
 double
-hexahedron_volume(const std::vector<double> &corners, const int precision);
+hexahedron_volume(const std::array<double, 24> &corners, const int precision);
 
 bool
 is_xy_point_in_polygon(const double x,

--- a/src/lib/include/xtgeo/grid3d.hpp
+++ b/src/lib/include/xtgeo/grid3d.hpp
@@ -28,7 +28,7 @@ grid_height_above_ffl(const size_t ncol,
                       const py::array_t<int> &actnumsv,
                       const py::array_t<float> &ffl,
                       const size_t option);
-std::vector<double>
+std::array<double, 24>
 cell_corners(const size_t i,
              const size_t j,
              const size_t k,
@@ -39,33 +39,19 @@ cell_corners(const size_t i,
              const py::array_t<float> &zcornsv);
 
 std::vector<double>
-get_corners_minmax(std::vector<double> &corners);
+get_corners_minmax(std::array<double, 24> &corners);
 
 bool
 is_xy_point_in_cell(const double x,
                     const double y,
-                    const size_t i,
-                    const size_t j,
-                    const size_t k,
-                    const size_t ncol,
-                    const size_t nrow,
-                    const size_t nlay,
-                    const py::array_t<double> &coordsv,
-                    const py::array_t<float> &zcornsv,
-                    const int option);
+                    const std::array<double, 24> &corners,
+                    int option);
 
 double
 get_depth_in_cell(const double x,
                   const double y,
-                  const size_t i,
-                  const size_t j,
-                  const size_t k,
-                  const size_t ncol,
-                  const size_t nrow,
-                  const size_t nlay,
-                  const py::array_t<double> &coordsv,
-                  const py::array_t<float> &zcornsv,
-                  const int option);
+                  const std::array<double, 24> &corners,
+                  int option);
 
 inline void
 init(py::module &m)

--- a/src/lib/include/xtgeo/numerics.hpp
+++ b/src/lib/include/xtgeo/numerics.hpp
@@ -1,7 +1,16 @@
 #ifndef XTGEO_NUMERICS_HPP_
 #define XTGEO_NUMERICS_HPP_
+#include <pybind11/pybind11.h>
+#include <limits>
+
+namespace py = pybind11;
 
 namespace xtgeo::numerics {
+
+constexpr double UNDEF_DOUBLE = std::numeric_limits<double>::max();
+constexpr double EPSILON = std::numeric_limits<double>::epsilon();
+constexpr double TOLERANCE = 1e-6;
+constexpr double QUIET_NAN = std::numeric_limits<double>::quiet_NaN();
 
 template<typename T>
 struct Vec3
@@ -13,6 +22,16 @@ inline Vec3<double>
 lerp3d(double x1, double y1, double z1, double x2, double y2, double z2, double t)
 {
     return Vec3<double>{ x1 + t * (x2 - x1), y1 + t * (y2 - y1), z1 + t * (z2 - z1) };
+}
+
+inline void
+init(py::module &m)
+{
+    auto m_numerics = m.def_submodule("numerics", "Internal functions for numerics.");
+
+    m_numerics.attr("UNDEF_DOUBLE") = UNDEF_DOUBLE;
+    m_numerics.attr("EPSILON") = EPSILON;
+    m_numerics.attr("TOLERANCE") = TOLERANCE;
 }
 
 }  // namespace xtgeo::numerics

--- a/src/lib/include/xtgeo/regsurf.hpp
+++ b/src/lib/include/xtgeo/regsurf.hpp
@@ -44,7 +44,11 @@ find_cell_range(const double xmin,
                 const size_t nrow,
                 const int expand);
 
-std::tuple<py::array_t<int>, py::array_t<int>, py::array_t<double>>
+std::tuple<py::array_t<int>,
+           py::array_t<int>,
+           py::array_t<double>,
+           py::array_t<double>,
+           py::array_t<bool>>
 sample_grid3d_layer(const size_t ncol,
                     const size_t nrow,
                     const double xori,
@@ -59,8 +63,8 @@ sample_grid3d_layer(const size_t ncol,
                     const py::array_t<float> &zcornsv,
                     const py::array_t<int> &actnumsv,
                     const size_t klayer,
-                    const int option,
-                    const int activeonly);
+                    const int index_position,
+                    const int num_threads);
 inline void
 init(py::module &m)
 {

--- a/src/lib/src/common/geometry/interpolate.cpp
+++ b/src/lib/src/common/geometry/interpolate.cpp
@@ -1,5 +1,6 @@
 #include <xtgeo/constants.hpp>
 #include <xtgeo/geometry.hpp>
+#include <xtgeo/numerics.hpp>
 
 namespace xtgeo::geometry {
 
@@ -28,7 +29,7 @@ interpolate_z_triangles(const double x,
     double z_estimated = std::numeric_limits<double>::quiet_NaN();
 
     // Check if the point is in the triangle
-    if (std::abs(total_area - (area1 + area2 + area3)) < xtgeo::constants::EPSILON) {
+    if (std::abs(total_area - (area1 + area2 + area3)) < numerics::TOLERANCE) {
         double w1 = area1 / total_area;
         double w2 = area2 / total_area;
         double w3 = area3 / total_area;
@@ -45,7 +46,7 @@ interpolate_z_triangles(const double x,
     total_area = triangle_area(p1_2d, p3_2d, p4_2d);
 
     // Check if the point is in the triangle
-    if (std::abs(total_area - (area1 + area2 + area3)) < xtgeo::constants::EPSILON) {
+    if (std::abs(total_area - (area1 + area2 + area3)) < numerics::TOLERANCE) {
         double w1 = area1 / total_area;
         double w2 = area2 / total_area;
         double w3 = area3 / total_area;
@@ -86,7 +87,7 @@ interpolate_z_4p_regular(const double x,
 
     // Quick check if the point is inside the quadrilateral; note ordering of points
     if (!is_xy_point_in_quadrilateral(x, y, p1, p2, p4, p3)) {
-        return std::numeric_limits<double>::quiet_NaN();
+        return numerics::QUIET_NAN;
     }
 
     // Extract coordinates
@@ -127,7 +128,7 @@ interpolate_z_4p(const double x,
 {
     // Quick check if the point is inside the quadrilateral
     if (!is_xy_point_in_quadrilateral(x, y, p1, p2, p4, p3)) {
-        return std::numeric_limits<double>::quiet_NaN();
+        return numerics::QUIET_NAN;
     }
 
     double z1 = interpolate_z_triangles(x, y, p1, p2, p3, p4);

--- a/src/lib/src/common/geometry/volumes.cpp
+++ b/src/lib/src/common/geometry/volumes.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/stl.h>
 #include <vector>
 #include <xtgeo/geometry.hpp>
+#include <xtgeo/numerics.hpp>
 #include <xtgeo/xtgeo.h>
 
 namespace xtgeo::geometry {
@@ -28,10 +29,10 @@ namespace xtgeo::geometry {
  * @return The volume of the hexahadron
  */
 double
-hexahedron_volume(const std::vector<double> &corners, const int precision)
+hexahedron_volume(const std::array<double, 24> &corners, const int precision)
 {
     // Avoid cells that collapsed in some way
-    if (hexahedron_dz(corners) < std::numeric_limits<double>::epsilon()) {
+    if (hexahedron_dz(corners) < numerics::EPSILON) {
         return 0.0;
     }
 

--- a/src/lib/src/cube/cube.cpp
+++ b/src/lib/src/cube/cube.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <xtgeo/numerics.hpp>
 
 namespace py = pybind11;
 
@@ -131,14 +132,14 @@ cube_stats_along_z(const size_t ncol,
                 meanabsv_(i, j) = sum_abs / n_items;
                 sumabsv_(i, j) = sum_abs;
             } else {
-                minv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                maxv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                meanv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                varv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                rmsv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                maxabsv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                meanabsv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                sumabsv_(i, j) = std::numeric_limits<double>::quiet_NaN();
+                minv_(i, j) = numerics::QUIET_NAN;
+                maxv_(i, j) = numerics::QUIET_NAN;
+                meanv_(i, j) = numerics::QUIET_NAN;
+                varv_(i, j) = numerics::QUIET_NAN;
+                rmsv_(i, j) = numerics::QUIET_NAN;
+                maxabsv_(i, j) = numerics::QUIET_NAN;
+                meanabsv_(i, j) = numerics::QUIET_NAN;
+                sumabsv_(i, j) = numerics::QUIET_NAN;
             }
 
             // Compute statistics for positive values
@@ -147,9 +148,9 @@ cube_stats_along_z(const size_t ncol,
                 meanposv_(i, j) = sum_pos / n_items_pos;
                 sumposv_(i, j) = sum_pos;
             } else {
-                maxposv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                meanposv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                sumposv_(i, j) = std::numeric_limits<double>::quiet_NaN();
+                maxposv_(i, j) = numerics::QUIET_NAN;
+                meanposv_(i, j) = numerics::QUIET_NAN;
+                sumposv_(i, j) = numerics::QUIET_NAN;
             }
 
             // Compute statistics for negative values
@@ -158,9 +159,9 @@ cube_stats_along_z(const size_t ncol,
                 meannegv_(i, j) = sum_neg / n_items_neg;
                 sumnegv_(i, j) = sum_neg;
             } else {
-                maxnegv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                meannegv_(i, j) = std::numeric_limits<double>::quiet_NaN();
-                sumnegv_(i, j) = std::numeric_limits<double>::quiet_NaN();
+                maxnegv_(i, j) = numerics::QUIET_NAN;
+                meannegv_(i, j) = numerics::QUIET_NAN;
+                sumnegv_(i, j) = numerics::QUIET_NAN;
             }
         }
     }

--- a/src/lib/src/init.cpp
+++ b/src/lib/src/init.cpp
@@ -2,6 +2,7 @@
 #include <xtgeo/cube.hpp>
 #include <xtgeo/geometry.hpp>
 #include <xtgeo/grid3d.hpp>
+#include <xtgeo/numerics.hpp>
 #include <xtgeo/regsurf.hpp>
 
 PYBIND11_MODULE(_internal, m)
@@ -13,4 +14,5 @@ PYBIND11_MODULE(_internal, m)
     xtgeo::geometry::init(m);
     xtgeo::grid3d::init(m);
     xtgeo::regsurf::init(m);
+    xtgeo::numerics::init(m);
 }

--- a/src/lib/src/regsurf/sample_grid3d.cpp
+++ b/src/lib/src/regsurf/sample_grid3d.cpp
@@ -1,17 +1,26 @@
 #include <pybind11/pybind11.h>  // always in top, refer to pybind11 docs
 #include <pybind11/numpy.h>
-#include <cmath>  // Include for std::isnan
+#include <cmath>
 #include <cstddef>
+
+#ifdef __linux__
+#include <omp.h>
+#endif
+
+#include <iostream>
 #include <vector>
 #include <xtgeo/grid3d.hpp>
 #include <xtgeo/logging.hpp>
+#include <xtgeo/numerics.hpp>
 #include <xtgeo/regsurf.hpp>
+
 namespace py = pybind11;
 
 namespace xtgeo::regsurf {
 
 /*
- * Sample I J and depths from 3D grid to regularsurface
+ * @brief Sample I J and depths from 3D grid to regularsurface
+ *
  * @param ncol Number of columns in the regular surface
  * @param nrow Number of rows in the regular surface
  * @param xori X origin of the regular surface
@@ -26,12 +35,14 @@ namespace xtgeo::regsurf {
  * @param zcornsv Z corners of the 3D grid
  * @param actnumsv Active cells of the 3D grid
  * @param klayer The layer to sample, base 0
- * @param option Option to sample the top (0) or bottom (1) of the cell
- * @param activeonly If 1, only sample active cells
- * @return Tuple of 3 numpy arrays: I index, J index, Depth
+ * @return Tuple of 5 numpy arrays: I index, J index, Depth_top, Depth_base, Inactive
  */
 
-std::tuple<py::array_t<int>, py::array_t<int>, py::array_t<double>>
+std::tuple<py::array_t<int>,
+           py::array_t<int>,
+           py::array_t<double>,
+           py::array_t<double>,
+           py::array_t<bool>>
 sample_grid3d_layer(const size_t ncol,
                     const size_t nrow,
                     const double xori,
@@ -46,11 +57,17 @@ sample_grid3d_layer(const size_t ncol,
                     const py::array_t<float> &zcornsv,
                     const py::array_t<int> &actnumsv,
                     const size_t klayer,
-                    const int option,
-                    const int activeonly)
+                    const int index_position,  // 0: top, 1: base|bot, 2: center
+                    const int num_threads = -1)
 {
     Logger logger(__func__);
     logger.debug("Sampling 3D grid layer to a regular surface...");
+
+    // clang-format off
+    #ifdef __linux__
+      if (num_threads > 0) omp_set_num_threads(num_threads);
+    #endif
+    // clang-format on
 
     // Check if yinc is negative which may occur if the RegilarSurface is flipped
     if (yinc < 0) {
@@ -60,44 +77,56 @@ sample_grid3d_layer(const size_t ncol,
     // Initialize 2D numpy arrays to store the sampled values
     py::array_t<int> iindex({ ncol, nrow });
     py::array_t<int> jindex({ ncol, nrow });
-    py::array_t<double> depth({ ncol, nrow });
+    py::array_t<double> depth_top({ ncol, nrow });
+    py::array_t<double> depth_bot({ ncol, nrow });
+    py::array_t<bool> inactive({ ncol, nrow });
 
     // Get unchecked access to the arrays
     auto iindex_ = iindex.mutable_unchecked<2>();
     auto jindex_ = jindex.mutable_unchecked<2>();
-    auto depth_ = depth.mutable_unchecked<2>();
+    auto depth_top_ = depth_top.mutable_unchecked<2>();
+    auto depth_bot_ = depth_bot.mutable_unchecked<2>();
+    auto inactive_ = inactive.mutable_unchecked<2>();
 
-    // Set all elements to -1 or nan initially
+    // Set all elements to -1 or undef initially
     std::fill(iindex_.mutable_data(0, 0), iindex_.mutable_data(0, 0) + (ncol * nrow),
               -1);
     std::fill(jindex_.mutable_data(0, 0), jindex_.mutable_data(0, 0) + (ncol * nrow),
               -1);
-    std::fill(depth_.mutable_data(0, 0), depth_.mutable_data(0, 0) + (ncol * nrow),
-              std::numeric_limits<double>::max());
+    std::fill(inactive_.mutable_data(0, 0),
+              inactive_.mutable_data(0, 0) + (ncol * nrow), false);
+
+    std::fill(depth_top_.mutable_data(0, 0),
+              depth_top_.mutable_data(0, 0) + (ncol * nrow), numerics::QUIET_NAN);
+    std::fill(depth_bot_.mutable_data(0, 0),
+              depth_bot_.mutable_data(0, 0) + (ncol * nrow), numerics::QUIET_NAN);
 
     // Loop over the grid
     logger.debug("Looping 3D GRID cell NCOLROW and NROW is", ncolgrid3d, nrowgrid3d);
+
+    // clang-format off
+    #pragma omp parallel for collapse(2) schedule(static)
+    // clang-format on
+
     for (size_t icell = 0; icell < ncolgrid3d; icell++) {
         for (size_t jcell = 0; jcell < nrowgrid3d; jcell++) {
 
-            // Check if the cell is active
-            if (activeonly == 1 & actnumsv.at(icell, jcell, klayer) == 0) {
-                continue;
-            }
             // Get cell corners
             auto corners =
               grid3d::cell_corners(icell, jcell, klayer, ncolgrid3d, nrowgrid3d,
                                    nlaygrid3d, coordsv, zcornsv);
 
             // Find the min/max of the cell corners. This is the bounding box of the
-            // cell and will narrow the search for the points that are within the cell
+            // cell and will narrow the search for the points that are within the
             auto minmax = grid3d::get_corners_minmax(corners);
             auto [xmin, xmax, ymin, ymax, zmin, zmax] = std::tie(
               minmax[0], minmax[1], minmax[2], minmax[3], minmax[4], minmax[5]);
 
-            // Find the range of the cells (expanded 1 cell) in the local map
-            auto [mxmin, mxmax, mymin, mymax] = regsurf::find_cell_range(
-              xmin, xmax, ymin, ymax, xori, yori, xinc, yinc, rotation, ncol, nrow, 1);
+            // Find the range of the cells (expanded <expand> cell) in the local map
+            int expand = 0;
+            auto [mxmin, mxmax, mymin, mymax] =
+              regsurf::find_cell_range(xmin, xmax, ymin, ymax, xori, yori, xinc, yinc,
+                                       rotation, ncol, nrow, expand);
 
             if (mxmin == -1) {
                 // Cell is outside the local map
@@ -111,19 +140,57 @@ sample_grid3d_layer(const size_t ncol,
                     auto p = regsurf::get_xy_from_ij(i, j, xori, yori, xinc, yinc, ncol,
                                                      nrow, rotation);
                     // Check if the point is within the cell
-                    bool is_inside = grid3d::is_xy_point_in_cell(
-                      p.x, p.y, icell, jcell, klayer, ncolgrid3d, nrowgrid3d,
-                      nlaygrid3d, coordsv, zcornsv, option);
+                    bool is_inside_top =
+                      grid3d::is_xy_point_in_cell(p.x, p.y, corners, 0);
 
-                    if (is_inside) {
-                        auto previous_depth = depth_(i, j);
-                        auto new_depth = grid3d::get_depth_in_cell(
-                          p.x, p.y, icell, jcell, klayer, ncolgrid3d, nrowgrid3d,
-                          nlaygrid3d, coordsv, zcornsv, option);
-                        // keep the cell which has the smallest depth (in case of e.g.
-                        // reverse faulting which gives overlapping cells)
-                        if (std::isnan(previous_depth) || new_depth < previous_depth) {
-                            depth_(i, j) = new_depth;
+                    bool is_inside_bot =
+                      grid3d::is_xy_point_in_cell(p.x, p.y, corners, 1);
+
+                    bool is_inside_mid =
+                      grid3d::is_xy_point_in_cell(p.x, p.y, corners, 2);
+
+                    if (is_inside_top && is_inside_bot && !is_inside_mid) {
+                        logger.error(
+                          "BUG? The point is inside both top and bottom but not "
+                          "center of the cell, seen from above. Force set to be same.");
+                        is_inside_mid = is_inside_top;
+                    }
+
+                    if (is_inside_top) {
+                        auto previous_depth_top = depth_top_(i, j);
+                        auto new_depth_top =
+                          grid3d::get_depth_in_cell(p.x, p.y, corners, 0);
+
+                        if (std::isnan(previous_depth_top) ||
+                            new_depth_top < previous_depth_top) {
+                            // Update the depth if the new depth is smaller
+                            depth_top_(i, j) = new_depth_top;
+                        }
+                        if (index_position == 0) {
+                            iindex_(i, j) = icell;
+                            jindex_(i, j) = jcell;
+                        }
+                    }
+                    if (is_inside_bot) {
+                        auto previous_depth_bot = depth_bot_(i, j);
+                        auto new_depth_bot =
+                          grid3d::get_depth_in_cell(p.x, p.y, corners, 1);
+                        if (std::isnan(previous_depth_bot) ||
+                            new_depth_bot < previous_depth_bot) {
+                            depth_bot_(i, j) = new_depth_bot;
+                        }
+                        if (index_position == 1) {
+                            iindex_(i, j) = icell;
+                            jindex_(i, j) = jcell;
+                        }
+                    }
+                    // the mid cell determines the active status and i, j index
+                    if (is_inside_mid) {
+                        // Check if the cell is active or not
+                        if (actnumsv.at(icell, jcell, klayer) == 0) {
+                            inactive_(i, j) = true;
+                        }
+                        if (index_position < 0 || index_position > 1) {
                             iindex_(i, j) = icell;
                             jindex_(i, j) = jcell;
                         }
@@ -134,7 +201,7 @@ sample_grid3d_layer(const size_t ncol,
     }
 
     logger.debug("Sampling 3D grid layer to a regular surface... done");
-    return std::make_tuple(iindex, jindex, depth);
+    return std::make_tuple(iindex, jindex, depth_top, depth_bot, inactive);
 }  // regsurf_sample_grid3d_layer
 
 }  // namespace xtgeo::regsurf

--- a/src/xtgeo/grid3d/_grid3d_fence.py
+++ b/src/xtgeo/grid3d/_grid3d_fence.py
@@ -123,22 +123,22 @@ def _update_tmpvars(self: Grid, force: bool = False) -> None:
         logger.info("Make a tmp onegrid instance... DONE")
         logger.info("Make a set of tmp surfaces for I J locations + depth...")
         self._tmp["topd"] = surface_from_grid3d(
-            one, where="top", property="depth", rfactor=4
+            one, where="top", property="depth", rfactor=4, index_position="top"
         )
         self._tmp["topi"] = surface_from_grid3d(
-            one, where="top", property="i", rfactor=4
+            one, where="top", property="i", rfactor=4, index_position="top"
         )
         self._tmp["topj"] = surface_from_grid3d(
-            one, where="top", property="j", rfactor=4
+            one, where="top", property="j", rfactor=4, index_position="top"
         )
         self._tmp["basd"] = surface_from_grid3d(
-            one, where="base", property="depth", rfactor=4
+            one, where="base", property="depth", rfactor=4, index_position="base"
         )
         self._tmp["basi"] = surface_from_grid3d(
-            one, where="base", property="i", rfactor=4
+            one, where="base", property="i", rfactor=4, index_position="base"
         )
         self._tmp["basj"] = surface_from_grid3d(
-            one, where="base", property="j", rfactor=4
+            one, where="base", property="j", rfactor=4, index_position="base"
         )
 
         self._tmp["topi"].fill()

--- a/tests/test_internal/test_cell_grid3d.py
+++ b/tests/test_internal/test_cell_grid3d.py
@@ -88,17 +88,14 @@ def test_is_xy_point_in_cell(x, y, cell, position, expected):
     """Test the XY point is inside a hexahedron cell, seen from top or base."""
 
     grid = xtgeo.create_box_grid((3, 4, 5))
-
+    corners = _internal.grid3d.cell_corners(
+        *cell, grid.ncol, grid.nrow, grid.nlay, grid._coordsv, grid._zcornsv
+    )
     assert (
         _internal.grid3d.is_xy_point_in_cell(
             x,
             y,
-            *cell,
-            grid.ncol,
-            grid.nrow,
-            grid.nlay,
-            grid._coordsv,
-            grid._zcornsv,
+            corners,
             0 if position == "top" else 1,
         )
         is expected
@@ -119,16 +116,14 @@ def test_get_depth_in_cell(testdata_path, x, y, cell, position, expected):
     # Read the banal6 grid
     grid = xtgeo.grid_from_file(f"{testdata_path}/3dgrids/etc/banal6.roff")
 
+    corners = _internal.grid3d.cell_corners(
+        *cell, grid.ncol, grid.nrow, grid.nlay, grid._coordsv, grid._zcornsv
+    )
     # Get the depth of the first cell
     depth = _internal.grid3d.get_depth_in_cell(
         x,
         y,
-        *cell,
-        grid.ncol,
-        grid.nrow,
-        grid.nlay,
-        grid._coordsv,
-        grid._zcornsv,
+        corners,
         0 if position == "top" else 1,
     )
 

--- a/tests/test_surface/test_regular_surface_vs_grd3d.py
+++ b/tests/test_surface/test_regular_surface_vs_grd3d.py
@@ -108,7 +108,6 @@ def test_surface_from_grd3d_layer(
     surf = xtgeo.surface_from_grid3d(
         grd, template=tmp, property="depth", where="3_base"
     )
-    surf.to_file(tmp_path / "surf_from_grid3d_3base.gri")
     assert surf.values.mean() == pytest.approx(1714.444, abs=0.01)
     if generate_plot:
         surf.quickplot(filename=tmp_path / "surf_from_grid3d_3base.png")
@@ -125,6 +124,20 @@ def test_surface_from_grd3d_layer_native(testdata_path):
     assert depth.ncol == grd.ncol
     assert depth.nrow == grd.nrow
     assert depth.values.mean() == pytest.approx(1701.074, abs=0.01)
+
+
+def test_surface_from_grd3d_layer_raw(testdata_path):
+    """Get multiple returns from a 3D grid layer, for own processing"""
+
+    grd = xtgeo.grid_from_file(testdata_path / RGRD2, fformat="roff")
+
+    template = "native"
+    ii, _, top, _, _ = xtgeo.surface_from_grid3d(
+        grd, template=template, property="raw", where=3
+    )
+    assert ii.shape == (grd.ncol, grd.nrow)
+
+    assert np.nanmean(top) == pytest.approx(1709.754, abs=0.01)
 
 
 def test_surface_from_grd3d_layer_deprecate_mode(testdata_path):


### PR DESCRIPTION
Closes #1262 

# Main elements
* Refactor some C++ vectors with known length to be of type `std::array` instead of `std::vector`. In particular the function that receives the corner coordinates, which has fixed length 24. In a future change, we should consider `structs` in stead
* Alllow top and base and indexes to be returned in the same call
*  Avoid recomputing corner coordinates
* Add OMP pragma for parallel processing (in the first implemention for Linux only)

In a concrete case I have, these changes will in effect change the execution for HC thickness maps fram 4-5 minutes to 10 seconds