### PR TITLE
BLD: Deprecate macOS x86-64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,7 @@ jobs:
         os_arch:
           - [ubuntu-latest, manylinux_x86_64]
           - [windows-latest, win_amd64]
-          - [macos-13, macosx_x86_64]  # macos-13 is the last x86-64 runner
-          - [macos-latest, macosx_arm64]  # macos-latest is always arm64 going forward
+          - [macos-latest, macosx_arm64]
     env:
       CIBW_BUILD: ${{ matrix.python }}-${{ matrix.os_arch[1] }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28


### PR DESCRIPTION
Resolves #1381

macOS has moved on from x86-64 for some years now, and GitHub is soon to move on from these runners also. We cannot continue to support it.