### PR TITLE
BLD: Publish for macOS Python 3.9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,6 @@ jobs:
           - [windows-latest, win_amd64]
           - [macos-13, macosx_x86_64]  # macos-13 is the last x86-64 runner
           - [macos-latest, macosx_arm64]  # macos-latest is always arm64 going forward
-        exclude:
-          - os_arch: [macos-latest, macosx_arm64]
-            python: ['3.9', cp39]
     env:
       CIBW_BUILD: ${{ matrix.python[1] }}-${{ matrix.os_arch[1] }}
 


### PR DESCRIPTION
Resolves #1100

GitHub Actions originally did not publish macOS arm64 runners with Python 3.9 and said they had no intention to. They seem to have reversed on this decision and (apparently) do.