### PR TITLE
ENH: Add TSurf to file_format_from_contents check

### DIFF
--- a/src/xtgeo/io/_file.py
+++ b/src/xtgeo/io/_file.py
@@ -84,6 +84,7 @@ class FileFormat(Enum):
     PETROMOD = ["pmd", "petromod"]
     XTG = ["xtg", "xtgeo", "xtgf", "xtgcpprop", "xtg.*"]
     XYZ = ["xyz", "poi", "pol"]
+    TSURF = ["ts", "tsurf"]
     RMS_ATTR = ["rms_attr", "rms_attrs", "rmsattr.*"]
     CSV = ["csv", "csv.*"]
     PARQUET = ["parquet", "parquet.*", "pq"]
@@ -590,5 +591,13 @@ class FileWrapper:
         ):
             logger.debug("Signature is rmswell")
             return FileFormat.RMSWELL
+
+        tsurf_signature = b"GOCAD TSurf 1"
+        if (
+            len(buffer) >= len(tsurf_signature)
+            and buffer[: len(tsurf_signature)] == tsurf_signature
+        ):
+            logger.debug("Signature is tsurf")
+            return FileFormat.TSURF
 
         return FileFormat.UNKNOWN

--- a/tests/test_io/test_file.py
+++ b/tests/test_io/test_file.py
@@ -27,6 +27,7 @@ FILE_FORMATS = ChainMap(
         pathlib.Path("3dgrids/reek/reek_geo_grid.roff"): FileFormat.ROFF_BINARY,
         pathlib.Path("3dgrids/reek/reek_geogrid.roffasc"): FileFormat.ROFF_ASCII,
         pathlib.Path("wells/battle/1/WELL12.rmswell"): FileFormat.RMSWELL,
+        pathlib.Path("surfaces/drogon/3/F5.ts"): FileFormat.TSURF,
     },
 )
 


### PR DESCRIPTION
Resolves #1406 and #1408.

Added TSURF to the known file formats in `xtgeo`.
Added TSURF to file_format_from_contents, enabling `xtgeo` to recognise this file format.