### PR TITLE
BLD: Pin swig<4.3.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,8 @@
 from datetime import date
 
-import xtgeo
 from autoclasstoc import PublicMethods
+
+import xtgeo
 
 version = xtgeo.__version__
 release = xtgeo.__version__

--- a/examples/grid3d_compute_stats.py
+++ b/examples/grid3d_compute_stats.py
@@ -7,6 +7,7 @@ handling and speed.
 from os.path import join as ojn
 
 import numpy.ma as npma
+
 import xtgeo
 
 # from memory_profiler import profile

--- a/examples/grid3d_print_init_csv.py
+++ b/examples/grid3d_print_init_csv.py
@@ -6,6 +6,7 @@ import pathlib
 import tempfile
 
 import numpy as np
+
 import xtgeo
 
 EXPATH = pathlib.Path("../../xtgeo-testdata/3dgrids/reek")

--- a/examples/regsurf_compute_stats.py
+++ b/examples/regsurf_compute_stats.py
@@ -8,6 +8,7 @@ import io
 from os.path import join as ojn
 
 import numpy.ma as npma
+
 import xtgeo
 
 # from memory_profiler import profile

--- a/examples/wellpath_fence_sample.py
+++ b/examples/wellpath_fence_sample.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+
 import xtgeo
 
 TPATH = Path("../xtgeo-testdata")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "pybind11",
     "scikit-build-core[pyproject]",
-    "swig",
+    "swig<4.3.0",
     "numpy==1.19.2; python_version == '3.8'",
     "numpy==1.19.5; python_version == '3.9'",
     "numpy==1.21.6; python_version == '3.10'",

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -101,7 +101,7 @@ def _allow_deprecated_init(func):
                 DeprecationWarning,
             )
             cfile = args[0]
-            fformat = args[1] if len(args) > 1 else kwargs.get("fformat", None)
+            fformat = args[1] if len(args) > 1 else kwargs.get("fformat")
 
             mfile = FileWrapper(cfile)
             fmt = mfile.fileformat(fformat)
@@ -1045,9 +1045,8 @@ class Cube:
         oflag = False
         # if outfile is none, it means that you want to plot on STDOUT
         if outfile is None:
-            fx = tempfile.NamedTemporaryFile(delete=False, prefix="tmpxgeo")
-            fx.close()
-            outfile = fx.name
+            with tempfile.NamedTemporaryFile(delete=False, prefix="tmpxgeo") as fx:
+                outfile = fx.name
             logger.info("TMP file name is %s", outfile)
             oflag = True
 
@@ -1082,9 +1081,8 @@ class Cube:
         flag = False
         # if outfile is none, it means that you want to print on STDOUT
         if outfile is None:
-            fc = tempfile.NamedTemporaryFile(delete=False, prefix="tmpxtgeo")
-            fc.close()
-            outfile = fc.name
+            with tempfile.NamedTemporaryFile(delete=False, prefix="tmpxtgeo") as fc:
+                outfile = fc.name
             logger.info("TMP file name is %s", outfile)
             flag = True
 

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -248,7 +248,7 @@ def _allow_deprecated_init(func: Callable) -> Callable:
                 "myprop = xtgeo.gridproperty_from_file('some_name.roff') instead",
                 DeprecationWarning,
             )
-            fformat = kwargs.get("fformat", None)
+            fformat = kwargs.get("fformat")
             mfile = FileWrapper(pfile)
             fmt = mfile.fileformat(fformat)
 

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -285,8 +285,8 @@ def _allow_deprecated_init(func):
                 DeprecationWarning,
             )
             sfile = kwargs.get("sfile", args[0])
-            fformat = kwargs.get("fformat", None)
-            values = kwargs.get("values", None)
+            fformat = kwargs.get("fformat")
+            values = kwargs.get("values")
             if isinstance(values, bool) and values is False:
                 load_values = False
             else:
@@ -337,7 +337,7 @@ def _allow_deprecated_default_init(func):
                 and kwargs.get("xori", 0.0) == kwargs.get("yori", 0.0) == 0.0
                 and kwargs.get("xinc", 25.0) == kwargs.get("yinc", 25.0) == 25.0
             )
-            values = kwargs.get("values", None)
+            values = kwargs.get("values")
             if values is None and default:
                 default_values = [
                     [1, 6, 11],

--- a/src/xtgeo/well/blocked_wells.py
+++ b/src/xtgeo/well/blocked_wells.py
@@ -179,7 +179,7 @@ class BlockedWells(Wells):
         project = args[0]
         gname = args[1]
         bwname = args[2]
-        lognames = kwargs.get("lognames", None)
+        lognames = kwargs.get("lognames")
         ijk = kwargs.get("ijk", True)
 
         _blockedwells_roxapi.import_bwells_roxapi(
@@ -208,7 +208,7 @@ class BlockedWells(Wells):
         project = args[0]
         gname = args[1]
         bwname = args[2]
-        lognames = kwargs.get("lognames", None)
+        lognames = kwargs.get("lognames")
         ijk = kwargs.get("ijk", True)
 
         _blockedwells_roxapi.import_bwells_roxapi(

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -772,7 +772,7 @@ class Well:
         trajectory = kwargs.get("trajectory", "Drilled trajectory")
         logrun = kwargs.get("logrun", "log")
         realisation = kwargs.get("realisation", 0)
-        update_option = kwargs.get("update_option", None)
+        update_option = kwargs.get("update_option")
 
         logger.debug("Not in use: realisation %s", realisation)
 

--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -214,7 +214,7 @@ def to_file(
         KeyError if pfilter is set and key(s) are invalid
 
     """
-    filter_deprecated = kwargs.get("filter", None)
+    filter_deprecated = kwargs.get("filter")
     if filter_deprecated is not None and pfilter is None:
         pfilter = filter_deprecated
 

--- a/tests/jupyter/xtgeo1.ipynb
+++ b/tests/jupyter/xtgeo1.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reekfile = '../xtgeo-testdata/3dgrids/reek/REEK.EGRID'\n",
+    "reekfile = \"../xtgeo-testdata/3dgrids/reek/REEK.EGRID\"\n",
     "reekgrid = xtgeo.grid3d.Grid(reekfile)"
    ]
   },

--- a/tests/test_common/test_calc.py
+++ b/tests/test_common/test_calc.py
@@ -3,9 +3,10 @@ import pathlib
 
 import numpy as np
 import pytest
+from hypothesis import given, strategies as st
+
 import xtgeo
 import xtgeo.common.calc as xcalc
-from hypothesis import given, strategies as st
 from xtgeo import _cxtgeo
 
 xtg = xtgeo.XTGeoDialog()

--- a/tests/test_common/test_cxtgeo_lowlevel.py
+++ b/tests/test_common/test_cxtgeo_lowlevel.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo import _cxtgeo
 

--- a/tests/test_common/test_sys.py
+++ b/tests/test_common/test_sys.py
@@ -1,6 +1,7 @@
 import hashlib
 
 import pytest
+
 from xtgeo.common.sys import generic_hash
 
 

--- a/tests/test_cube/test_cube.py
+++ b/tests/test_cube/test_cube.py
@@ -4,8 +4,9 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import segyio
-import xtgeo
 from hypothesis import HealthCheck, given, settings
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.cube import Cube
 from xtgeo.cube._cube_import import (

--- a/tests/test_cube/test_cube_deprecations.py
+++ b/tests/test_cube/test_cube_deprecations.py
@@ -1,4 +1,5 @@
 import pytest
+
 import xtgeo
 
 

--- a/tests/test_cube/test_cube_xtgformats_io.py
+++ b/tests/test_cube/test_cube_xtgformats_io.py
@@ -2,8 +2,9 @@
 from os.path import join
 
 import pytest
-import xtgeo
 from numpy.testing import assert_allclose
+
+import xtgeo
 
 
 @pytest.mark.benchmark(group="import/export")

--- a/tests/test_etc/test_clib_errors.py
+++ b/tests/test_etc/test_clib_errors.py
@@ -2,6 +2,7 @@ import io
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo import _cxtgeo
 from xtgeo.io._file import FileWrapper

--- a/tests/test_etc/test_etc_make_avg_maps.py
+++ b/tests/test_etc/test_etc_make_avg_maps.py
@@ -2,6 +2,7 @@ import pathlib
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface

--- a/tests/test_etc/test_etc_make_hcpv_maps.py
+++ b/tests/test_etc/test_etc_make_hcpv_maps.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import numpy.ma as ma
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface

--- a/tests/test_grid3d/eclrun_fixtures.py
+++ b/tests/test_grid3d/eclrun_fixtures.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import pytest
+
 import xtgeo
 
 

--- a/tests/test_grid3d/egrid_generator.py
+++ b/tests/test_grid3d/egrid_generator.py
@@ -1,7 +1,8 @@
 import hypothesis.strategies as st
 import numpy as np
-import xtgeo.grid3d._egrid as xtge
 from hypothesis.extra.numpy import arrays
+
+import xtgeo.grid3d._egrid as xtge
 
 from .grdecl_grid_generator import (
     coordinate_types,

--- a/tests/test_grid3d/grdecl_grid_generator.py
+++ b/tests/test_grid3d/grdecl_grid_generator.py
@@ -1,8 +1,9 @@
 import hypothesis.strategies as st
 import numpy as np
+from hypothesis.extra.numpy import arrays
+
 import xtgeo.grid3d._ecl_grid as eclgrid
 import xtgeo.grid3d._grdecl_grid as ggrid
-from hypothesis.extra.numpy import arrays
 
 from .grid_generator import indices
 

--- a/tests/test_grid3d/grid_generator.py
+++ b/tests/test_grid3d/grid_generator.py
@@ -1,4 +1,5 @@
 import hypothesis.strategies as st
+
 import xtgeo
 
 indices = st.integers(min_value=4, max_value=6)

--- a/tests/test_grid3d/gridprop_generator.py
+++ b/tests/test_grid3d/gridprop_generator.py
@@ -1,6 +1,7 @@
 import hypothesis.strategies as st
 import numpy as np
 from hypothesis.extra.numpy import arrays
+
 from xtgeo.grid3d import GridProperty
 
 from .grdecl_grid_generator import finites

--- a/tests/test_grid3d/test_ecl_inte_head.py
+++ b/tests/test_grid3d/test_ecl_inte_head.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 from xtgeo.grid3d._ecl_inte_head import InteHead, Phases
 from xtgeo.grid3d._ecl_output_file import Simulator, TypeOfGrid, UnitSystem
 

--- a/tests/test_grid3d/test_ecl_logi_head.py
+++ b/tests/test_grid3d/test_ecl_logi_head.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from xtgeo.grid3d._ecl_logi_head import LogiHead
 from xtgeo.grid3d._ecl_output_file import Simulator
 

--- a/tests/test_grid3d/test_ecl_simpleb8_cases.py
+++ b/tests/test_grid3d/test_ecl_simpleb8_cases.py
@@ -22,6 +22,7 @@ import pathlib
 import numpy as np
 import pytest
 import resfo
+
 import xtgeo
 
 xtg = xtgeo.XTGeoDialog()

--- a/tests/test_grid3d/test_eclrun.py
+++ b/tests/test_grid3d/test_eclrun.py
@@ -3,6 +3,7 @@ from os.path import basename
 
 import numpy as np
 import pytest
+
 import xtgeo
 
 from .eclrun_fixtures import *  # noqa: F401, F403

--- a/tests/test_grid3d/test_grdecl_format.py
+++ b/tests/test_grid3d/test_grdecl_format.py
@@ -1,6 +1,7 @@
 from unittest.mock import mock_open, patch
 
 import pytest
+
 from xtgeo.grid3d._grdecl_format import open_grdecl
 
 

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -6,8 +6,9 @@ import warnings
 
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import given
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.grid3d import Grid
 

--- a/tests/test_grid3d/test_grid3d_deprecations.py
+++ b/tests/test_grid3d/test_grid3d_deprecations.py
@@ -3,9 +3,10 @@ import pathlib
 
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import given
 from packaging import version
+
+import xtgeo
 from xtgeo import GridProperties, GridProperty
 from xtgeo.common.version import __version__ as xtgeo_version
 

--- a/tests/test_grid3d/test_grid_bytesio.py
+++ b/tests/test_grid3d/test_grid_bytesio.py
@@ -7,6 +7,7 @@ Currently tested format(s):
 import io
 
 import numpy as np
+
 import xtgeo
 
 

--- a/tests/test_grid3d/test_grid_dual_index.py
+++ b/tests/test_grid3d/test_grid_dual_index.py
@@ -57,6 +57,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+
 import xtgeo.grid3d.grid
 
 

--- a/tests/test_grid3d/test_grid_ecl_grid.py
+++ b/tests/test_grid3d/test_grid_ecl_grid.py
@@ -1,11 +1,12 @@
 import hypothesis.strategies as st
 import numpy as np
 import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from numpy.testing import assert_allclose
+
 import xtgeo
 import xtgeo.grid3d._egrid as xtg_egrid
 import xtgeo.grid3d._grdecl_grid as ggrid
-from hypothesis import HealthCheck, assume, given, settings
-from numpy.testing import assert_allclose
 from xtgeo.grid3d._ecl_grid import (
     inverse_transform_xtgeo_coord_by_mapaxes,
     transform_xtgeo_coord_by_mapaxes,

--- a/tests/test_grid3d/test_grid_egrid.py
+++ b/tests/test_grid3d/test_grid_egrid.py
@@ -5,9 +5,10 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import resfo
+from hypothesis import HealthCheck, assume, given, settings
+
 import xtgeo as xtg
 import xtgeo.grid3d._egrid as xtge
-from hypothesis import HealthCheck, assume, given, settings
 
 from .egrid_generator import (
     egrids,

--- a/tests/test_grid3d/test_grid_fence.py
+++ b/tests/test_grid3d/test_grid_fence.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 
 REEKROOT = pathlib.Path("3dgrids/reek/REEK")

--- a/tests/test_grid3d/test_grid_grdecl.py
+++ b/tests/test_grid3d/test_grid_grdecl.py
@@ -5,10 +5,11 @@ from unittest.mock import mock_open, patch
 import hypothesis.strategies as st
 import numpy as np
 import pytest
+from hypothesis import HealthCheck, assume, given, settings
+
 import xtgeo
 import xtgeo.grid3d._ecl_grid as ecl_grid
 import xtgeo.grid3d._grdecl_grid as ggrid
-from hypothesis import HealthCheck, assume, given, settings
 from xtgeo.grid3d import Grid
 from xtgeo.grid3d._grdecl_format import open_grdecl
 from xtgeo.grid3d._grid_import_ecl import grid_from_ecl_grid

--- a/tests/test_grid3d/test_grid_operations.py
+++ b/tests/test_grid3d/test_grid_operations.py
@@ -3,8 +3,9 @@
 import pathlib
 
 import pytest
-import xtgeo
 from hypothesis import given
+
+import xtgeo
 
 from .grid_generator import xtgeo_grids
 

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -5,8 +5,9 @@ import pathlib
 
 import hypothesis.strategies as st
 import pytest
-import xtgeo
 from hypothesis import assume, given
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.grid3d import GridProperties, GridProperty

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -8,8 +8,9 @@ import hypothesis.strategies as st
 import numpy as np
 import numpy.ma as npma
 import pytest
-import xtgeo
 from hypothesis import HealthCheck, example, given, settings
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import KeywordNotFoundError
 from xtgeo.grid3d import Grid, GridProperty

--- a/tests/test_grid3d/test_grid_property_etc.py
+++ b/tests/test_grid3d/test_grid_property_etc.py
@@ -2,6 +2,7 @@
 """Testing: test_grid_property more special functions"""
 
 import pytest
+
 from xtgeo.grid3d import _gridprop_roxapi
 
 

--- a/tests/test_grid3d/test_grid_property_grdecl.py
+++ b/tests/test_grid3d/test_grid_property_grdecl.py
@@ -3,9 +3,10 @@ from unittest.mock import mock_open, patch
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import HealthCheck, assume, given, settings
 from numpy.testing import assert_allclose
+
+import xtgeo
 from xtgeo.grid3d._gridprop_import_grdecl import read_grdecl_3d_property
 
 from .grid_generator import xtgeo_grids as grids

--- a/tests/test_grid3d/test_grid_property_roff.py
+++ b/tests/test_grid3d/test_grid_property_roff.py
@@ -4,9 +4,10 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import roffio
-import xtgeo
 from hypothesis import HealthCheck, given, settings
 from hypothesis.extra.numpy import arrays
+
+import xtgeo
 from xtgeo.grid3d import GridProperty
 from xtgeo.grid3d._roff_parameter import RoffParameter
 

--- a/tests/test_grid3d/test_grid_roff.py
+++ b/tests/test_grid3d/test_grid_roff.py
@@ -9,6 +9,7 @@ import roffio
 from hypothesis import given
 from hypothesis.extra.numpy import arrays
 from numpy.testing import assert_allclose
+
 from xtgeo import _cxtgeo
 from xtgeo.grid3d import Grid
 from xtgeo.grid3d._grid_import_roff import handle_deprecated_xtgeo_roff_file

--- a/tests/test_grid3d/test_grid_specialcases.py
+++ b/tests/test_grid3d/test_grid_specialcases.py
@@ -9,6 +9,7 @@ The tests where made on resolving issues #873, #874
 import pathlib
 
 import pytest
+
 import xtgeo
 
 SPE9 = pathlib.Path("3dgrids/bench_spe9")

--- a/tests/test_grid3d/test_grid_vs_points.py
+++ b/tests/test_grid3d/test_grid_vs_points.py
@@ -2,6 +2,7 @@ import pathlib
 
 import pandas as pd
 import pytest
+
 import xtgeo
 
 xtg = xtgeo.common.XTGeoDialog()

--- a/tests/test_grid3d/test_grid_vs_well.py
+++ b/tests/test_grid3d/test_grid_vs_well.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_grid3d/test_grid_xtgformats_io.py
+++ b/tests/test_grid3d/test_grid_xtgformats_io.py
@@ -6,9 +6,10 @@ from os.path import join
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_allclose
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 
 xtg = XTGeoDialog()

--- a/tests/test_grid3d/test_gridprop_import_eclrun.py
+++ b/tests/test_grid3d/test_gridprop_import_eclrun.py
@@ -8,9 +8,10 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import resfo
+from hypothesis import HealthCheck, assume, given, settings
+
 import xtgeo
 import xtgeo.grid3d._find_gridprop_in_eclrun as xtg_im_ecl
-from hypothesis import HealthCheck, assume, given, settings
 from xtgeo.grid3d._ecl_inte_head import InteHead
 from xtgeo.grid3d._ecl_logi_head import LogiHead
 from xtgeo.grid3d._ecl_output_file import Phases

--- a/tests/test_grid3d/test_gridprops_list_properties.py
+++ b/tests/test_grid3d/test_gridprops_list_properties.py
@@ -2,6 +2,7 @@ import pathlib
 from pathlib import Path
 
 import pytest
+
 from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.grid3d import list_gridproperties

--- a/tests/test_io/test_file.py
+++ b/tests/test_io/test_file.py
@@ -4,6 +4,7 @@ import sys
 from collections import ChainMap
 
 import pytest
+
 import xtgeo
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.io._file import FileFormat, FileWrapper

--- a/tests/test_opm_integration/test_grid_io.py
+++ b/tests/test_opm_integration/test_grid_io.py
@@ -1,9 +1,10 @@
 import os
 
 import pytest
-import xtgeo
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
+
+import xtgeo
 
 from ..test_grid3d.grid_generator import xtgeo_grids  # noqa
 

--- a/tests/test_opm_integration/test_gridprop_io.py
+++ b/tests/test_opm_integration/test_gridprop_io.py
@@ -5,8 +5,9 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 import resfo
-import xtgeo
 from hypothesis import given, settings
+
+import xtgeo
 from xtgeo.grid3d._ecl_inte_head import InteHead
 from xtgeo.grid3d._ecl_logi_head import LogiHead
 from xtgeo.grid3d._ecl_output_file import Simulator, TypeOfGrid, UnitSystem

--- a/tests/test_plot/test_grid3dsliceplot.py
+++ b/tests/test_plot/test_grid3dsliceplot.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.plot import Grid3DSlice

--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog, null_logger
 

--- a/tests/test_surface/test_deprecation.py
+++ b/tests/test_surface/test_deprecation.py
@@ -2,8 +2,9 @@ import functools
 
 import deprecation
 import pytest
-import xtgeo
 from packaging import version
+
+import xtgeo
 from xtgeo.common.version import __version__ as xtgeo_version
 
 

--- a/tests/test_surface/test_file_io.py
+++ b/tests/test_surface/test_file_io.py
@@ -1,8 +1,9 @@
 import deprecation
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import given, strategies as st
+
+import xtgeo
 from xtgeo import Cube, RegularSurface
 
 

--- a/tests/test_surface/test_ijxyz_spec.py
+++ b/tests/test_surface/test_ijxyz_spec.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface._regsurf_ijxyz_parser import SurfaceIJXYZ

--- a/tests/test_surface/test_new_surface.py
+++ b/tests/test_surface/test_new_surface.py
@@ -1,8 +1,9 @@
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-import xtgeo
 from hypothesis import assume, given
+
+import xtgeo
 from xtgeo import RegularSurface
 
 

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -6,8 +6,9 @@ import sys
 import numpy as np
 import pandas as pd
 import pytest
-import xtgeo
 from packaging import version
+
+import xtgeo
 from xtgeo import RegularSurface
 from xtgeo.common import XTGeoDialog
 from xtgeo.common.version import __version__ as xtgeo_version

--- a/tests/test_surface/test_regular_surface_bytesio.py
+++ b/tests/test_surface/test_regular_surface_bytesio.py
@@ -6,6 +6,7 @@ import pathlib
 import threading
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_surface/test_regular_surface_in_other.py
+++ b/tests/test_surface/test_regular_surface_in_other.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import numpy.ma as ma
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_surface/test_regular_surface_resample.py
+++ b/tests/test_surface/test_regular_surface_resample.py
@@ -4,6 +4,7 @@ import pathlib
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface

--- a/tests/test_surface/test_regular_surface_vs_cube.py
+++ b/tests/test_surface/test_regular_surface_vs_cube.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import numpy.ma as ma
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_surface/test_regular_surface_vs_grd3d.py
+++ b/tests/test_surface/test_regular_surface_vs_grd3d.py
@@ -2,6 +2,7 @@ import pathlib
 
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_surface/test_regular_surface_vs_points.py
+++ b/tests/test_surface/test_regular_surface_vs_points.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface

--- a/tests/test_surface/test_regular_surface_xtgformats_io.py
+++ b/tests/test_surface/test_regular_surface_xtgformats_io.py
@@ -4,8 +4,9 @@
 from os.path import join
 
 import pytest
-import xtgeo
 from numpy.testing import assert_allclose
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 
 xtg = XTGeoDialog()

--- a/tests/test_surface/test_surf_xyz_from_ij.py
+++ b/tests/test_surface/test_surf_xyz_from_ij.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import xtgeo
 from xtgeo import _cxtgeo
 

--- a/tests/test_surface/test_surface_cube_attrs.py
+++ b/tests/test_surface/test_surface_cube_attrs.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 
 xtg = xtgeo.common.XTGeoDialog()

--- a/tests/test_surface/test_surfaces.py
+++ b/tests/test_surface/test_surfaces.py
@@ -5,6 +5,7 @@ import pathlib
 
 import numpy as np
 import pytest
+
 import xtgeo
 
 xtg = xtgeo.common.XTGeoDialog()

--- a/tests/test_surface/test_swapaxis.py
+++ b/tests/test_surface/test_swapaxis.py
@@ -1,4 +1,5 @@
 import pytest
+
 from xtgeo import RegularSurface
 
 

--- a/tests/test_surface/test_val_from_xy.py
+++ b/tests/test_surface/test_val_from_xy.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+
 import xtgeo
 
 

--- a/tests/test_surface/test_zmap_spec.py
+++ b/tests/test_surface/test_zmap_spec.py
@@ -2,6 +2,7 @@ import pathlib
 from io import StringIO
 
 import pytest
+
 import xtgeo
 from xtgeo.surface._zmap_parser import ZMAPFormatException, ZMAPSurface, parse_zmap
 

--- a/tests/test_well/conftest.py
+++ b/tests/test_well/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import xtgeo
 
 

--- a/tests/test_well/test_blockedwell.py
+++ b/tests/test_well/test_blockedwell.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_well/test_blockedwells.py
+++ b/tests/test_well/test_blockedwells.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.well import BlockedWells

--- a/tests/test_well/test_well.py
+++ b/tests/test_well/test_well.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import pandas as pd
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.well import Well

--- a/tests/test_well/test_well_deprecations.py
+++ b/tests/test_well/test_well_deprecations.py
@@ -1,6 +1,7 @@
 import pytest
-import xtgeo
 from packaging import version
+
+import xtgeo
 from xtgeo import Well
 from xtgeo.common.version import __version__ as xtgeo_version
 

--- a/tests/test_well/test_well_hdf5.py
+++ b/tests/test_well/test_well_hdf5.py
@@ -1,4 +1,5 @@
 import pytest
+
 from xtgeo.well._well_io import import_wlogs
 
 

--- a/tests/test_well/test_well_to_points.py
+++ b/tests/test_well/test_well_to_points.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_well/test_well_vs_grid.py
+++ b/tests/test_well/test_well_vs_grid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pathlib
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 

--- a/tests/test_well/test_well_vs_surface.py
+++ b/tests/test_well/test_well_vs_surface.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import pytest
+
 import xtgeo
 
 xtg = xtgeo.common.XTGeoDialog()

--- a/tests/test_well/test_well_xyzdata_class.py
+++ b/tests/test_well/test_well_xyzdata_class.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 import pytest
+
 from xtgeo.common import _AttrType
 from xtgeo.xyz._xyz_data import _XYZData
 

--- a/tests/test_well/test_wells.py
+++ b/tests/test_well/test_wells.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import pytest
+
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.well import Wells

--- a/tests/test_xyz/test_points.py
+++ b/tests/test_xyz/test_points.py
@@ -4,8 +4,9 @@ import pathlib
 import numpy as np
 import pandas as pd
 import pytest
-import xtgeo
 from hypothesis import given, strategies as st
+
+import xtgeo
 from xtgeo.xyz import Points
 
 PFILE = pathlib.Path("points/eme/1/emerald_10_random.poi")

--- a/tests/test_xyz/test_points_from_surface.py
+++ b/tests/test_xyz/test_points_from_surface.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pandas as pd
+
 import xtgeo
 
 SURFACE = pathlib.Path("surfaces/reek/1/topreek_rota.gri")

--- a/tests/test_xyz/test_points_from_wells.py
+++ b/tests/test_xyz/test_points_from_wells.py
@@ -2,6 +2,7 @@ import glob
 import pathlib
 
 import pytest
+
 import xtgeo
 from xtgeo.xyz import Points
 

--- a/tests/test_xyz/test_points_poly.py
+++ b/tests/test_xyz/test_points_poly.py
@@ -2,6 +2,7 @@ import pathlib
 import sys
 
 import pytest
+
 import xtgeo
 from xtgeo.xyz import Points, Polygons
 

--- a/tests/test_xyz/test_points_vs_other.py
+++ b/tests/test_xyz/test_points_vs_other.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 import xtgeo
 
 SFILE1A = pathlib.Path("surfaces/reek/1/topupperreek.gri")

--- a/tests/test_xyz/test_polygon.py
+++ b/tests/test_xyz/test_polygon.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import pandas as pd
 import pytest
+
 import xtgeo
 from xtgeo.xyz import Points, Polygons
 

--- a/tests/test_xyz/test_xyz_deprecated.py
+++ b/tests/test_xyz/test_xyz_deprecated.py
@@ -5,8 +5,9 @@ import pathlib
 
 import pandas as pd
 import pytest
-import xtgeo
 from packaging import version
+
+import xtgeo
 from xtgeo.common.version import __version__ as xtgeo_version
 
 PFILE1A = pathlib.Path("polygons/reek/1/top_upper_reek_faultpoly.zmap")

--- a/tests/test_xyz/test_xyz_roxapi_mock.py
+++ b/tests/test_xyz/test_xyz_roxapi_mock.py
@@ -6,8 +6,9 @@ Tests for roxar RoxarAPI interface as mocks.
 import numpy as np
 import pandas as pd
 import pytest
-import xtgeo
 from pandas.testing import assert_frame_equal
+
+import xtgeo
 
 
 @pytest.fixture


### PR DESCRIPTION
This will create a new 3.9.x version, NOT a 4.0 version where this change has already been made. It is specific to Python 3.8.

Includes a second commit to pass the latest ruff.

See: https://github.com/equinor/xtgeo/issues/1275 https://github.com/equinor/xtgeo/issues/1277