### PR TITLE
ENH: Utilize grid property  codes when using grid.subgrids_from_zoneprop method

### DIFF
--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -1293,7 +1293,10 @@ class Grid(_Grid3D):
         for izone in range(minzone, maxzone + 1):
             mininzn = int(kval[zprval == izone].min())  # 1 base
             maxinzn = int(kval[zprval == izone].max())  # 1 base
-            newd["zone" + str(izone)] = range(mininzn, maxinzn + 1)
+
+            newd[zoneprop.codes.get(izone, "zone" + str(izone))] = range(
+                mininzn, maxinzn + 1
+            )
 
         self.subgrids = newd  # type: ignore
 

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -178,8 +178,10 @@ def test_subgrids():
     zprop = k_index.copy()
     zprop.values[k_index.values > 4] = 2
     zprop.values[k_index.values <= 4] = 1
+    zprop.codes = {1: "Upper", 2: "Lower"}
 
-    grd.subgrids_from_zoneprop(zprop)
+    subgrids = grd.subgrids_from_zoneprop(zprop)
+    assert "Upper" in subgrids
 
     # rename
     grd.rename_subgrids(["AAAA", "BBBB"])

--- a/tests/test_grid3d/test_grid_operations.py
+++ b/tests/test_grid3d/test_grid_operations.py
@@ -132,7 +132,7 @@ def test_refine_vertically_per_zone(testdata_path):
     refinement = {1: 4, 2: 2}
     grd.refine_vertically(refinement, zoneprop=emerald2_zone)
 
-    assert grd.get_subgrids() == {"zone1": 64, "zone2": 60}
+    assert grd.get_subgrids() == {"Zone1": 64, "Zone2": 60}
 
     grd = emerald2_grid.copy()
     grd.refine_vertically(refinement)  # no zoneprop


### PR DESCRIPTION
Closes #1327 

Use zone property codes if they are available when calling `grid.subgrids_from_zoneprop` method