### PR TITLE
CLN: Set RLE to default False.

### DIFF
--- a/src/xtgeo/grid3d/_grdecl_grid.py
+++ b/src/xtgeo/grid3d/_grdecl_grid.py
@@ -311,7 +311,7 @@ class GrdeclGrid(EclGrid):
                 results[kw.lower()] = factory(values)
         return cls(**results)
 
-    def to_file(self, filename, fileformat="grdecl", rle: bool = True):
+    def to_file(self, filename, fileformat="grdecl", rle: bool = False):
         """
         write the grdeclgrid to a file.
         :param filename: path to file to write.

--- a/src/xtgeo/grid3d/_grid_export.py
+++ b/src/xtgeo/grid3d/_grid_export.py
@@ -49,7 +49,7 @@ def export_roff(
         )
 
 
-def export_grdecl(grid: Grid, gfile: FileLike, mode: int, rle: bool = True) -> None:
+def export_grdecl(grid: Grid, gfile: FileLike, mode: int, rle: bool = False) -> None:
     """Export grid to Eclipse GRDECL format (ascii, mode=1) or binary (mode=0).
     Optionally for ASCII GRDECL, run-length encoding RLE can be applied"""
     fileformat = "grdecl" if mode == 1 else "bgrdecl"

--- a/src/xtgeo/grid3d/_gridprop_export.py
+++ b/src/xtgeo/grid3d/_gridprop_export.py
@@ -38,7 +38,7 @@ def to_file(
     append: bool = False,
     dtype: type[np.float32] | type[np.float64] | type[np.int32] | None = None,
     fmt: str | None = None,
-    rle: bool = True,
+    rle: bool = False,
 ) -> None:
     """Export the grid property to file."""
     logger.debug("Export property to file %s as %s", pfile, fformat)
@@ -107,7 +107,7 @@ def _export_grdecl(
     append: bool = False,
     binary: bool = False,
     fmt: str | None = None,
-    rle: bool = True,
+    rle: bool = False,
 ) -> None:
     """Export ascii or binary GRDECL"""
     vals: npt.NDArray = gridprop.values.ravel(order="F")

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -994,7 +994,9 @@ class Grid(_Grid3D):
     # Create/import/export
     # ==================================================================================
 
-    def to_file(self, gfile: FileLike, fformat: str = "roff", rle: bool = True) -> None:
+    def to_file(
+        self, gfile: FileLike, fformat: str = "roff", rle: bool = False
+    ) -> None:
         """Export grid geometry to file, various vendor formats.
 
         Args:

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -773,7 +773,7 @@ class GridProperty(_Grid3D):
         append: bool = False,
         dtype: type[np.float32] | type[np.float64] | type[np.int32] | None = None,
         fmt: str | None = None,
-        rle: bool = True,
+        rle: bool = False,
     ) -> None:
         """
         Export the grid property to file.


### PR DESCRIPTION
Apparently, RLE is not supported yet by seismicforward. To avoid issue and breaking changes, set RLE to default False.