### PR TITLE
Pin swig

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "pybind11",
     "scikit-build-core[pyproject]>=0.10",
-    "swig",
+    "swig<4.3.0",
     "numpy==1.19.2; python_version == '3.8'",
     "numpy==1.19.5; python_version == '3.9'",
     "numpy==1.21.6; python_version == '3.10'",


### PR DESCRIPTION
With SWIG 4.3.0, the build fails with
 /tmp/tmpyg6r6r3_/wheel/platlib/cxtgeoPYTHON_wrap.c:6156:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 resultobj = SWIG_Python_AppendOutput(resultobj,(PyObject*)array1);