### PR TITLE
Improve cpp python logging

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -21,6 +21,21 @@ message(STATUS "Python include dirs   : ${Python_INCLUDE_DIRS}")
 message(STATUS "numpy include path    : ${Python_NumPy_INCLUDE_DIRS}")
 message(STATUS "pybind11 include path : ${pybind11_INCLUDE_DIRS}")
 
+# Ensure position independent code for all targets
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Use FetchContent for fmt library
+include(FetchContent)
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG 9.1.0)
+
+# Configure fmt options before making it available
+set(FMT_MASTER_PROJECT OFF)
+set(BUILD_SHARED_LIBS OFF)
+FetchContent_MakeAvailable(fmt)
+
 # TODO: replace globbing with unique list, as globbing is bad practice
 file(GLOB SOURCES ${SRC}/*.c)
 add_library(xtgeo STATIC ${SOURCES})
@@ -30,7 +45,7 @@ if(MSVC)
   set(CXTGEOFLAGS /Ox /wd4996 /wd4267 /wd4244 /wd4305)
 else()
   set(XTGFLAGS -Wall -Wno-unused-but-set-variable -Wno-undef -fPIC)
-  set(CXTGEOFLAGS -Wall -Wno-unused-but-set-variable -Wno-undef)
+  set(CXTGEOFLAGS -Wall -Wno-unused-but-set-variable -Wno-undef -fPIC)
 endif()
 
 pybind11_add_module(
@@ -40,6 +55,7 @@ pybind11_add_module(
   "${SRC}/common/geometry/polygons.cpp"
   "${SRC}/common/geometry/quadrilateral.cpp"
   "${SRC}/common/geometry/volumes.cpp"
+  "${SRC}/common/logging/logging.cpp"
   "${SRC}/grid3d/cell.cpp"
   "${SRC}/grid3d/grid.cpp"
   "${SRC}/grid3d/grid_reorganize.cpp"
@@ -56,6 +72,8 @@ if(UNIX
    AND OpenMP_CXX_FOUND)
   target_link_libraries(_internal PRIVATE OpenMP::OpenMP_CXX)
 endif()
+
+target_link_libraries(_internal PRIVATE fmt::fmt)
 
 message(STATUS "Compiling swig bindings")
 

--- a/src/lib/include/xtgeo/logging.hpp
+++ b/src/lib/include/xtgeo/logging.hpp
@@ -2,82 +2,263 @@
 #define XTGEO_LOGGING_HPP_
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <iomanip>
+#include <atomic>
+#include <fmt/format.h>
+#include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 namespace py = pybind11;
 
+namespace xtgeo::logging {
+
+// Logger class for logging messages to Python's logging module
+// This class is thread-safe and can be used in a multi-threaded environment, inlcuding
+// OMP, but possibly be careful in parallel regions
+
+// It uses Python's Global Interpreter Lock (GIL) to ensure thread safety
+// and to avoid issues with Python's memory management
+// The logger can be used to log messages at different levels: debug, info, warning,
+// error, and critical
+// The logger name is passed as a parameter to the constructor, and it is used to create
+// a logger object in Python's logging module.
+
+// Thread-local storage for Python state
+class ThreadLocalPythonState
+{
+public:
+    ThreadLocalPythonState() : m_initialized(false) {}
+
+    // Initialize Python state for the current thread if needed
+    void ensure_initialized()
+    {
+        if (!m_initialized) {
+            // Initialize Python for this thread if needed
+            if (!Py_IsInitialized()) {
+                PyGILState_STATE gstate = PyGILState_Ensure();
+                PyGILState_Release(gstate);
+            }
+            m_initialized = true;
+        }
+    }
+
+private:
+    bool m_initialized;
+};
+
+// Logger class with explicit OMP support
 class Logger
 {
 public:
-    explicit Logger(const std::string &name) : logger_name(name)
+    explicit Logger(const std::string &name) : m_logger_name(name)
     {
-        py::gil_scoped_acquire acquire;  // Acquire GIL (Global Interpreter Lock)
+        initialize_python_objects();
+    }
+
+    // Delete copy constructor and assignment operator
+    Logger(const Logger &) = delete;
+    Logger &operator=(const Logger &) = delete;
+
+    // Delete move operations as well since std::mutex is not movable
+    Logger(Logger &&) = delete;
+    Logger &operator=(Logger &&) = delete;
+
+    // Initialize or reinitialize Python objects
+    void initialize_python_objects()
+    {
+        py::gil_scoped_acquire acquire;
         py::object logging = py::module::import("logging");
-        logger = logging.attr("getLogger")(logger_name);
+        m_logger = logging.attr("getLogger")(m_logger_name);
+        m_debug_level = logging.attr("DEBUG");
+        m_info_level = logging.attr("INFO");
+        m_warning_level = logging.attr("WARNING");
+        m_error_level = logging.attr("ERROR");
+        m_critical_level = logging.attr("CRITICAL");
+
+        // Pre-populate the level map
+        if (m_level_map.empty()) {
+            m_level_map["debug"] = "debug";
+            m_level_map["info"] = "info";
+            m_level_map["warning"] = "warning";
+            m_level_map["error"] = "error";
+            m_level_map["critical"] = "critical";
+        }
     }
 
     template<typename... Args>
-    void log(const std::string &level, const std::string &message, Args... args)
+    void log(const std::string &level, const std::string &format_string, Args... args)
     {
-        std::ostringstream oss;
-        ((oss << args << " "),
-         ...);  // Fold expression to concatenate arguments with spaces
-        std::string formatted_message =
-          "[C++: " + logger_name + "] " + message + oss.str();
+        std::string formatted_message;
 
-        {
-            py::gil_scoped_acquire acquire;  // Acquire GIL (Global Interpreter Lock)
-            if (level == "debug") {
-                logger.attr("debug")(formatted_message);
-            } else if (level == "info") {
-                logger.attr("info")(formatted_message);
-            } else if (level == "warning") {
-                logger.attr("warning")(formatted_message);
-            } else if (level == "error") {
-                logger.attr("error")(formatted_message);
-            } else if (level == "critical") {
-                logger.attr("critical")(formatted_message);
-            } else {
-                logger.attr("info")(formatted_message);
-            }
-        }  // GIL is released here
+        // Use fmt library for formatting
+        try {
+            formatted_message = fmt::format("[C++: {}] {}", m_logger_name,
+                                            fmt::format(format_string, args...));
+        } catch (const fmt::format_error &e) {
+            // Fallback to traditional formatting if the format string is invalid
+            std::ostringstream oss;
+            ((oss << args << " "), ...);
+            formatted_message =
+              fmt::format("[C++: {}] {} {}", m_logger_name, format_string, oss.str());
+        }
+
+        // Thread-local initialization
+        thread_local ThreadLocalPythonState tls;
+        tls.ensure_initialized();
+
+        // Acquire mutex for thread safety when accessing Python
+        std::lock_guard<std::mutex> lock(m_log_mutex);
+
+        // Call the appropriate logger method with GIL
+        py::gil_scoped_acquire acquire;
+
+        // Ensure Python objects are valid (they might not be in OMP contexts)
+        if (!m_logger) {
+            initialize_python_objects();
+        }
+
+        auto it = m_level_map.find(level);
+        if (it != m_level_map.end()) {
+            m_logger.attr(it->second.c_str())(formatted_message);
+        } else {
+            m_logger.attr("info")(formatted_message);
+        }
     }
 
     template<typename... Args>
     void debug(const std::string &message, Args... args)
     {
+        // Check if debug level is enabled before formatting message
+        bool enabled = false;
+        {
+            py::gil_scoped_acquire gil;
+            if (!m_logger) {
+                initialize_python_objects();
+            }
+            enabled = m_logger.attr("isEnabledFor")(m_debug_level).cast<bool>();
+        }
+
+        if (!enabled) {
+            return;
+        }
         log("debug", message, args...);
     }
 
+    // Other level methods similar to debug()...
     template<typename... Args>
     void info(const std::string &message, Args... args)
     {
+        bool enabled = false;
+        {
+            py::gil_scoped_acquire gil;
+            if (!m_logger) {
+                initialize_python_objects();
+            }
+            enabled = m_logger.attr("isEnabledFor")(m_info_level).cast<bool>();
+        }
+
+        if (!enabled) {
+            return;
+        }
         log("info", message, args...);
     }
 
     template<typename... Args>
     void warning(const std::string &message, Args... args)
     {
+        bool enabled = false;
+        {
+            py::gil_scoped_acquire gil;
+            if (!m_logger) {
+                initialize_python_objects();
+            }
+            enabled = m_logger.attr("isEnabledFor")(m_warning_level).cast<bool>();
+        }
+
+        if (!enabled) {
+            return;
+        }
         log("warning", message, args...);
     }
 
     template<typename... Args>
     void error(const std::string &message, Args... args)
     {
+        bool enabled = false;
+        {
+            py::gil_scoped_acquire gil;
+            if (!m_logger) {
+                initialize_python_objects();
+            }
+            enabled = m_logger.attr("isEnabledFor")(m_error_level).cast<bool>();
+        }
+
+        if (!enabled) {
+            return;
+        }
         log("error", message, args...);
     }
 
     template<typename... Args>
     void critical(const std::string &message, Args... args)
     {
+        bool enabled = false;
+        {
+            py::gil_scoped_acquire gil;
+            if (!m_logger) {
+                initialize_python_objects();
+            }
+            enabled = m_logger.attr("isEnabledFor")(m_critical_level).cast<bool>();
+        }
+
+        if (!enabled) {
+            return;
+        }
         log("critical", message, args...);
     }
 
 private:
-    std::string logger_name;
-    py::object logger;
+    std::string m_logger_name;
+    py::object m_logger;
+    py::object m_debug_level;
+    py::object m_info_level;
+    py::object m_warning_level;
+    py::object m_error_level;
+    py::object m_critical_level;
+    std::mutex m_log_mutex;
+    std::unordered_map<std::string, std::string> m_level_map;
 };
+
+// OMP-safe Singleton manager for loggers
+class LoggerManager
+{
+public:
+    static Logger &get(const std::string &name);
+
+private:
+    LoggerManager() = default;
+    ~LoggerManager() = default;
+
+    // Use pointers to avoid static initialization/destruction issues
+    static std::unordered_map<std::string, std::unique_ptr<Logger>> *m_loggers_ptr;
+    static std::mutex *m_manager_mutex_ptr;
+};
+
+void
+test_logging_levels(const std::string &logger_name);
+
+inline void
+init(py::module &m)
+{
+    auto m_logging = m.def_submodule("logging", "Internal functions for logging.");
+
+    m_logging.def("test_logging_levels", &test_logging_levels,
+                  "Test function to demonstrate logging at different levels",
+                  py::arg("logger_name"));
+}
+
+}  // namespace xtgeo::logging
 
 #endif  // XTGEO_LOGGING_HPP_

--- a/src/lib/src/common/logging/logging.cpp
+++ b/src/lib/src/common/logging/logging.cpp
@@ -1,0 +1,49 @@
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <xtgeo/logging.hpp>
+
+// Define static members outside the namespace
+std::unordered_map<std::string, std::unique_ptr<xtgeo::logging::Logger>>
+  *xtgeo::logging::LoggerManager::m_loggers_ptr = nullptr;
+std::mutex *xtgeo::logging::LoggerManager::m_manager_mutex_ptr = nullptr;
+
+namespace xtgeo::logging {
+
+Logger &
+LoggerManager::get(const std::string &name)
+{
+    // Rest of the implementation unchanged
+    static std::once_flag init_flag;
+    std::call_once(init_flag, []() {
+        // Initialize the logger map
+        m_loggers_ptr = new std::unordered_map<std::string, std::unique_ptr<Logger>>();
+        m_manager_mutex_ptr = new std::mutex();
+    });
+
+    std::lock_guard<std::mutex> lock(*m_manager_mutex_ptr);
+
+    auto it = m_loggers_ptr->find(name);
+    if (it == m_loggers_ptr->end()) {
+        // Create the logger in-place and return a reference to it
+        auto result = m_loggers_ptr->emplace(name, std::make_unique<Logger>(name));
+        return *(result.first->second);
+    }
+    return *(it->second);
+}
+
+// this is for unit testing in python
+void
+test_logging_levels(const std::string &logger_name)
+{
+    auto &logger = LoggerManager::get(logger_name);
+
+    // Log at different levels
+    logger.debug("This is a debug message from C++");
+    logger.info("This is an info message from C++");
+    logger.warning("This is a warning message from C++");
+    logger.error("This is an error message from C++");
+    logger.critical("This is a critical message from C++");
+}
+}  // namespace xtgeo::logging

--- a/src/lib/src/cube/cube.cpp
+++ b/src/lib/src/cube/cube.cpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 #include <vector>
 #include <xtgeo/cube.hpp>
+#include <xtgeo/logging.hpp>
 #include <xtgeo/numerics.hpp>
 
 namespace py = pybind11;
@@ -28,6 +29,8 @@ namespace xtgeo::cube {
 std::unordered_map<std::string, py::array_t<double>>
 cube_stats_along_z(const Cube &cube)
 {
+    auto &logger = xtgeo::logging::LoggerManager::get("xtgeo.cube.cube_stats_along_z");
+    logger.debug("Computing cube statistics along Z axis");
     size_t ncol = cube.ncol;
     size_t nrow = cube.nrow;
     size_t nlay = cube.nlay;
@@ -181,6 +184,7 @@ cube_stats_along_z(const Cube &cube)
     stats["sumneg"] = sumnegv;
     stats["sumabs"] = sumabsv;
 
+    logger.debug("Cube statistics computed successfully");
     return stats;
 }  // cube_stats_along_z()
 

--- a/src/lib/src/grid3d/grid.cpp
+++ b/src/lib/src/grid3d/grid.cpp
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <xtgeo/geometry.hpp>
 #include <xtgeo/grid3d.hpp>
+#include <xtgeo/logging.hpp>
 #include <xtgeo/numerics.hpp>
 #include <xtgeo/types.hpp>
 #include <xtgeo/xtgeo.h>
@@ -166,6 +167,15 @@ create_grid_from_cube(const cube::Cube &cube,
                       const bool use_cell_center,
                       const int flip)
 {
+
+    // logging here, more for demonstration than anything else
+    auto &logger =
+      xtgeo::logging::LoggerManager::get("xtgeo.grid3d.create_grid_from_cube");
+
+    logger.debug("Creating grid from cube with dimensions {} {} {} and cube "
+                 "xori/yori/zori: {:6.2f} {:6.2f} {:6.2f}",
+                 cube.ncol, cube.nrow, cube.nlay, cube.xori, cube.yori, cube.zori);
+
     // Define the shape of the arrays
     std::vector<size_t> coordsv_shape = { cube.ncol + 1, cube.nrow + 1, 6 };
     std::vector<size_t> zcornsv_shape = { cube.ncol + 1, cube.nrow + 1, cube.nlay + 1,

--- a/src/lib/src/grid3d/grid_reorganize.cpp
+++ b/src/lib/src/grid3d/grid_reorganize.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/numpy.h>
 #include <tuple>
 #include <xtgeo/grid3d.hpp>
+#include <xtgeo/logging.hpp>
 #include <xtgeo/types.hpp>
 
 namespace py = pybind11;
@@ -17,6 +18,10 @@ std::tuple<py::array_t<double>,
            py::array_t<bool>>
 convert_xtgeo_to_rmsapi(const Grid &grd)
 {
+    auto &logger =
+      xtgeo::logging::LoggerManager::get("xtgeo.grid3d.convert_xtgeo_to_rmsapi");
+    logger.debug("Converting XTGeo grid to RMSAPI grid layout");
+
     auto coordsv = grd.coordsv.unchecked<3>();
     auto zcornsv = grd.zcornsv.unchecked<4>();
     auto actnumsv = grd.actnumsv.unchecked<3>();
@@ -166,7 +171,7 @@ convert_xtgeo_to_rmsapi(const Grid &grd)
             }
         }
     }
-
+    logger.debug("Conversion to RMSAPI grid layout completed");
     return std::make_tuple(tpillars, bpillars, zcorners, zmask);
 }
 

--- a/src/lib/src/init.cpp
+++ b/src/lib/src/init.cpp
@@ -2,6 +2,7 @@
 #include <xtgeo/cube.hpp>
 #include <xtgeo/geometry.hpp>
 #include <xtgeo/grid3d.hpp>
+#include <xtgeo/logging.hpp>
 #include <xtgeo/numerics.hpp>
 #include <xtgeo/regsurf.hpp>
 #include <xtgeo/xyz.hpp>
@@ -14,6 +15,7 @@ PYBIND11_MODULE(_internal, m)
     xtgeo::cube::init(m);
     xtgeo::geometry::init(m);
     xtgeo::grid3d::init(m);
+    xtgeo::logging::init(m);
     xtgeo::regsurf::init(m);
     xtgeo::numerics::init(m);
     xtgeo::xyz::init(m);

--- a/src/lib/src/regsurf/sample_grid3d.cpp
+++ b/src/lib/src/regsurf/sample_grid3d.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <vector>
 #include <xtgeo/grid3d.hpp>
+#include <xtgeo/logging.hpp>
 #include <xtgeo/numerics.hpp>
 #include <xtgeo/regsurf.hpp>
 
@@ -37,9 +38,15 @@ sample_grid3d_layer(const RegularSurface &regsurf,
                     const int index_position,  // 0: top, 1: base|bot, 2: center
                     const int num_threads)
 {
+    auto &logger =
+      xtgeo::logging::LoggerManager::get("xtgeo.regsurf.sample_grid3d_layer");
+    logger.debug("Sampling grid3d layer ", klayer, " to regular surface");
+    logger.debug("Initial number of threads: ", num_threads);
+
     // clang-format off
     #ifdef __linux__
       if (num_threads > 0) omp_set_num_threads(num_threads);
+      logger.debug("Actual number of threads: ", omp_get_max_threads());
     #endif
     // clang-format on
 

--- a/src/xtgeo/common/log.py
+++ b/src/xtgeo/common/log.py
@@ -39,6 +39,7 @@ def functimer(
     func: Optional[Callable] = None,
     *,
     output: Literal["debug", "info", "print"] = "debug",
+    comment: str = "",
 ) -> Callable:
     """A decorator function to measure the execution time of a function.
 
@@ -47,7 +48,7 @@ def functimer(
 
     Usage is simple, just add the decorator to the function you want to measure:
 
-    @functimer(output="print")
+    @functimer(output="print", comment="My function took a while to run")
     def my_function():
         pass
 
@@ -61,7 +62,7 @@ def functimer(
     if func is None:
 
         def decorator(func: Callable) -> Callable:
-            return functimer(func, output=output)
+            return functimer(func, output=output, comment=comment)
 
         return decorator
 
@@ -73,16 +74,20 @@ def functimer(
         result = func(*args, **kwargs)  # Execute the function
         end_time = time.perf_counter()  # End the timer
         elapsed_time = f"{end_time - start_time: .5f}"
+
+        # Build message with optional comment
+        message = f"Function {func.__name__} executed in {elapsed_time} seconds"
+        if comment:
+            message += f" - {comment}"
+
+        # Output according to specified method
         if output == "print":
-            print(f"Function {func.__name__} executed in {elapsed_time} seconds")
+            print(message)
         elif output == "info":
-            logger.info(
-                "Function %s executed in %s seconds", func.__name__, elapsed_time
-            )
+            logger.info(message)
         else:
-            logger.debug(
-                "Function %s executed in %s seconds", func.__name__, elapsed_time
-            )
+            logger.debug(message)
+
         return result
 
     return wrapper

--- a/src/xtgeo/grid3d/_grid_etc1.py
+++ b/src/xtgeo/grid3d/_grid_etc1.py
@@ -69,6 +69,7 @@ def create_box(
     )
 
     cubecpp = _internal.cube.Cube(cube)
+    logger.debug("Calling CPP internal 'create_grid_from_cube'...")
     coordsv, zcornsv, actnumsv = _internal.grid3d.create_grid_from_cube(
         cubecpp, oricenter, flip
     )

--- a/tests/test_common/test_calc.py
+++ b/tests/test_common/test_calc.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import pathlib
 
@@ -10,7 +11,7 @@ import xtgeo.common.calc as xcalc
 from xtgeo import _cxtgeo
 
 xtg = xtgeo.XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 TESTGRID = pathlib.Path("3dgrids/etc/gridqc1.roff")
 TESTGRID_TBULK = pathlib.Path("3dgrids/etc/gridqc1_totbulk.roff")

--- a/tests/test_cube/test_cube.py
+++ b/tests/test_cube/test_cube.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import hypothesis.strategies as st
@@ -7,15 +8,13 @@ import segyio
 from hypothesis import HealthCheck, given, settings
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.cube import Cube
 from xtgeo.cube._cube_import import (
     _import_segy_all_traces,
     _import_segy_incomplete_traces,
 )
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 SFILE1 = pathlib.Path("cubes/reek/syntseis_20000101_seismic_depth_stack.segy")
 SFILE3 = pathlib.Path("cubes/reek/syntseis_20000101_seismic_depth_stack.storm")
@@ -142,15 +141,9 @@ def test_segy_export_import(tmp_path, testdata_path):
 def test_storm_import(testdata_path):
     """Import Cube using Storm format (case Reek)."""
 
-    st1 = xtg.timer()
     acube = xtgeo.cube_from_file(testdata_path / SFILE3, fformat="storm")
-    elapsed = xtg.timer(st1)
-    logger.info("Reading Storm format took %s", elapsed)
-
     assert acube.ncol == 280, "NCOL"
-
     vals = acube.values
-
     assert vals[180, 185, 4] == pytest.approx(0.117074, 0.0001)
 
 
@@ -159,10 +152,7 @@ def test_storm_import(testdata_path):
 def test_segy_import(loadsfile1):
     """Import SEGY using internal reader (case 1 Reek)."""
 
-    st1 = xtg.timer()
     xcu = loadsfile1
-    elapsed = xtg.timer(st1)
-    logger.info("Reading with XTGEO took %s", elapsed)
 
     assert xcu.ncol == 408, "NCOL"
 
@@ -170,17 +160,13 @@ def test_segy_import(loadsfile1):
 
     assert dim == (408, 280, 70), "Dimensions 3D"
 
-    print(xcu.values.max())
     assert xcu.values.max() == pytest.approx(7.42017, 0.001)
 
 
 def test_segyio_import(loadsfile1):
     """Import SEGY (case 1 Reek) via SegIO library."""
 
-    st1 = xtg.timer()
     xcu = loadsfile1
-    elapsed = xtg.timer(st1)
-    logger.info("Reading with SEGYIO took %s", elapsed)
 
     assert xcu.ncol == 408, "NCOL"
     dim = xcu.values.shape

--- a/tests/test_etc/test_etc_make_avg_maps.py
+++ b/tests/test_etc/test_etc_make_avg_maps.py
@@ -1,16 +1,13 @@
+import logging
 import pathlib
 
 import numpy as np
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 
-# set default level
-xtg = XTGeoDialog()
-
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 GFILE2 = pathlib.Path("3dgrids/reek/REEK.EGRID")
 IFILE2 = pathlib.Path("3dgrids/reek/REEK.INIT")

--- a/tests/test_etc/test_etc_make_hcpv_maps.py
+++ b/tests/test_etc/test_etc_make_hcpv_maps.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import numpy as np
@@ -5,13 +6,9 @@ import numpy.ma as ma
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 
-# set default level
-xtg = XTGeoDialog()
-
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 ROFF1_GRID = pathlib.Path("3dgrids/eme/1/emerald_hetero_grid.roff")
 ROFF1_PROPS = pathlib.Path("3dgrids/eme/1/emerald_hetero.roff")
@@ -84,7 +81,6 @@ def test_hcpvfz1(tmp_path, generate_plot, testdata_path):
     zp = np.ones((grd.ncol, grd.nrow, grd.nlay))
     # now make hcpf map
 
-    t1 = xtg.timer()
     hcmap.hc_thickness_from_3dprops(
         xprop=xcv,
         yprop=ycv,
@@ -96,11 +92,6 @@ def test_hcpvfz1(tmp_path, generate_plot, testdata_path):
 
     assert hcmap.values.mean() == pytest.approx(1.447, abs=0.1)
 
-    t2 = xtg.timer(t1)
-
-    logger.info("Speed basic is %s", t2)
-
-    t1 = xtg.timer()
     hcmap2.hc_thickness_from_3dprops(
         xprop=xcv,
         yprop=ycv,
@@ -112,9 +103,6 @@ def test_hcpvfz1(tmp_path, generate_plot, testdata_path):
         zone_minmax=(1, 1),
         mask_outside=True,
     )
-    t2 = xtg.timer(t1)
-
-    logger.info("Speed zoneavg coarsen 2 is %s", t2)
 
     if generate_plot:
         hcmap.quickplot(filename=tmp_path / "quickplot_hcpv.png")

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -1,6 +1,7 @@
 """Testing: test_grid_operations"""
 
 import io
+import logging
 import pathlib
 
 import hypothesis.strategies as st
@@ -8,15 +9,13 @@ import pytest
 from hypothesis import assume, given
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.grid3d import GridProperties, GridProperty
 
 from .grid_generator import xtgeo_grids
 from .gridprop_generator import grid_properties as gridproperties_elements, keywords
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 GFILE1 = pathlib.Path("3dgrids/reek/REEK.EGRID")
 IFILE1 = pathlib.Path("3dgrids/reek/REEK.INIT")
@@ -124,12 +123,8 @@ def test_gridproperties_invalid_format(grid_property):
 
 def test_scan_dates(testdata_path):
     """A static method to scan dates in a RESTART file"""
-    t1 = xtg.timer()
     assert GridProperties.scan_dates(testdata_path / RFILE2) == [(0, 20220101)]
-    t2 = xtg.timer(t1)
-    logger.info(f"Scanned {RFILE2} scanned in {t2} seconds")
 
-    t1 = xtg.timer()
     assert GridProperties.scan_dates(testdata_path / RFILE1) == [
         (0, 19991201),
         (1, 20000101),
@@ -147,9 +142,6 @@ def test_scan_dates(testdata_path):
         (13, 20010101),
         (14, 20030101),
     ]
-    t2 = xtg.timer(t1)
-    logger.info(f"Scanned {RFILE1} scanned in {t2} seconds")
-    t1 = xtg.timer()
     assert GridProperties.scan_dates(testdata_path / SPEFILE1) == [
         (0, 19900101),
         (1, 19900102),
@@ -188,8 +180,6 @@ def test_scan_dates(testdata_path):
         (34, 19920505),
         (35, 19920619),
     ]
-    t2 = xtg.timer(t1)
-    logger.info(f"Scanned {SPEFILE1} scanned in {t2} seconds")
 
 
 def test_scan_dates_invalid_file(testdata_path):
@@ -200,13 +190,9 @@ def test_scan_dates_invalid_file(testdata_path):
 
 def test_dates_from_restart(testdata_path):
     """A simpler static method to scan dates in a RESTART file"""
-    t1 = xtg.timer()
     assert GridProperties.scan_dates(testdata_path / RFILE2, datesonly=True) == [
         20220101
     ]
-    t2 = xtg.timer(t1)
-    logger.info(f"Scanned {RFILE2} scanned in {t2} seconds")
-    t1 = xtg.timer()
     assert GridProperties.scan_dates(testdata_path / RFILE1, datesonly=True) == [
         19991201,
         20000101,
@@ -224,9 +210,6 @@ def test_dates_from_restart(testdata_path):
         20010101,
         20030101,
     ]
-    t2 = xtg.timer(t1)
-    logger.info(f"Scanned {RFILE1} scanned in {t2} seconds")
-    t1 = xtg.timer()
     assert GridProperties.scan_dates(testdata_path / SPEFILE1, datesonly=True) == [
         19900101,
         19900102,
@@ -265,8 +248,6 @@ def test_dates_from_restart(testdata_path):
         19920505,
         19920619,
     ]
-    t2 = xtg.timer(t1)
-    logger.info(f"Scanned {SPEFILE1} scanned in {t2} seconds")
 
 
 def test_get_dataframe(testdata_path):

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -11,16 +11,11 @@ import pytest
 from hypothesis import HealthCheck, example, given, settings
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import KeywordNotFoundError
 from xtgeo.grid3d import GridProperty
 
 from .grid_generator import dimensions, xtgeo_grids
 from .gridprop_generator import grid_properties
-
-# set default level
-xtg = XTGeoDialog()
-
 
 TESTFILE1 = pathlib.Path("3dgrids/reek/reek_sim_poro.roff")
 TESTFILE2 = pathlib.Path("3dgrids/eme/1/emerald_hetero.roff")

--- a/tests/test_grid3d/test_grid_vs_well.py
+++ b/tests/test_grid3d/test_grid_vs_well.py
@@ -1,12 +1,11 @@
+import logging
 import pathlib
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 GRIDFILE = pathlib.Path("3dgrids/reek/reek_sim_grid.roff")
 ZONEFILE = pathlib.Path("3dgrids/reek/reek_sim_zone.roff")

--- a/tests/test_grid3d/test_grid_xtgformats_io.py
+++ b/tests/test_grid3d/test_grid_xtgformats_io.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 """Testing new xtgf and hdf5/h5 formats."""
 
+import logging
 from os.path import join
 
 import hypothesis.strategies as st
@@ -10,10 +11,8 @@ from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_allclose
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 BIGBOX_DIMENSIONS = (100, 100, 20)

--- a/tests/test_grid3d/test_gridprops_list_properties.py
+++ b/tests/test_grid3d/test_gridprops_list_properties.py
@@ -1,16 +1,15 @@
+import logging
 import pathlib
 from pathlib import Path
 
 import pytest
 
-from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.grid3d import list_gridproperties
 from xtgeo.grid3d._gridprops_import_roff import read_roff_properties
 from xtgeo.io._file import FileWrapper
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 E100_BO_FINIT = pathlib.Path("3dgrids/simpleb8/E100_BO.FINIT")
 E100_BO_FUNRST = pathlib.Path("3dgrids/simpleb8/E100_BO.FUNRST")

--- a/tests/test_internal/test_cpp_logging.py
+++ b/tests/test_internal/test_cpp_logging.py
@@ -1,0 +1,147 @@
+import io
+import logging
+from contextlib import contextmanager
+
+import pytest
+
+import xtgeo
+import xtgeo._internal as _internal  # type: ignore # noqa
+
+
+@contextmanager
+def capture_logs(logger_name, level=logging.DEBUG):
+    """Capture logs from a specific logger."""
+    # Create a logger
+    logger = logging.getLogger(logger_name)
+    original_level = logger.level
+    logger.setLevel(level)
+
+    # Create a string IO handler to capture logs
+    log_capture = io.StringIO()
+    handler = logging.StreamHandler(log_capture)
+    handler.setLevel(level)
+    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    try:
+        yield log_capture
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(original_level)
+
+
+# Convert to a pytest fixture for reuse across tests
+@pytest.fixture
+def log_capturer():
+    """Fixture that returns a function to capture logs."""
+
+    def _capture_logs(logger_name, level=logging.DEBUG):
+        return capture_logs(logger_name, level)
+
+    return _capture_logs
+
+
+def test_regsurf_logging(log_capturer):
+    """Test that C++ logs as expected in regular surface operations."""
+    logger_name = "xtgeo.regsurf.sample_grid3d_layer"
+
+    with log_capturer(logger_name) as log_capture:
+        # Call a function that should trigger C++ logging
+        grid = xtgeo.create_box_grid((10, 10, 10))
+        _ = xtgeo.surface_from_grid3d(grid)
+
+        # Get the captured logs
+        log_contents = log_capture.getvalue()
+
+        # Verify logs contain expected messages
+        assert (
+            "[C++: xtgeo.regsurf.sample_grid3d_layer] Sampling grid3d" in log_contents
+        )
+
+
+def test_logging_levels(log_capturer):
+    """Test that C++ respects Python logging levels."""
+    logger_name = "xtgeo.test_logger"
+
+    # Create a custom logger for testing
+    logger = logging.getLogger(logger_name)
+    original_level = logger.level
+
+    try:
+        # Set the logger level to INFO - debug messages should not appear
+        logger.setLevel(logging.INFO)
+
+        with log_capturer(logger_name, level=logging.INFO) as log_capture:
+            # Call a function that logs at different levels
+            _internal.logging.test_logging_levels(logger_name)
+
+            log_contents = log_capture.getvalue()
+
+            # Debug messages should not be present
+            assert "DEBUG:" not in log_contents
+            # Info messages should be present
+            assert "INFO:" in log_contents
+
+    finally:
+        logger.setLevel(original_level)
+
+
+# Add a test for all logging levels
+@pytest.mark.parametrize(
+    "log_level,visible_levels,hidden_levels",
+    [
+        (logging.DEBUG, ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], []),
+        (logging.INFO, ["INFO", "WARNING", "ERROR", "CRITICAL"], ["DEBUG"]),
+        (logging.WARNING, ["WARNING", "ERROR", "CRITICAL"], ["DEBUG", "INFO"]),
+        (logging.ERROR, ["ERROR", "CRITICAL"], ["DEBUG", "INFO", "WARNING"]),
+        (logging.CRITICAL, ["CRITICAL"], ["DEBUG", "INFO", "WARNING", "ERROR"]),
+    ],
+)
+def test_all_logging_levels(log_capturer, log_level, visible_levels, hidden_levels):
+    """Test that all logging levels are respected correctly."""
+    logger_name = f"xtgeo.test_logger.{log_level}"
+    logger = logging.getLogger(logger_name)
+    original_level = logger.level
+
+    try:
+        logger.setLevel(log_level)
+
+        with log_capturer(logger_name, level=log_level) as log_capture:
+            _internal.logging.test_logging_levels(logger_name)
+
+            log_contents = log_capture.getvalue()
+
+            # Check visible levels
+            for level in visible_levels:
+                assert f"{level}:" in log_contents, (
+                    f"Expected {level} to be visible at log level {log_level}"
+                )
+
+            # Check hidden levels
+            for level in hidden_levels:
+                assert f"{level}:" not in log_contents, (
+                    f"Expected {level} to be hidden at log level {log_level}"
+                )
+
+    finally:
+        logger.setLevel(original_level)
+
+
+# Test that thread logging works
+def test_thread_logging(log_capturer):
+    """Test that thread information is properly logged."""
+    logger_name = "xtgeo.regsurf.sample_grid3d_layer"
+
+    with log_capturer(logger_name) as log_capture:
+        # Trigger a function that uses multiple threads
+        grid = xtgeo.create_box_grid(
+            (20, 20, 20)
+        )  # Larger grid to ensure multi-threading
+        _ = xtgeo.surface_from_grid3d(grid)
+
+        log_contents = log_capture.getvalue()
+
+        # Check for thread-related logging
+        # This assertion might need adjustment based on your actual logging format
+        assert "thread" in log_contents.lower() or "Thread" in log_contents

--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -11,6 +11,7 @@ ran in e.g. public Github actions.
 
 from __future__ import annotations
 
+import logging
 import pathlib
 from typing import Any
 
@@ -18,11 +19,9 @@ import numpy as np
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog, null_logger
 from xtgeo.roxutils._roxar_loader import roxar, roxar_jobs, roxar_well_picks
 
-xtg = XTGeoDialog()
-logger = null_logger(__name__)
+logger = logging.getLogger(__name__)
 
 PROJNAME = "tmp_project.rmsxxx"
 

--- a/tests/test_surface/test_ijxyz_spec.py
+++ b/tests/test_surface/test_ijxyz_spec.py
@@ -7,14 +7,14 @@ import numpy as np
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.surface._regsurf_ijxyz_parser import SurfaceIJXYZ
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 IJXYZFILE1 = pathlib.Path("surfaces/etc/ijxyz1.dat")  # OW IJXYZ format with comments

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -1,5 +1,6 @@
 """Testing RegularSurface class with methods."""
 
+import logging
 import pathlib
 import sys
 
@@ -9,11 +10,9 @@ import pytest
 
 import xtgeo
 from xtgeo import RegularSurface
-from xtgeo.common import XTGeoDialog
 from xtgeo.common.exceptions import InvalidFileFormatError
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 TESTSET1 = pathlib.Path("surfaces/reek/1/topreek_rota.gri")
 TESTSET1A = pathlib.Path("surfaces/reek/1/basereek_rota.gri")
@@ -255,18 +254,12 @@ def test_irapbin_import_metadatafirst(testdata_path):
 
     nsurf = 10
     sur = []
-    t1 = xtg.timer()
     for ix in range(nsurf):
         sur.append(xtgeo.surface_from_file(testdata_path / TESTSET2, values=False))
-    t2 = xtg.timer(t1)
-    logger.info("Loading %s surfaces lazy took %s secs.", nsurf, t2)
     assert sur[nsurf - 1].ncol == 1264
 
-    t1 = xtg.timer()
     for ix in range(nsurf):
         sur[ix].load_values()
-    t2 = xtg.timer(t1)
-    logger.info("Loading %s surfaces actual values took %s secs.", nsurf, t2)
 
     assert sur[nsurf - 1].ncol == 1264
     assert sur[nsurf - 1].nrow == 2010

--- a/tests/test_surface/test_regular_surface_bytesio.py
+++ b/tests/test_surface/test_regular_surface_bytesio.py
@@ -2,16 +2,15 @@
 
 import base64
 import io
+import logging
 import pathlib
 import threading
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 TESTSET1 = pathlib.Path("surfaces/reek/1/topreek_rota.gri")
 TESTSET2 = pathlib.Path("surfaces/reek/1/topreek_rota.fgr")

--- a/tests/test_surface/test_regular_surface_in_other.py
+++ b/tests/test_surface/test_regular_surface_in_other.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import numpy as np
@@ -5,10 +6,8 @@ import numpy.ma as ma
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 SURF1 = pathlib.Path("surfaces/reek/1/topreek_rota.gri")
 POLY1 = pathlib.Path("polygons/reek/1/closedpoly1.pol")

--- a/tests/test_surface/test_regular_surface_resample.py
+++ b/tests/test_surface/test_regular_surface_resample.py
@@ -1,16 +1,15 @@
 """Testing regular surface vs resampling."""
 
+import logging
 import pathlib
 
 import numpy as np
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 FTOP1 = pathlib.Path("surfaces/reek/1/topreek_rota.gri")
 

--- a/tests/test_surface/test_regular_surface_vs_cube.py
+++ b/tests/test_surface/test_regular_surface_vs_cube.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import numpy as np
@@ -5,9 +6,8 @@ import numpy.ma as ma
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
+logger = logging.getLogger(__name__)
 
 RPATH1 = pathlib.Path("surfaces/reek")
 RPATH3 = pathlib.Path("surfaces/etc")

--- a/tests/test_surface/test_regular_surface_vs_points.py
+++ b/tests/test_surface/test_regular_surface_vs_points.py
@@ -1,14 +1,13 @@
+import logging
 import pathlib
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 from xtgeo.xyz import Points
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 FTOP1 = pathlib.Path("surfaces/reek/1/reek_stooip_map.gri")
 

--- a/tests/test_surface/test_regular_surface_xtgformats_io.py
+++ b/tests/test_surface/test_regular_surface_xtgformats_io.py
@@ -7,9 +7,6 @@ import pytest
 from numpy.testing import assert_allclose
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
-
-xtg = XTGeoDialog()
 
 
 @pytest.fixture(name="benchmark_surface")

--- a/tests/test_well/test_blockedwell.py
+++ b/tests/test_well/test_blockedwell.py
@@ -1,12 +1,11 @@
+import logging
 from os.path import join
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(name="loadwell1")

--- a/tests/test_well/test_blockedwells.py
+++ b/tests/test_well/test_blockedwells.py
@@ -1,13 +1,12 @@
+import logging
 from os.path import join
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.well import BlockedWells
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(name="testblockedwells")

--- a/tests/test_well/test_well.py
+++ b/tests/test_well/test_well.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 
 import numpy as np
@@ -5,12 +6,10 @@ import pandas as pd
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.well import Well
 from xtgeo.xyz import Polygons
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 WFILE = pathlib.Path("wells/reek/1/OP_1.w")
 WFILE2 = pathlib.Path("wells/reek/2/OP_6a.w")
@@ -286,15 +285,11 @@ def test_shortwellname(create_well):
 
 
 def test_import_export_rmsasc(tmp_path, simple_well):
-    t0 = xtg.timer()
     wname = (tmp_path / "$random").with_suffix(".rmsasc")
     wuse = simple_well.to_file(wname)
-    print("Time for save RMSASC: ", xtg.timer(t0))
 
-    t0 = xtg.timer()
     result = xtgeo.well_from_file(wuse)
     assert result.get_dataframe().equals(result.get_dataframe())
-    print("Time for load RMSASC: ", xtg.timer(t0))
 
 
 def test_create_and_delete_logs(loadwell3):

--- a/tests/test_well/test_well_to_points.py
+++ b/tests/test_well/test_well_to_points.py
@@ -1,12 +1,11 @@
+import logging
 import pathlib
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 WFILE = pathlib.Path("wells/etc/otest.rmswell")
 

--- a/tests/test_well/test_well_to_polygons.py
+++ b/tests/test_well/test_well_to_polygons.py
@@ -1,10 +1,9 @@
+import logging
 import os
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def test_well_to_polygons(testdata_path):

--- a/tests/test_well/test_well_vs_grid.py
+++ b/tests/test_well/test_well_vs_grid.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
+import logging
 import pathlib
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 WFILE = pathlib.Path("wells/reek/1/OP_1.w")
 GFILE = pathlib.Path("3dgrids/reek/REEK.EGRID")

--- a/tests/test_well/test_wells.py
+++ b/tests/test_well/test_wells.py
@@ -1,13 +1,12 @@
+import logging
 from os.path import join
 
 import pytest
 
 import xtgeo
-from xtgeo.common import XTGeoDialog
 from xtgeo.well import Wells
 
-xtg = XTGeoDialog()
-logger = xtg.basiclogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(name="testwells")


### PR DESCRIPTION
First commit:
When integrating python and C++, consistent debugging may be challenging, and getting the logging to work across both is quite beneficial. With this PR, the C++ is now a working part of python logging, still allowing multithreading.

Typical logging while testing: `pytest -k some_test_function -o log_cli=true -o log_cli_level=debug` 
Closes #1320 

Second commit:
In addition, many tests in python uses patterns like `logger = xtg. basic_logger(...)` (should have been `xtg.function_logger(...)`; my bad a long time ago... but anyway), now change these to standard 
`logger = logging.getLogger(__name__)`
Closes #1174