### PR TITLE
ENH: Add Run Length Encoding compression for GRDECL format

### DIFF
--- a/src/xtgeo/grid3d/_grdecl_format.py
+++ b/src/xtgeo/grid3d/_grdecl_format.py
@@ -4,6 +4,8 @@ import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from xtgeo.common import null_logger
 
 if TYPE_CHECKING:
@@ -13,6 +15,43 @@ if TYPE_CHECKING:
     from xtgeo.common.types import FileLike
 
 logger = null_logger(__name__)
+
+
+def run_length_encoding(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Perform run-length encoding on a 1D NumPy array.
+
+    Run-length encoding is a data compression technique that represents
+    consecutive repeated values as a single value and a count.
+
+    Parameters:
+    -----------
+    arr : np.ndarray
+        A 1D NumPy array to be encoded.
+
+    Returns:
+    --------
+    tuple[np.ndarray, np.ndarray]
+        A tuple containing two 1D NumPy arrays:
+        - counts: An array of counts representing the number of consecutive occurrences
+                  of each unique value.
+        - values: An array of the unique values corresponding to the counts.
+
+    Example:
+    --------
+    >>> import numpy as np
+    >>> arr = np.array([1, 1, 2, 2, 2, 3, 3, 1])
+    >>> counts, values = run_length_encoding(arr)
+    >>> counts
+    array([2, 3, 2, 1])
+    >>> values
+    array([1, 2, 3, 1])
+    """
+    change_indices = np.where(~np.isclose(arr[:-1], arr[1:]))[0] + 1
+    counts = np.diff(np.concatenate(([0], change_indices, [len(arr)])))
+    values = arr[np.concatenate(([0], change_indices))]
+
+    return counts, values
 
 
 def split_line(line: str) -> Generator[str, None, None]:

--- a/src/xtgeo/grid3d/_grdecl_grid.py
+++ b/src/xtgeo/grid3d/_grdecl_grid.py
@@ -41,7 +41,7 @@ from ._ecl_grid import (
     MapAxes,
     Units,
 )
-from ._grdecl_format import IGNORE_ALL, open_grdecl
+from ._grdecl_format import IGNORE_ALL, open_grdecl, run_length_encoding
 
 
 @dataclass
@@ -340,14 +340,24 @@ class GrdeclGrid(EclGrid):
                 if values is None:
                     continue
                 filestream.write(f"{kw}\n")
-                numcolumns = 0
-                for value in values:
-                    numcolumns += 1
-                    filestream.write(f" {value}")
+                if kw == "ACTNUM":
+                    counts, unique_values = run_length_encoding(values)
+                    for i, (count, unique_value) in enumerate(
+                        zip(counts, unique_values)
+                    ):
+                        filestream.write(
+                            f" {count}*{unique_value}"
+                            if count > 1
+                            else f" {unique_value}"
+                        )
+                        if i % 6 == 5:
+                            filestream.write("\n")
+                else:
+                    for i, value in enumerate(values):
+                        filestream.write(f" {value}")
 
-                    if numcolumns >= 6:  # 6 should ensure < 128 character width total
-                        filestream.write("\n")
-                        numcolumns = 0
+                        if i % 6 == 5:  # 6 should ensure < 128 character width total
+                            filestream.write("\n")
 
                 filestream.write("\n /\n")
 

--- a/src/xtgeo/grid3d/_gridprop_export.py
+++ b/src/xtgeo/grid3d/_gridprop_export.py
@@ -17,6 +17,7 @@ from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.common.log import null_logger
 from xtgeo.io._file import FileFormat, FileWrapper
 
+from ._grdecl_format import run_length_encoding
 from ._roff_parameter import RoffParameter
 
 if TYPE_CHECKING:
@@ -130,16 +131,19 @@ def _export_grdecl(
         else:
             # Always the case when not binary
             assert isinstance(fout, io.TextIOWrapper)
-            fout.write(name)
-            fout.write("\n")
-            for i, v in enumerate(vals):
+            fout.write(f"{name}\n")
+            counts, unique_values = run_length_encoding(vals)
+            for i, (count, unique_value) in enumerate(zip(counts, unique_values)):
                 fout.write(" ")
                 if fmt:
-                    fout.write(fmt % v)
+                    formatted_value = fmt % unique_value
                 elif gridprop.isdiscrete:
-                    fout.write(str(v))
+                    formatted_value = str(unique_value)
                 else:
-                    fout.write(f"{v:3e}")
+                    formatted_value = f"{unique_value:3e}"
+                fout.write(
+                    f"{count}*{formatted_value}" if count > 1 else formatted_value
+                )
                 if i % 6 == 5:
                     fout.write("\n")
             fout.write(" /\n")

--- a/tests/test_grid3d/test_grid_property.py
+++ b/tests/test_grid3d/test_grid_property.py
@@ -335,7 +335,7 @@ def test_eclinit_simple_importexport(tmp_path, testdata_path):
     )
     with open(tmp_path / "simple_disc.grdecl") as f:
         fields = f.read().split()
-        assert len(fields) == 17
+        assert len(fields) == 14
         assert fields[3] == "1"  # undef cell for discrete
 
 


### PR DESCRIPTION
Closes #1325 

I'm contemplating if we should make it optional, but to my knowledge, the RLE is supported by most if not all tools that we are using (eclipse, flow, xtgeo, rms and resinsight)