### PR TITLE
CI: Revert macOS runner pkg-config work-around

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Install HDF5 for macOS arm64
         if: ${{ matrix.os_arch[1] == 'macosx_arm64' }}
         run: |
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew unlink pkg-config@0.29.2
-          brew install pkgconf
-          echo "PKG_CONFIG=$(brew --prefix pkgconf)/bin/pkgconf" >> $GITHUB_ENV
           brew install hdf5
 
       - name: Install cibuildwheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,12 +38,6 @@ jobs:
       - name: Fix macos HDF5 library for pytables install (works for python >= 3.10)
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew unlink pkg-config@0.29.2
-          brew install pkgconf
-          echo "PKG_CONFIG=$(brew --prefix pkgconf)/bin/pkgconf" >> $GITHUB_ENV
           brew install hdf5
 
       - name: Setup xtgeo


### PR DESCRIPTION
Resolves #1272

GitHub has updated their macOS images to install pkgconf over pkg-config.