### PR TITLE
BLD: Use newer manylinux for wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
           - [macos-latest, macosx_arm64]  # macos-latest is always arm64 going forward
     env:
       CIBW_BUILD: ${{ matrix.python }}-${{ matrix.os_arch[1] }}
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #1362

We've used manylinux2014 for years now but it is now a year past EOL. Most platforms it supported as its minimum version are also out of date. This PR drops support for manylinux2014 and moves to manylinux_2_28 which still supports Python 3.8 as a minimum version but does not reach EOL until 2029.