### PR TITLE
DEP: Deprecate Python 3.9 support

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -20,7 +20,7 @@ jobs:
   mypy:
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [cp39, cp310, cp311, cp312, cp313]
+        python: [cp310, cp311, cp312, cp313]
         os_arch:
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,17 +22,17 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
           - os: macos-latest
             python-version: "3.10"
           - os: macos-latest
-            python-version: 3.13
+            python-version: "3.13"
           - os: windows-latest
-            python-version: 3.9
+            python-version: "3.10"
           - os: windows-latest
-            python-version: 3.13
+            python-version: "3.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
       - name: Setup xtgeo
         uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
@@ -155,7 +155,7 @@ jobs:
       - name: Setup xtgeo
         uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
@@ -174,7 +174,7 @@ jobs:
       - name: Setup xtgeo
         uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
@@ -195,7 +195,7 @@ jobs:
 
       - uses: "./.github/actions/setup_xtgeo"
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Detailed documentation for [XTGeo at Read _the_ Docs](https://xtgeo.readthedocs.
 
 ## Feature summary
 
--   Python 3.9+ support
+-   Python 3.10+ support
 -   Focus on high speed, using numpy and pandas with C backend
 -   Regular surfaces, i.e. 2D maps with regular sampling and rotation
 -   3D grids (corner-point), supporting several formats such as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "pybind11",
     "scikit-build-core[pyproject]>=0.10",
     "swig<4.3.0",
-    "numpy>=2.0.0; python_version >= '3.9'",
+    "numpy>=2.0.0",
 ]
 
 build-backend = "scikit_build_core.build"
@@ -19,7 +19,7 @@ wheel.install-dir = "xtgeo"
 name = "xtgeo"
 description = "XTGeo is a Python library for 3D grids, surfaces, wells, etc"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "LGPL-3.0" }
 authors = [{ name = "Equinor", email = "fg_fmu-atlas@equinor.com" }]
 keywords = ["grids", "surfaces", "wells", "cubes"]
@@ -33,7 +33,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Natural Language :: English",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Resolves #1382 

Python 3.9 reaches EOL October 2025.