### PR TITLE
ENH: improve memory/performance of Cube compute_attributes_in_window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "hypothesis",
     "mypy",
     "pandas-stubs",
+    "psutil",
     "pydocstyle",
     "pytest",
     "pytest-benchmark",

--- a/src/lib/include/xtgeo/cube.hpp
+++ b/src/lib/include/xtgeo/cube.hpp
@@ -12,7 +12,15 @@ namespace py = pybind11;
 namespace xtgeo::cube {
 
 std::unordered_map<std::string, py::array_t<double>>
-cube_stats_along_z(const Cube &cube_cpp);
+cube_stats_along_z(const Cube &cube_cpp,
+                   const py::array_t<double> &upper_surface,
+                   const py::array_t<double> &lower_surface,
+                   const py::array_t<double> &depth_array,
+                   int ndiv = 1,
+                   const std::string &interpolation = "linear",
+                   double min_thickness = 0.0,
+                   int min_index = 0,
+                   int max_index = -1);
 
 inline void
 init(py::module &m)
@@ -33,9 +41,11 @@ init(py::module &m)
       .def_readonly("zinc", &Cube::zinc)
       .def_readonly("rotation", &Cube::rotation)
       .def_readonly("values", &Cube::values)
+      .def_readonly("traceidcodes", &Cube::traceidcodes)
 
       .def("cube_stats_along_z", &cube_stats_along_z,
-           "Compute various statistics for cube along the Z axis, returning maps.")
+           "Compute various statistics for cube along the Z axis, returning "
+           "maps.")
 
       ;
 }

--- a/src/lib/include/xtgeo/numerics.hpp
+++ b/src/lib/include/xtgeo/numerics.hpp
@@ -1,7 +1,12 @@
 #ifndef XTGEO_NUMERICS_HPP_
 #define XTGEO_NUMERICS_HPP_
 #include <pybind11/pybind11.h>
+#include <Eigen/Sparse>
+#include <algorithm>
+#include <cmath>
 #include <limits>
+#include <numeric>
+#include <vector>
 #include <xtgeo/types.hpp>
 
 namespace py = pybind11;
@@ -23,6 +28,180 @@ init(py::module &m)
     m_numerics.attr("EPSILON") = numerics::EPSILON;
     m_numerics.attr("TOLERANCE") = numerics::TOLERANCE;
 }
+
+/**
+ * @brief Performs linear interpolation between points in a vector.
+ *
+ * For each segment between two consecutive points, this function generates
+ * 'ndiv' evenly spaced points (including the start point, excluding the end point).
+ * The final point of the entire set is added at the end.
+ *
+ * @tparam T A container type that supports `[]` and `.size()`, like `std::vector`
+ *           or `pybind11::detail::unchecked_reference`.
+ * @param points The input data points.
+ * @param ndiv The number of divisions to create within each segment.
+ * @return A vector of interpolated values.
+ */
+template<typename T>
+inline std::vector<double>
+linear_interpolate(const T &points, int ndiv)
+{
+    size_t n_points = points.size();
+    if (ndiv <= 1 || n_points < 2) {
+        std::vector<double> result(n_points);
+        for (size_t i = 0; i < n_points; ++i) {
+            result[i] = points[i];
+        }
+        return result;
+    }
+
+    size_t num_new_points = (n_points - 1) * ndiv + 1;
+    std::vector<double> result;
+    result.reserve(num_new_points);
+
+    for (size_t i = 0; i < n_points - 1; ++i) {
+        for (int l = 0; l < ndiv; ++l) {
+            double fraction = static_cast<double>(l) / ndiv;
+            result.push_back(points[i] + fraction * (points[i + 1] - points[i]));
+        }
+    }
+    result.push_back(points[n_points - 1]);
+
+    return result;
+}
+
+/**
+ * @brief A pre-computing solver for cubic spline interpolation.
+ *
+ * This class computes and stores the LU decomposition of the spline matrix,
+ * allowing for rapid solving for multiple right-hand side vectors (i.e.,
+ * multiple data traces). Resembles scipy's CubicSpline with 'not-a-knot' boundary
+ * conditions.
+ */
+class CubicSplineSolver
+{
+public:
+    /**
+     * @brief Constructs and computes the solver for a given set of x-points.
+     * @param x_pts The x-coordinates of the data points.
+     */
+    explicit CubicSplineSolver(const std::vector<double> &x_pts) : n_(x_pts.size())
+    {
+        if (n_ < 2) {  // Allow for linear interpolation case
+            return;
+        }
+        h_.resize(n_ - 1);
+        for (size_t i = 0; i < n_ - 1; ++i) {
+            h_[i] = x_pts[i + 1] - x_pts[i];
+            if (!(h_[i] > 0.0)) {  // Epsilon comparison might be safer
+                throw std::invalid_argument(
+                  "CubicSplineSolver: x_pts must be strictly increasing");
+            }
+        }
+
+        if (n_ < 3) {  // Not enough points for cubic spline
+            return;
+        }
+
+        Eigen::SparseMatrix<double> A(n_, n_);
+        std::vector<Eigen::Triplet<double>> triplets;
+        triplets.reserve(3 * n_ - 4);  // More precise reservation
+
+        // Standard interior points
+        for (size_t i = 1; i < n_ - 1; ++i) {
+            triplets.emplace_back(i, i - 1, h_[i - 1]);
+            triplets.emplace_back(i, i, 2 * (h_[i - 1] + h_[i]));
+            triplets.emplace_back(i, i + 1, h_[i]);
+        }
+
+        // Not-a-knot boundary conditions
+        triplets.emplace_back(0, 0, h_[1]);
+        triplets.emplace_back(0, 1, -(h_[0] + h_[1]));
+        triplets.emplace_back(0, 2, h_[0]);
+        triplets.emplace_back(n_ - 1, n_ - 3, h_[n_ - 2]);
+        triplets.emplace_back(n_ - 1, n_ - 2, -(h_[n_ - 3] + h_[n_ - 2]));
+        triplets.emplace_back(n_ - 1, n_ - 1, h_[n_ - 3]);
+
+        A.setFromTriplets(triplets.begin(), triplets.end());
+        solver_.compute(A);
+        if (solver_.info() != Eigen::Success) {
+            // It's good practice to check for decomposition failure here.
+            // Depending on desired behavior, you could throw or set a failure state.
+        }
+    }
+
+    /**
+     * @brief Interpolates y-values using the pre-computed solver.
+     */
+    std::vector<double> interpolate(const std::vector<double> &x_pts,
+                                    const std::vector<double> &y_pts,
+                                    const std::vector<double> &new_x_pts) const
+    {
+        if (n_ != x_pts.size() || n_ != y_pts.size()) {
+            throw std::invalid_argument("Input vector sizes do not match solver size.");
+        }
+
+        if (n_ < 2) {
+            return std::vector<double>(new_x_pts.size(), n_ == 1 ? y_pts[0] : 0.0);
+        }
+        if (n_ == 2) {  // Handle linear case explicitly
+            std::vector<double> result;
+            result.reserve(new_x_pts.size());
+            if (h_[0] <= 0)
+                return std::vector<double>(new_x_pts.size(),
+                                           y_pts[0]);  // Avoid division by zero
+            for (const auto &x : new_x_pts) {
+                double t = (x - x_pts[0]) / h_[0];
+                result.push_back(y_pts[0] + t * (y_pts[1] - y_pts[0]));
+            }
+            return result;
+        }
+
+        Eigen::VectorXd b = Eigen::VectorXd::Zero(n_);
+        for (size_t i = 1; i < n_ - 1; ++i) {
+            b(i) = 6.0 * ((y_pts[i + 1] - y_pts[i]) / h_[i] -
+                          (y_pts[i] - y_pts[i - 1]) / h_[i - 1]);
+        }
+
+        if (solver_.info() != Eigen::Success) {
+            // Consider throwing an exception or returning an empty vector
+            // to indicate that the solver was not successfully initialized.
+            return {};
+        }
+        Eigen::VectorXd M = solver_.solve(b);
+        if (solver_.info() != Eigen::Success) {
+            // Solving failed for this specific `b` vector.
+            return {};
+        }
+
+        std::vector<double> y_new;
+        y_new.reserve(new_x_pts.size());
+
+        size_t seg = 0;
+        for (const auto &x : new_x_pts) {
+            // Find segment for x, can be optimized if new_x_pts is sorted
+            while (seg < n_ - 2 && x_pts[seg + 1] < x) {
+                seg++;
+            }
+
+            double dx1 = x - x_pts[seg];
+            double dx2 = x_pts[seg + 1] - x;
+            double h_seg = h_[seg];
+
+            double val =
+              (dx2 / h_seg) * y_pts[seg] + (dx1 / h_seg) * y_pts[seg + 1] +
+              (dx1 * dx1 * dx1 - h_seg * h_seg * dx1) * M(seg + 1) / (6 * h_seg) +
+              (dx2 * dx2 * dx2 - h_seg * h_seg * dx2) * M(seg) / (6 * h_seg);
+            y_new.push_back(val);
+        }
+        return y_new;
+    }
+
+private:
+    size_t n_;
+    std::vector<double> h_;
+    Eigen::SparseLU<Eigen::SparseMatrix<double>> solver_;
+};
 
 }  // namespace xtgeo::numerics
 

--- a/src/lib/include/xtgeo/types.hpp
+++ b/src/lib/include/xtgeo/types.hpp
@@ -634,6 +634,7 @@ struct Cube
     double zinc;
     double rotation;
     py::array_t<float> values;
+    py::array_t<int> traceidcodes;
 
     // Default constructor (deleted)
     Cube() = delete;
@@ -654,11 +655,14 @@ struct Cube
 
         // Extract the numpy array
         values = cube.attr("values").cast<py::array_t<float>>();
+        traceidcodes = cube.attr("traceidcodes").cast<py::array_t<int>>();
 
         py::buffer_info buf_info_values = values.request();
+        py::buffer_info buf_info_traceidcodes = traceidcodes.request();
 
-        if (buf_info_values.ndim != 3) {
-            throw std::runtime_error("Cube values must be a 3D numpy array");
+        if (buf_info_values.ndim != 3 || buf_info_traceidcodes.ndim != 2) {
+            throw std::runtime_error("Cube values must be a 3D numpy array and "
+                                     "traceidcodes must be 2D array");
         }
     };
 };

--- a/src/lib/src/cube/cube.cpp
+++ b/src/lib/src/cube/cube.cpp
@@ -9,31 +9,66 @@
 #include <unordered_map>
 #include <vector>
 #include <xtgeo/cube.hpp>
+#include <xtgeo/geometry_basics.hpp>
 #include <xtgeo/logging.hpp>
 #include <xtgeo/numerics.hpp>
 
+#ifdef XTGEO_USE_OPENMP
+#include <omp.h>
+#endif
 namespace py = pybind11;
 
 namespace xtgeo::cube {
 
-/*
- * Compute cube statistics per column, returning 2D arrays of min, max, mean, var, rms,
- * maxabs, maxpos, maxneg, meanabs, meanpos, meanneg, sumpos, sumneg, sumabs. This could
- * technically be done in numpy, but this approach is more efficient as it can do all
- * operations per column in one operation.
+/**
+ * Compute cube statistics per column, returning 2D arrays of min, max, mean,
+ * var, rms, maxabs, maxpos, maxneg, meanabs, meanpos, meanneg, sumpos, sumneg, sumabs.
  *
  * @param cube Cube instance
+ * @param upper_surface 2D array of upper surface Z values
+ * @param lower_surface 2D array of lower surface Z values
+ * @param depth_array 1D array of depth values corresponding to cube layers
+ * @param ndiv Number of subdivisions between layers for interpolation (default: 1, no
+ * subdivision)
+ * @param interpolation Interpolation method ("cubic" or "linear")
+ * @param min_thickness Minimum thickness for valid computation. Ie.e if lower - upper
+ * maps <= min_thickness per map node, stats are NaN for those nodes (default: 0.0)
+ * @param min_index Optional minimum Z index for cube slicing (default: 0)
+ * @param max_index Optional maximum Z index for cube slicing (default: nlay)
  * @return A map of arrays: min, max, mean, var, rms, maxpos, maxneg, maxabs,
  * meanpos, meanneg, meanabs, sumpos, sumneg, sumabs
  */
 std::unordered_map<std::string, py::array_t<double>>
-cube_stats_along_z(const Cube &cube)
+cube_stats_along_z(const Cube &cube,
+                   const py::array_t<double> &upper_surface,
+                   const py::array_t<double> &lower_surface,
+                   const py::array_t<double> &depth_array,
+                   int ndiv,
+                   const std::string &interpolation,
+                   double min_thickness,
+                   int min_index,
+                   int max_index)
 {
     auto &logger = xtgeo::logging::LoggerManager::get("xtgeo.cube.cube_stats_along_z");
     logger.debug("Computing cube statistics along Z axis");
     size_t ncol = cube.ncol;
     size_t nrow = cube.nrow;
     size_t nlay = cube.nlay;
+
+    // Handle default slice indices
+    if (max_index < 0) {
+        max_index = static_cast<int>(nlay);
+    }
+    if (min_index < 0) {
+        min_index = 0;
+    }
+    if (max_index > static_cast<int>(nlay)) {
+        max_index = static_cast<int>(nlay);
+    }
+
+    auto upper_ = upper_surface.unchecked<2>();
+    auto lower_ = lower_surface.unchecked<2>();
+    auto depth_ = depth_array.unchecked<1>();
 
     py::array_t<double> minv({ ncol, nrow });
     py::array_t<double> maxv({ ncol, nrow });
@@ -51,6 +86,7 @@ cube_stats_along_z(const Cube &cube)
     py::array_t<double> sumabsv({ ncol, nrow });
 
     auto cubev_ = cube.values.unchecked<3>();  // Use unchecked for efficiency
+    auto traceidcodes_ = cube.traceidcodes.unchecked<2>();  // Access traceidcodes
     auto minv_ = minv.mutable_unchecked<2>();
     auto maxv_ = maxv.mutable_unchecked<2>();
     auto meanv_ = meanv.mutable_unchecked<2>();
@@ -66,8 +102,88 @@ cube_stats_along_z(const Cube &cube)
     auto sumnegv_ = sumnegv.mutable_unchecked<2>();
     auto sumabsv_ = sumabsv.mutable_unchecked<2>();
 
-    for (size_t i = 0; i < ncol; i++) {
-        for (size_t j = 0; j < nrow; j++) {
+    // Pre-compute effective layer count and spline solver
+    if (min_index >= max_index) {
+        throw std::invalid_argument("min_index must be less than max_index");
+    }
+
+    size_t effective_nlay = max_index - min_index;
+    std::unique_ptr<numerics::CubicSplineSolver> spline_solver;
+    if (interpolation == "cubic" && ndiv > 1 && effective_nlay > 2) {
+        std::vector<double> x_pts(effective_nlay);
+        std::iota(x_pts.begin(), x_pts.end(), 0);
+        spline_solver = std::make_unique<numerics::CubicSplineSolver>(x_pts);
+    }
+
+    // clang-format off
+    #ifdef XTGEO_USE_OPENMP
+        #pragma omp parallel for collapse(2) schedule(static)
+    #endif
+    // clang-format on
+    for (int i = 0; i < static_cast<int>(ncol); i++) {  // int due to MSVC OpenMP...
+        for (int j = 0; j < static_cast<int>(nrow); j++) {
+
+            double upper_z = upper_(i, j);
+            double lower_z = lower_(i, j);
+
+            // Check if traceidcode indicates dead trace or thickness is too small
+            if (traceidcodes_(i, j) == 2 || lower_z - upper_z <= min_thickness) {
+                minv_(i, j) = numerics::QUIET_NAN;
+                maxv_(i, j) = numerics::QUIET_NAN;
+                meanv_(i, j) = numerics::QUIET_NAN;
+                varv_(i, j) = numerics::QUIET_NAN;
+                rmsv_(i, j) = numerics::QUIET_NAN;
+                maxabsv_(i, j) = numerics::QUIET_NAN;
+                meanabsv_(i, j) = numerics::QUIET_NAN;
+                sumabsv_(i, j) = numerics::QUIET_NAN;
+                maxposv_(i, j) = numerics::QUIET_NAN;
+                meanposv_(i, j) = numerics::QUIET_NAN;
+                sumposv_(i, j) = numerics::QUIET_NAN;
+                maxnegv_(i, j) = numerics::QUIET_NAN;
+                meannegv_(i, j) = numerics::QUIET_NAN;
+                sumnegv_(i, j) = numerics::QUIET_NAN;
+
+                continue;
+            }
+
+            // Extract trace using slice indices and perform interpolation
+            std::vector<double> trace(effective_nlay);
+            for (size_t k = 0; k < effective_nlay; ++k) {
+                trace[k] = cubev_(i, j, min_index + k);
+            }
+
+            // Slice the depth array once - this is common to all branches
+            std::vector<double> sliced_depth(effective_nlay);
+            for (size_t k = 0; k < effective_nlay; ++k) {
+                sliced_depth[k] = depth_(min_index + k);
+            }
+
+            std::vector<double> refined_trace;
+            std::vector<double> refined_depth;
+
+            if (spline_solver && ndiv > 1) {
+                // Use pre-computed spline solver
+                std::vector<double> x_pts(effective_nlay);
+                std::iota(x_pts.begin(), x_pts.end(), 0);
+
+                size_t num_new_points = (effective_nlay - 1) * ndiv + 1;
+                std::vector<double> new_x_pts(num_new_points);
+                double step =
+                  static_cast<double>(effective_nlay - 1) / (num_new_points - 1);
+                for (size_t k = 0; k < num_new_points; ++k) {
+                    new_x_pts[k] = k * step;
+                }
+
+                refined_trace = spline_solver->interpolate(x_pts, trace, new_x_pts);
+                refined_depth = numerics::linear_interpolate(sliced_depth, ndiv);
+
+            } else if (ndiv > 1 && effective_nlay > 1) {  // Linear interpolation
+                refined_trace = numerics::linear_interpolate(trace, ndiv);
+                refined_depth = numerics::linear_interpolate(sliced_depth, ndiv);
+            } else {  // No interpolation
+                refined_trace = trace;
+                refined_depth = numerics::linear_interpolate(sliced_depth, 1);
+            }
             double min_val = std::numeric_limits<double>::max();
             double max_val = std::numeric_limits<double>::lowest();
             double sum = 0.0;
@@ -84,8 +200,12 @@ cube_stats_along_z(const Cube &cube)
             double mean = 0.0;
             double variance_sum = 0.0;
 
-            for (size_t k = 0; k < nlay; k++) {
-                float value = cubev_(i, j, k);
+            for (size_t k = 0; k < refined_trace.size(); k++) {
+                double depth = refined_depth[k];
+                if (depth < upper_z || depth > lower_z) {
+                    continue;
+                }
+                float value = refined_trace[k];
                 if (std::isnan(value)) {
                     continue;
                 }

--- a/tests/test_cube/test_cube_attrs_more.py
+++ b/tests/test_cube/test_cube_attrs_more.py
@@ -1,0 +1,46 @@
+import pytest
+
+import xtgeo
+from tests.conftest import measure_peak_memory_usage
+from xtgeo.common.log import functimer
+
+
+@pytest.mark.bigtest
+def test_large_cube_memory_usage():
+    """Get attribute around a constant cube slices and check peak memory."""
+    import gc
+
+    # Cube size: 500 * 600 * 700 * 4 bytes ~= 840 MB
+    mycube = xtgeo.Cube(
+        ncol=500, nrow=600, nlay=700, xinc=12, yinc=12, zinc=4, values=666.0
+    )
+
+    level1 = 10
+    level2 = 1500
+
+    @measure_peak_memory_usage
+    @functimer(output="print")
+    def compute_with_mem_tracking(cube, interp):
+        """Helper function to be decorated."""
+        return cube.compute_attributes_in_window(
+            level1,
+            level2,
+            interpolation=interp,
+        )
+
+    # Force garbage collection to get a cleaner baseline
+    gc.collect()
+
+    for intp in ["linear", "cubic"]:
+        print(f"\nTesting interpolation={intp}")
+        peak_mem_increase_bytes, result = compute_with_mem_tracking(mycube, intp)
+
+        del result
+        gc.collect()  # Clean up before the next run
+
+        peak_mem_increase_gb = peak_mem_increase_bytes / (1024 * 1024 * 1024)
+
+        # The cube itself is ~840MB. The operation needs more.
+        # Let's set a reasonable upper bound for this cube size.
+        assert peak_mem_increase_gb > 0.001, "Peak memory increase is unexpectedly low."
+        assert peak_mem_increase_gb < 1, "Memory usage increase exceeded threshold"

--- a/tests/test_surface/test_surface_cube_attrs.py
+++ b/tests/test_surface/test_surface_cube_attrs.py
@@ -231,10 +231,10 @@ def test_various_attrs_rewrite(loadsfile1):
 @pytest.mark.parametrize(
     "ndiv, expected_mean",
     (
-        [2, 176.417],
+        [2, 176.432],
         [4, 176.426],
-        [12, 176.422],
-        [32, 176.421],
+        [12, 176.423],
+        [32, 176.422],
     ),
 )
 def test_various_attrs_new_ndiv(loadsfile1, ndiv, expected_mean):
@@ -548,7 +548,7 @@ def test_compute_attrs_handling_of_dead_traces(loadsfile3):
 
     # Check if the result is as expected
     assert "mean" in attrs
-    assert attrs["mean"].values.mean() == pytest.approx(239.18202, abs=1e-4)
+    assert attrs["mean"].values.mean() == pytest.approx(239.29096, abs=1e-4)
 
     # count number of dead traces in cube
     dead_traces = (cube.traceidcodes == 2).sum()
@@ -571,4 +571,4 @@ def test_attribute_around_constant_cube_slices(loadsfile2):
 
     myattrs = mycube.compute_attributes_in_window(level1, level2)
 
-    assert myattrs["mean"].values.mean() == pytest.approx(-0.00293736, abs=1e-5)
+    assert myattrs["mean"].values.mean() == pytest.approx(-0.0027869, abs=1e-5)


### PR DESCRIPTION
Closes #1399 

For the current (former) implementation, a bigger cube combined with a large window and large ndiv can trigger additional > 20 GByte or more of peak memory use. The new implementation here moves the logic of dividing the traces in C++, instead of making instances of a refined cube in python (which can be quite memory demanding). In addition the code is also now reusing views of the numpy arrays instead of making copies. 

Main changes are in this PR:
* Additional peak memory usage is here quite small, even for large cubes and ndiv / windows sizes (typically < 0.3 GBytes) 
* Usage of C++ looping combined with OMP parallel processing speed up CPU significantly (5-10 times)
* The algorithm of cubic spline interpolation of the trace is now implemented in the C++ code (former was using a scipy function)