### PR TITLE
ENH: Use surfio for irap ascii

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
-        python: ["cp310", "cp311", "cp312", "cp313"]
+        python: ["cp311", "cp312", "cp313"]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,15 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - os: macos-latest
             python-version: "3.13"
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - os: windows-latest
             python-version: "3.13"
 
@@ -79,7 +79,7 @@ jobs:
       - name: Setup xtgeo
         uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
@@ -154,7 +154,7 @@ jobs:
       - name: Setup xtgeo
         uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
@@ -173,7 +173,7 @@ jobs:
       - name: Setup xtgeo
         uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
@@ -194,7 +194,7 @@ jobs:
 
       - uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "scipy>=1.5",
     "segyio>1.8.0",
     "shapely>=1.6.2",
+    "surfio",
     "tables",
     "typing_extensions",
     "xtgeoviz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "scikit_build_core.build"
 name = "xtgeo"
 description = "XTGeo is a Python library for 3D grids, surfaces, wells, etc"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { text = "LGPL-3.0" }
 authors = [{ name = "Equinor", email = "fg_fmu-atlas@equinor.com" }]
 keywords = ["grids", "surfaces", "wells", "cubes"]
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Natural Language :: English",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -99,7 +98,7 @@ sdist.include = ["src/xtgeo/common/version.py"]
 wheel.install-dir = "xtgeo"
 
 [tool.cibuildwheel]
-build = "cp3{10,11,12,13}-*"
+build = "cp3{11,12,13}-*"
 skip = ["*-musllinux_*", "*-win32", "*-manylinux_i686"]
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"

--- a/tests/test_surface/test_file_io.py
+++ b/tests/test_surface/test_file_io.py
@@ -4,6 +4,7 @@ from hypothesis import given, strategies as st
 
 import xtgeo
 from xtgeo import Cube, RegularSurface
+from xtgeo.common.constants import UNDEF_MAP_IRAPA
 
 
 def assert_similar_surfaces(surf1, surf2):
@@ -28,8 +29,8 @@ def surfaces(draw):
             values=st.lists(
                 st.floats(
                     allow_nan=False,
-                    max_value=1e29,
-                    min_value=-xtgeo.UNDEF_LIMIT,
+                    max_value=UNDEF_MAP_IRAPA - 1,
+                    min_value=-UNDEF_MAP_IRABA + 1,
                 ),
                 min_size=ncol * nrow,
                 max_size=ncol * nrow,


### PR DESCRIPTION
In order to use surfio, python >= 3.11 is required.