### PR TITLE
BUG: undef values in grdecl export shall be 0 or 1

### DIFF
--- a/src/xtgeo/grid3d/_gridprop_export.py
+++ b/src/xtgeo/grid3d/_gridprop_export.py
@@ -106,7 +106,8 @@ def _export_grdecl(
     """Export ascii or binary GRDECL"""
     vals = gridprop.values.ravel(order="F")
     if np.ma.isMaskedArray(vals):
-        vals = np.ma.filled(vals, gridprop.undef)
+        undef_export = 1 if gridprop.isdiscrete or "int" in str(dtype) else 0.0
+        vals = np.ma.filled(vals, fill_value=undef_export)
 
     mode = "a" if append else "w"
     if binary:

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -318,6 +318,25 @@ def test_eclinit_simple_importexport(tmp_path, testdata_path):
 
     p2 = xtgeo.gridproperty_from_file(tmp_path / "simple.grdecl", grid=gg, name="PORO2")
     assert p2.name == "PORO2"
+    with open(tmp_path / "simple.grdecl") as f:
+        fields = f.read().split()
+        assert len(fields) == 17
+        assert fields[3] == "0.00000"  # undef cell
+
+    # mark as discrete
+    po.values = 33
+    po.isdiscrete = True
+    po.to_file(
+        tmp_path / "simple_disc.grdecl",
+        fformat="grdecl",
+        dtype=np.int32,
+        name="SOMEDISK",
+        fmt="%12d",
+    )
+    with open(tmp_path / "simple_disc.grdecl") as f:
+        fields = f.read().split()
+        assert len(fields) == 17
+        assert fields[3] == "1"  # undef cell for discrete
 
 
 def test_grdecl_import_reek(tmp_path, testdata_path):


### PR DESCRIPTION
Closes #1279 


Note: It could also be possible to let the user input this value, but that will be a larger change. I propose we add this a patch now and consider future improvements later.

Related to this is also the use of the `isdiscrete` property and `dtype` option in the `to_file()` appears unclear for me now. Perhaps a need for a deeper look into this at some point.