### PR TITLE
BLD: Unpin numpy 2 

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -16,7 +16,7 @@ jobs:
   mypy:
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,20 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: 
-          - ['3.8', cp38] 
+        python:
           - ['3.9', cp39]
           - ['3.10', cp310]
           - ['3.11', cp311]
           - ['3.12', cp312]
-        os_arch: 
+        os_arch:
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]
           - [macos-13, macosx_x86_64]  # macos-13 is the last x86-64 runner
           - [macos-latest, macosx_arm64]  # macos-latest is always arm64 going forward
         exclude:
-          - os_arch: [macos-latest, macosx_arm64]
-            python: ['3.8', cp38]
           - os_arch: [macos-latest, macosx_arm64]
             python: ['3.9', cp39]
     env:
@@ -38,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python[0] }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,18 +87,6 @@ jobs:
       matrix:
         config:
           - {
-              name: "RMS 12.1.4, 13.0.3, 13.1.0, 14.1.1",
-              os: ubuntu-20.04,
-              python: 3.8.6,
-              pip: 23.2.1,
-              wheel: 0.37.1,
-              setuptools: 63.4.3,
-              matplotlib: 3.3.2,
-              numpy: 1.19.2,
-              pandas: 1.1.3,
-              scipy: 1.5.3,
-            }
-          - {
               name: "RMS 14.2",
               os: ubuntu-latest,
               python: 3.11.3,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             python-version: 3.12
           - os: windows-latest
-            python-version: 3.8
+            python-version: 3.9
           - os: windows-latest
             python-version: 3.12
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Detailed documentation for [XTGeo at Read _the_ Docs](https://xtgeo.readthedocs.
 
 ## Feature summary
 
--   Python 3.8+ support
+-   Python 3.9+ support
 -   Focus on high speed, using numpy and pandas with C backend
 -   Regular surfaces, i.e. 2D maps with regular sampling and rotation
 -   3D grids (corner-point), supporting several formats such as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,9 @@ requires = [
     "scikit-build-core[pyproject]>=0.10",
     "swig<4.3.0",
     "numpy==1.19.2; python_version == '3.8'",
-    "numpy==1.19.5; python_version == '3.9'",
-    "numpy==1.21.6; python_version == '3.10'",
-    "numpy==1.23.5; python_version == '3.11'",
-    "numpy==1.26.2; python_version == '3.12'",
+    "numpy>=2.0.0; python_version > '3.8'",
 ]
+
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
@@ -53,7 +51,7 @@ dependencies = [
     "hdf5plugin>=2.3",
     "joblib",
     "matplotlib>=3.3",
-    "numpy<2",
+    "numpy",
     "pandas>=1.1",
     "resfo>=4.0.0",
     "roffio>=0.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ requires = [
     "pybind11",
     "scikit-build-core[pyproject]>=0.10",
     "swig<4.3.0",
-    "numpy==1.19.2; python_version == '3.8'",
-    "numpy>=2.0.0; python_version > '3.8'",
+    "numpy>=2.0.0; python_version >= '3.9'",
 ]
 
 build-backend = "scikit_build_core.build"
@@ -20,7 +19,7 @@ wheel.install-dir = "xtgeo"
 name = "xtgeo"
 description = "XTGeo is a Python library for 3D grids, surfaces, wells, etc"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "LGPL-3.0" }
 authors = [{ name = "Equinor", email = "fg_fmu-atlas@equinor.com" }]
 keywords = ["grids", "surfaces", "wells", "cubes"]
@@ -34,7 +33,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Natural Language :: English",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/xtgeo/grid3d/_ecl_inte_head.py
+++ b/src/xtgeo/grid3d/_ecl_inte_head.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Any, Literal, cast
 
 import numpy as np
+import numpy.typing as npt
 
 from ._ecl_output_file import Phases, Simulator, TypeOfGrid, UnitSystem
 
@@ -29,7 +30,7 @@ class InteHead:
     True
     """
 
-    def __init__(self, values: np.ndarray[np.int_, Any]) -> None:
+    def __init__(self, values: npt.NDArray[np.int_]) -> None:
         """Create an InteHead from the corresponding array.
 
         Args:

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from copy import deepcopy
 from functools import lru_cache
 from math import atan2, degrees
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, no_type_check
 
 import numpy as np
 import pandas as pd
@@ -1007,6 +1007,7 @@ def copy(self: Grid) -> Grid:
     )
 
 
+@no_type_check  # due to some hard-to-solve issues with mypy
 def crop(
     self: Grid,
     spec: tuple[tuple[int, int], tuple[int, int], tuple[int, int]],

--- a/src/xtgeo/grid3d/_roff_parameter.py
+++ b/src/xtgeo/grid3d/_roff_parameter.py
@@ -104,8 +104,9 @@ class RoffParameter:
         Returns:
             True if the RoffParameter is a discrete type
         """
-        return isinstance(self.values, bytes) or np.issubdtype(
-            self.values.dtype, np.integer
+        return bool(
+            isinstance(self.values, bytes)
+            or np.issubdtype(self.values.dtype, np.integer)
         )
 
     def xtgeo_codes(self) -> dict[int, str]:

--- a/tests/test_grid3d/test_grdecl_format.py
+++ b/tests/test_grid3d/test_grdecl_format.py
@@ -21,13 +21,16 @@ from xtgeo.grid3d._grdecl_format import open_grdecl
     ],
 )
 def test_read_simple_property(file_data):
-    with patch(
-        "builtins.open",
-        mock_open(read_data=file_data),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["PROP"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=file_data),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["PROP"],
+        ) as kw,
+    ):
         assert list(kw) == [("PROP", ["1", "2", "3", "4"])]
 
 
@@ -37,34 +40,43 @@ def test_read_simple_property(file_data):
 )
 def test_read_repeated_property(repeats, value):
     inp_str = f"PROP\n {repeats}*{value} /\n"
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(mock_file, keywords=["PROP"]) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(mock_file, keywords=["PROP"]) as kw,
+    ):
         assert list(kw) == [("PROP", [str(value)] * repeats)]
 
 
 def test_read_repeated_string_literal():
     inp_str = "PROP\n 3*'INP   ' /\n"
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["PROP"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["PROP"],
+        ) as kw,
+    ):
         assert list(kw) == [("PROP", ["INP   "] * 3)]
 
 
 def test_read_string():
     inp_str = "PROP\n 'FOO BAR' FOO /\n"
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["PROP"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["PROP"],
+        ) as kw,
+    ):
         assert list(kw) == [("PROP", ["FOO BAR", "FOO"])]
 
 
@@ -73,13 +85,16 @@ def test_read_extra_keyword_characters():
         "LONGPROP Eclipse comment\n"
         "1 2 3 4 / More Eclipse comment\nOTHERPROP\n 5 6 7 8 /\n"
     )
-    with patch(
-        "builtins.open",
-        mock_open(read_data=file_data),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["LONGPROP", "OTHERPROP"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=file_data),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["LONGPROP", "OTHERPROP"],
+        ) as kw,
+    ):
         assert list(kw) == [
             ("LONGPROP", ["1", "2", "3", "4"]),
             ("OTHERPROP", ["5", "6", "7", "8"]),
@@ -89,13 +104,16 @@ def test_read_extra_keyword_characters():
 def test_read_long_keyword():
     very_long_keyword = "a" * 200
     file_data = f"{very_long_keyword} Eclipse comment\n" "1 2 3 4 /"
-    with patch(
-        "builtins.open",
-        mock_open(read_data=file_data),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=[very_long_keyword],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=file_data),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=[very_long_keyword],
+        ) as kw,
+    ):
         assert list(kw) == [
             (very_long_keyword, ["1", "2", "3", "4"]),
         ]
@@ -112,11 +130,15 @@ def test_read_long_keyword():
     ],
 )
 def test_read_prop_raises_error_when_no_forwardslash(undelimited_file_data):
-    with patch(
-        "builtins.open",
-        mock_open(read_data=undelimited_file_data),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["PROP"],
-    ) as kw, pytest.raises(ValueError):
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=undelimited_file_data),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["PROP"],
+        ) as kw,
+        pytest.raises(ValueError),
+    ):
         list(kw)

--- a/tests/test_grid3d/test_grid_grdecl.py
+++ b/tests/test_grid3d/test_grid_grdecl.py
@@ -40,13 +40,16 @@ def test_grid_relative():
     ],
 )
 def test_mapaxes(inp_str, values):
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["MAPAXES"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["MAPAXES"],
+        ) as kw,
+    ):
         keyword, values = next(kw)
         assert keyword == "MAPAXES"
         mapaxes = ggrid.MapAxes.from_grdecl(values)
@@ -59,13 +62,16 @@ def test_mapaxes(inp_str, values):
 
 def test_gdorient():
     inp_str = "GDORIENT\n INC INC INC DOWN LEFT /"
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["GDORIENT"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["GDORIENT"],
+        ) as kw,
+    ):
         keyword, values = next(kw)
         assert keyword == "GDORIENT"
         gdorient = ecl_grid.GdOrient.from_grdecl(values)
@@ -81,13 +87,16 @@ def test_gdorient():
 
 def test_specgrid():
     inp_str = "SPECGRID\n 64 118 263 1 F /"
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["SPECGRID"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["SPECGRID"],
+        ) as kw,
+    ):
         keyword, values = next(kw)
         assert keyword == "SPECGRID"
         specgrid = ggrid.SpecGrid.from_grdecl(values)
@@ -113,13 +122,16 @@ def test_specgrid():
     ],
 )
 def test_gridunit(inp_str, expected_unit, expected_relative):
-    with patch(
-        "builtins.open",
-        mock_open(read_data=inp_str),
-    ) as mock_file, open_grdecl(
-        mock_file,
-        keywords=["GRIDUNIT"],
-    ) as kw:
+    with (
+        patch(
+            "builtins.open",
+            mock_open(read_data=inp_str),
+        ) as mock_file,
+        open_grdecl(
+            mock_file,
+            keywords=["GRIDUNIT"],
+        ) as kw,
+    ):
         keyword, values = next(kw)
         assert keyword == "GRIDUNIT"
         gridunit = ggrid.GridUnit.from_grdecl(values)

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -116,7 +116,12 @@ def test_assign():
     # this shall now broadcast the value 33 to all activecells
     x.isdiscrete = True
     x.values = 33
-    assert x.dtype == np.int32
+
+    numpy_version = tuple(map(int, np.__version__.split(".")))
+    if numpy_version >= (2, 0, 0):
+        assert x.dtype == np.int64
+    else:
+        assert x.dtype == np.int32
 
     x.isdiscrete = False
     x.values = 44.0221

--- a/tests/test_grid3d/test_grid_roff.py
+++ b/tests/test_grid3d/test_grid_roff.py
@@ -337,12 +337,15 @@ def test_deprecated_fileread(roff_grid):
         )
     )
 
-    with pytest.warns(
-        UserWarning,
-        match="nonstandard but harmless roff",
-    ), handle_deprecated_xtgeo_roff_file(
-        new_buff,
-    ) as converted_buff:
+    with (
+        pytest.warns(
+            UserWarning,
+            match="nonstandard but harmless roff",
+        ),
+        handle_deprecated_xtgeo_roff_file(
+            new_buff,
+        ) as converted_buff,
+    ):
         new_grid = RoffGrid.from_file(converted_buff)
 
     assert new_grid == roff_grid


### PR DESCRIPTION
This PR replaces #1233 

Resolves https://github.com/equinor/xtgeo/issues/1209

This unpins numpy<2 and builds the SWIG C library against numpy >= 2.0.0. Versions of numpy major 2 are backward compatible with numpy 1 with respect to the C api. Hence we should not see issues in environments where numpy<2 may be maintained for years to come, i.e. RMS environments.

The numpy SWIG bindings committed in this repository are not out-of-date in a way that would break compatibility. The last update to them in numpy's repository was two years ago from the time of this commit.

The PR has been manually tested with RMS 14.2, which applies python 3.11 and numpy==1.24.

As a consequence of supporting numpy>=2 this PR deprecates support for Python 3.8, which hits EOL on October 2024.