### PR TITLE
Add missing documentation for some class functions

### DIFF
--- a/docs/api-grids.rst
+++ b/docs/api-grids.rst
@@ -11,6 +11,12 @@ Functions
 
 .. autofunction:: xtgeo.grid_from_roxar
 
+.. autofunction:: xtgeo.create_box_grid
+
+.. autofunction:: xtgeo.grid_from_cube
+
+.. autofunction:: xtgeo.grid_from_surfaces
+
 Classes
 """""""
 

--- a/docs/api-well.rst
+++ b/docs/api-well.rst
@@ -21,6 +21,11 @@ Classes
 Wells (multiple)
 ^^^^^^^^^^^^^^^^
 
+Functions
+"""""""""
+
+.. autofunction:: xtgeo.wells_from_files
+
 Classes
 """""""
 


### PR DESCRIPTION
Add documentation for a few useful class functions 

- xtgeo.create_box_grid
- xtgeo.grid_from_cube
- xtgeo.grid_from_surfaces
- xtgeo.wells_from_files