### PR TITLE
TST: Skip tests on rmsapi license error

### DIFF
--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -76,7 +76,17 @@ def tmp_data_dir(tmp_path_factory):
 @pytest.fixture(name="roxinstance", scope="module")
 def fixture_roxinstance():
     """Create roxinstance in module scope."""
-    project = roxar.Project.create()
+    # Imports indirectly from rmsapi also
+    from roxar import LicenseError
+
+    try:
+        project = roxar.Project.create()
+    except LicenseError:
+        pytest.skip(
+            "Unable to check out RMS API license. This indicates an error that "
+            "must be resolved with the RMS installation or RMS license server.",
+            allow_module_level=True,
+        )
     return xtgeo.RoxUtils(project)
 
 


### PR DESCRIPTION
Resolves #1359
Should fix the failing CI by skipping these tests.