### PR TITLE
ENH: add attributes for Polygons when reading RMS

### DIFF
--- a/src/xtgeo/common/_xyz_enum.py
+++ b/src/xtgeo/common/_xyz_enum.py
@@ -14,6 +14,7 @@ class _AttrName(ExtendedEnum):
     XNAME = "X_UTME"
     YNAME = "Y_UTMN"
     ZNAME = "Z_TVDSS"
+    PNAME = "POLY_ID"
     M_MD_NAME = "M_MDEPTH"
     Q_MD_NAME = "Q_MDEPTH"
     M_AZI_NAME = "M_AZI"
@@ -24,6 +25,12 @@ class _AttrName(ExtendedEnum):
     J_INDEX = "J_INDEX"
     K_INDEX = "K_INDEX"
     R_HLEN_NAME = "R_HLEN"
+    HNAME = "H_CUMLEN"
+    DHNAME = "H_DELTALEN"
+    TNAME = "T_CUMLEN"
+    DTNAME = "T_DELTALEN"
+    WELLNAME = "WELLNAME"
+    TRAJECTORY = "TRAJECTORY"
 
 
 @unique
@@ -38,6 +45,6 @@ class _AttrType(ExtendedEnum):
 class _XYZType(ExtendedEnum):
     """Enumerate type of context"""
 
-    POINTS = 1
-    POLYGONS = 2  # ie. same here as PolyLines
-    WELL = 3
+    POINTS = "POINTS"
+    POLYGONS = "POLYGONS"
+    WELL = "WELL"

--- a/tests/test_xyz/test_points.py
+++ b/tests/test_xyz/test_points.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from hypothesis import given, strategies as st
+from pandas.testing import assert_frame_equal
 
 import xtgeo
 from xtgeo.xyz import Points
@@ -49,6 +50,24 @@ def test_points_from_list_of_tuples():
     z2 = mypoints.get_dataframe()["Z_TVDSS"].values[2]
     assert x0 == 234
     assert z2 == 12
+
+
+def test_points_with_attrs_copy():
+    plist = [
+        (234, 556, 11, "some", 1.0),
+        (235, 559, 14, "attr", 1.1),
+        (255, 577, 12, "here", 1.2),
+    ]
+    attrs = {}
+    attrs["sometxt"] = "str"
+    attrs["somefloat"] = "float"
+
+    mypoi = Points(plist, attributes=attrs)
+
+    cppoi = mypoi.copy()
+
+    assert_frame_equal(mypoi.get_dataframe(), cppoi.get_dataframe())
+    assert "somefloat" in mypoi.get_dataframe().columns
 
 
 @st.composite

--- a/tests/test_xyz/test_polygon.py
+++ b/tests/test_xyz/test_polygon.py
@@ -3,6 +3,7 @@ import pathlib
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
 import xtgeo
 from xtgeo.xyz import Points, Polygons
@@ -90,6 +91,23 @@ def test_polygons_from_attrs_not_ordereddict():
 
     mypol = Polygons(plist, attributes=attrs)
     assert mypol.get_dataframe()["POLY_ID"].values[2] == 1
+
+
+def test_polygons_with_attrs_copy():
+    plist = [
+        (234, 556, 11, 0, "some", 1.0),
+        (235, 559, 14, 1, "attr", 1.1),
+        (255, 577, 12, 1, "here", 1.2),
+    ]
+    attrs = {}
+    attrs["sometxt"] = "str"
+    attrs["somefloat"] = "float"
+
+    mypol = Polygons(plist, attributes=attrs)
+
+    cppol = mypol.copy()
+
+    assert_frame_equal(mypol.get_dataframe(), cppol.get_dataframe())
 
 
 def test_import_zmap_and_xyz(testdata_path):


### PR DESCRIPTION
Closes #900

Polygons from RMS can now be read including attributes. Note that the current RMSAPI do not allow for storing attributes back to RMS, and also there are no (known) file formats for Polygons that supports attributes. As a workaround, one can use CVS  files to both read and write Polygons Pandas dataframes with attributes.

In addition several "fixups" on more consistent usage of Enum's in the code.

