### PR TITLE
FIX: remove calls to custom logger in c++ code and revert "big" ci test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
         uses: "./.github/actions/setup_testdata"
 
       - name: Run just tests marked big
-        run: OMP_NUM_THREADS=1 XTG_BIGTEST=1 pytest -n 4 tests --disable-warnings -m bigtest --generate-plots
+        run: XTG_BIGTEST=1 pytest -n 4 tests --disable-warnings -m bigtest --generate-plots
 
   codecov:
     runs-on: ubuntu-latest

--- a/src/lib/src/regsurf/utilities.cpp
+++ b/src/lib/src/regsurf/utilities.cpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <tuple>
 #include <xtgeo/geometry.hpp>
-#include <xtgeo/logging.hpp>
 #include <xtgeo/point.hpp>
 #include <xtgeo/regsurf.hpp>
 


### PR DESCRIPTION
The custom logger made in C++ which applies python's logging is probably too fragile when multithreaded and/or nested calls, and usage is removed for now in the codebase (although keep the class/function until a better solution)

This links to #1262 