### PR TITLE
ENH: add several gridding methods for 2D regular surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecation",
+    "gstools",
     "h5py>=3",
     "hdf5plugin>=2.3",
     "joblib",
@@ -150,6 +151,10 @@ markers = [
     "requires_roxar: Test requires to run in RMS python",
 ]
 doctest_optionflags = "ELLIPSIS"
+filterwarnings = [
+    "ignore:Epsilon auto-calculated:UserWarning",
+    "ignore:Points are very close together:RuntimeWarning",
+]
 
 [tool.setuptools_scm]
 write_to = "src/xtgeo/common/version.py"

--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -3,28 +3,151 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
+import gstools as gs
 import numpy as np
 import numpy.ma as ma
 import scipy.interpolate
 import scipy.ndimage
+from numpy.typing import NDArray
+from scipy.spatial import cKDTree
 
+import xtgeo._internal as _internal
 from xtgeo.common.constants import UNDEF, UNDEF_LIMIT
 from xtgeo.common.log import null_logger
+from xtgeo.xyz.polygons import Polygons
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from xtgeo.surface import RegularSurface
+    from xtgeo.xyz import Points
 
 logger = null_logger(__name__)
 
+# Type aliases
+FloatArray = NDArray[np.float64]
+IntArray = NDArray[np.int32]
+BoolArray = NDArray[np.bool_]
+MaskedArray = ma.MaskedArray[Any, np.dtype[np.float64]]
+
 # Note: 'self' is an instance of RegularSurface
 
+# ======================================================================================
+# HELPER FUNCTIONS (internal for this module)
+# ======================================================================================
 
-def points_gridding(self, points, method="linear", coarsen=1):
-    """Do gridding from a points data set."""
+
+def merge_close_points_preprocessing(
+    points: Points,
+    merge_close_points: float | None = None,
+    merge_method: Literal["average", "median", "first", "min_z", "max_z"] = "average",
+) -> Points:
+    """
+    Preprocess points by merging those that are too close together.
+
+    This is a common preprocessing step for all gridding methods to avoid numerical
+    issues when points are very close to each other.
+
+    Args:
+        points: Points object to potentially merge
+        merge_close_points: Minimum distance threshold (in map units) for merging
+            close points. Set to None to disable merging.
+        merge_method: Method for merging close points ('average', 'median', 'first',
+            'min_z', 'max_z'). Default is 'average'.
+
+    Returns:
+        Points object (either original or a merged copy)
+    """
+    if merge_close_points is None:
+        return points
+
+    threshold = float(merge_close_points)
+
+    # Make a copy before merging to avoid modifying original
+    working_points = points.copy()
+    working_points.merge_close_points(min_distance=threshold, method=merge_method)
+
+    logger.debug(
+        "Merged close points: %d -> %d (threshold=%.2f, method=%s)",
+        points.nrow,
+        working_points.nrow,
+        threshold,
+        merge_method,
+    )
+
+    return working_points
+
+
+def _check_close_points_warning(
+    surface: RegularSurface, points: Points, threshold_factor: float = 0.1
+) -> None:
+    """
+    Check if points are too close together and emit a warning.
+
+    This is useful for methods like radial basis and kriging where very close points
+    can cause numerical instability or ill-conditioned matrices.
+
+    Args:
+        surface: RegularSurface instance (for calculating avg_inc)
+        points: Points object to check
+        threshold_factor: Fraction of avg_inc to use as threshold (default 0.1)
+
+    Returns:
+        None (emits warning if close points detected)
+    """
+    if points.nrow < 2:
+        return
+
+    avg_inc = (surface.xinc + surface.yinc) / 2.0
+    threshold = threshold_factor * avg_inc
+
+    dfra = points.get_dataframe(copy=False)
+    coords = dfra[[points.xname, points.yname]].values
+
+    # Use KDTree to find nearest neighbors efficiently
+    tree = cKDTree(coords)
+    # Query for 2 nearest neighbors (first will be the point itself)
+    distances, _ = tree.query(coords, k=2)
+    # Get minimum distance to nearest neighbor (excluding self)
+    min_distance = distances[:, 1].min()
+
+    if min_distance < threshold:
+        import warnings
+
+        warnings.warn(
+            f"Points are very close together (minimum distance: {min_distance:.2f} "
+            f"< {threshold_factor}*avg_inc = {threshold:.2f}). "
+            f"This may cause numerical issues with this gridding method. "
+            f"Consider using Points.merge_close_points() to merge nearby points "
+            f"before gridding, e.g. with min_distance = 10% of the mapping increment",
+            RuntimeWarning,
+            stacklevel=4,
+        )
+        logger.warning(
+            "Close points detected: min_distance=%.2f, threshold=%.2f",
+            min_distance,
+            threshold,
+        )
+
+
+def _points_gridding_common(
+    self: RegularSurface, input_points: Points, coarsen: int
+) -> tuple[Any, FloatArray, FloatArray, FloatArray, FloatArray, FloatArray]:
+    """
+    Do gridding from a points data set - common preprocessing.
+
+    Args:
+        self: RegularSurface instance
+        input_points: Points object (already merged if needed)
+        coarsen: Coarsening factor for points
+
+    Returns:
+        tuple: (dfra, xcv, ycv, zcv, xiv, yiv) where xcv, ycv, zcv are filtered
+    """
+
+    points = _filter_points_within_surface(self, input_points)
 
     xiv, yiv = self.get_xy_values()
 
@@ -39,38 +162,1568 @@ def points_gridding(self, points, method="linear", coarsen=1):
         ycv = ycv[::coarsen]
         zcv = zcv[::coarsen]
 
+    return dfra, xcv, ycv, zcv, xiv, yiv
+
+
+def _filter_points_within_surface(self: RegularSurface, points: Points) -> Points:
+    """
+    Filter points to only those within surface boundaries.
+
+    Args:
+        self: RegularSurface instance
+        points: Input xtgeo.Points
+
+    Returns:
+        An updated xtgeo.Points instance
+    """
+    p = points.copy()
+
+    logger.debug("Number of points before filtering: %d", p.nrow)
+
+    r = _internal.regsurf.RegularSurface(self).get_outer_corners()
+    plist = [
+        (r[0].x, r[0].y, r[0].z, 0),
+        (r[1].x, r[1].y, r[1].z, 0),
+        (r[3].x, r[3].y, r[3].z, 0),
+        (r[2].x, r[2].y, r[2].z, 0),
+        (r[0].x, r[0].y, r[0].z, 0),
+    ]
+    boundary = Polygons(plist)
+
+    p.eli_outside_polygons(boundary)
+
+    logger.debug("Filtered points inside surface: %d", p.nrow)
+
+    return p
+
+
+def _calculate_optimal_epsilon(
+    xcv: FloatArray, ycv: FloatArray, k_neighbors: int = 5
+) -> float:
+    """
+    Calculate optimal epsilon parameter for RBF kernels based on point spacing.
+
+    Uses the mean distance to k nearest neighbors to be more robust to clustering.
+
+    Args:
+        xcv: X coordinates of points
+        ycv: Y coordinates of points
+        k_neighbors: Number of neighbors to consider (default 5)
+
+    Returns:
+        float: Optimal epsilon value
+    """
+
+    # Sample points if too many (for performance)
+    n_sample = min(1000, len(xcv))
+    if len(xcv) > n_sample:
+        idx = np.random.choice(len(xcv), n_sample, replace=False)
+        sample_x = xcv[idx]
+        sample_y = ycv[idx]
+    else:
+        sample_x = xcv
+        sample_y = ycv
+
+    sample_coords = np.column_stack([sample_x, sample_y])
+
+    tree = cKDTree(sample_coords)
+
+    # Find distance to k nearest neighbors (k+1 because first is the point itself)
+    k_neighbors = min(k_neighbors + 1, len(sample_coords))
+    distances, _ = tree.query(sample_coords, k=k_neighbors)
+
+    # Take mean of the k nearest neighbors
+    mean_k_distances = distances[:, 1:].mean(axis=1)
+
+    epsilon = np.median(mean_k_distances)
+
+    # Safety check: ensure minimum based on data extent
+    x_range = sample_x.max() - sample_x.min()
+    y_range = sample_y.max() - sample_y.min()
+    extent = np.sqrt(x_range**2 + y_range**2)
+    min_epsilon = extent / n_sample
+
+    epsilon = max(epsilon, min_epsilon)
+
+    logger.debug(
+        "Auto-calculated epsilon: %.2f "
+        "(based on median of mean %d-neighbor distances from %d samples)",
+        epsilon,
+        k_neighbors - 1,
+        n_sample,
+    )
+
+    warnings.warn(
+        f"Epsilon auto-calculated as {epsilon:.2f}. For better control and "
+        "to avoid artifacts from duplicate/close points, consider merging nearby "
+        "points using Points.merge_close_points() before gridding.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+    return epsilon
+
+
+def _calculate_optimal_radius(
+    self: RegularSurface, xcv: FloatArray, ycv: FloatArray
+) -> float:
+    """
+    Calculate optimal search radius based on grid resolution and point density.
+
+    Args:
+        self: RegularSurface instance
+        xcv: X coordinates of points
+        ycv: Y coordinates of points
+
+    Returns:
+        float: Optimal search radius in map units
+    """
+    # Base radius on grid increments (cover adjacent cells)
+    grid_based_radius = 2.0 * max(self.xinc, self.yinc)
+
+    # Estimate point density and spacing
+    x_range = xcv.max() - xcv.min()
+    y_range = ycv.max() - ycv.min()
+    area = x_range * y_range
+
+    if area > 0 and len(xcv) > 0:
+        point_density = len(xcv) / area
+        avg_point_distance = 1.0 / np.sqrt(point_density)
+
+        # Use the larger of grid-based or point-based radius
+        # This ensures we capture enough points while respecting grid resolution
+        radius = max(grid_based_radius, 1.5 * avg_point_distance)
+
+        logger.debug(
+            "Auto-calculated search radius: %.2f "
+            "(grid-based: %.2f, point-based: %.2f, xinc=%.2f, yinc=%.2f)",
+            radius,
+            grid_based_radius,
+            1.5 * avg_point_distance,
+            self.xinc,
+            self.yinc,
+        )
+    else:
+        radius = grid_based_radius
+        logger.debug(
+            "Auto-calculated search radius: %.2f (based on grid increments only)",
+            radius,
+        )
+
+    return radius
+
+
+def _estimate_correlation_length(
+    xcv: FloatArray, ycv: FloatArray, zcv: FloatArray
+) -> float:
+    """
+    Estimate correlation length (range_value) from point data.
+
+    Uses the empirical variogram to estimate where correlation drops to ~5% of sill.
+
+    Args:
+        xcv: X coordinates
+        ycv: Y coordinates
+        zcv: Z values
+
+    Returns:
+        float: Estimated correlation length
+    """
+
+    # Sample points for efficiency
+    n_sample = min(500, len(xcv))
+    if len(xcv) > n_sample:
+        idx = np.random.choice(len(xcv), n_sample, replace=False)
+        sample_x = xcv[idx]
+        sample_y = ycv[idx]
+        sample_z = zcv[idx]
+    else:
+        sample_x = xcv
+        sample_y = ycv
+        sample_z = zcv
+
+    coords = np.column_stack([sample_x, sample_y])
+    tree = cKDTree(coords)
+
+    # Calculate semi-variogram for different distance bins
+    max_dist = (
+        np.sqrt(
+            (sample_x.max() - sample_x.min()) ** 2
+            + (sample_y.max() - sample_y.min()) ** 2
+        )
+        / 3
+    )
+
+    n_bins = 20
+    bin_edges = np.linspace(0, max_dist, n_bins + 1)
+    gamma = []
+    bin_centers = []
+
+    for i in range(n_bins):
+        d_min = bin_edges[i]
+        d_max = bin_edges[i + 1]
+
+        # Find pairs in this distance range
+        pairs = []
+        for j, coord in enumerate(coords):
+            idx_neighbors = tree.query_ball_point(coord, d_max)
+            for k in idx_neighbors:
+                if k > j:  # Avoid duplicates
+                    dist = np.linalg.norm(coords[j] - coords[k])
+                    if d_min <= dist < d_max:
+                        pairs.append((j, k))
+
+        if len(pairs) > 10:  # Need enough pairs
+            pairs_z = [(sample_z[j] - sample_z[k]) ** 2 for j, k in pairs]
+            gamma.append(0.5 * np.mean(pairs_z))
+            bin_centers.append((d_min + d_max) / 2)
+
+    if len(gamma) > 3:
+        # ~ range_value as distance where variogram reaches ~63% of sill (1 - 1/e)
+        sill = max(gamma)
+        threshold = 0.63 * sill
+
+        for dist, g in zip(bin_centers, gamma):
+            if g >= threshold:
+                return dist
+
+        # If not found, use 1/3 of max distance
+        return max_dist
+
+    # Fallback: use mean nearest neighbor distance * 3
+    distances, _ = tree.query(coords, k=2)
+    return 3.0 * np.mean(distances[:, 1])
+
+
+# ======================================================================================
+# FUNCTIONS doing gridding - to be called by public module
+# ======================================================================================
+
+
+def points_simple_gridding(
+    self: RegularSurface,
+    points: Points,
+    method: Literal["linear", "nearest", "cubic"] = "linear",
+    coarsen: int = 1,
+) -> None:
+    """
+    Triangulation-based gridding using scipy.interpolate.griddata.
+
+    Fast and reliable for dense point datasets.
+    Methods: 'linear', 'nearest', 'cubic'
+
+    Args:
+        points: Points object (may already be merged)
+        method: Interpolation method
+        coarsen: Coarsening factor
+    """
+    dfra, xcv, ycv, zcv, xiv, yiv = _points_gridding_common(
+        self,
+        points,
+        coarsen=coarsen,
+    )
+
     validmethods = ["linear", "nearest", "cubic"]
     if method not in set(validmethods):
         raise ValueError(
             f"Invalid method for gridding: {method}, valid options are {validmethods}"
         )
 
+    npoints = len(xcv)
+    logger.debug("Gridding %d points with method '%s'...", npoints, method)
+
     try:
         znew = scipy.interpolate.griddata(
             (xcv, ycv), zcv, (xiv, yiv), method=method, fill_value=np.nan
         )
+
     except ValueError as verr:
         raise RuntimeError(f"Could not do gridding: {verr}")
 
-    logger.info("Gridding point ... DONE")
+    logger.debug("Gridding point ... DONE")
 
     self._ensure_correct_values(znew)
 
 
+def points_rbf_gridding(
+    self: RegularSurface,
+    points: Points,
+    function: str = "thin_plate_spline",
+    smoothing: float = 0.0,
+    epsilon: float | None = None,
+    coarsen: int = 1,
+) -> None:
+    """
+    Do Radial Basis Function (RBF) gridding from a points data set.
+
+    RBF is excellent for sparse data and provides smooth interpolation
+    similar to 'cubic' but with better control over smoothness. It will also work nicely
+    with more dense data, in particular when using a linear function (kernel).
+
+    Args:
+        points: Points object containing x, y, z coordinates
+        function: RBF kernel type. Options:
+            - 'thin_plate_spline': Thin plate spline (recommended, similar to cubic)
+            - 'cubic': Cubic RBF (smoother than thin_plate_spline)
+            - 'quintic': Quintic RBF (very smooth)
+            - 'linear': Linear RBF, good for dense data (less smooth)
+            - 'multiquadric': Multiquadric (requires epsilon)
+            - 'inverse_multiquadric': Inverse multiquadric (requires epsilon)
+            - 'inverse_quadratic': Inverse quadratic (requires epsilon)
+            - 'gaussian': Gaussian (requires epsilon)
+        smoothing: Smoothing parameter (0 = interpolating, >0 = smoothing).
+            For noisy data, try 0.1 to 1.0
+        epsilon: Shape parameter for certain kernels. If None and required by kernel,
+            automatically calculated as the mean distance between points.
+        coarsen: Coarsening factor for input points
+    """
+    dfra, xcv, ycv, zcv, xiv, yiv = _points_gridding_common(
+        self, points, coarsen=coarsen
+    )
+
+    # Check for close points that may cause numerical issues
+    _check_close_points_warning(self, points, threshold_factor=0.1)
+
+    npoints = len(xcv)
+
+    # Kernels that require epsilon parameter
+    epsilon_required = {
+        "multiquadric",
+        "inverse_multiquadric",
+        "inverse_quadratic",
+        "gaussian",
+    }
+
+    # Auto-calculate epsilon if needed but not provided
+    if function in epsilon_required and epsilon is None:
+        epsilon = _calculate_optimal_epsilon(xcv, ycv)
+
+    logger.debug(
+        "RBF gridding from %d points (function=%s, smooth=%s, epsilon=%s)...",
+        npoints,
+        function,
+        smoothing,
+        epsilon,
+    )
+
+    try:
+        rbf = scipy.interpolate.RBFInterpolator(
+            np.column_stack([xcv, ycv]),
+            zcv,
+            kernel=function,
+            smoothing=smoothing,
+            epsilon=epsilon,
+        )
+        znew = rbf(np.column_stack([xiv.ravel(), yiv.ravel()])).reshape(xiv.shape)
+
+    except (ValueError, TypeError) as err:
+        raise RuntimeError(f"Could not do RBF gridding: {err}")
+
+    logger.debug("RBF gridding ... DONE")
+    self._ensure_correct_values(znew)
+
+
+def points_moving_average_gridding(
+    self: RegularSurface,
+    points: Points,
+    radius: float | None = None,
+    min_points: int = 3,
+    coarsen: int = 1,
+) -> None:
+    """
+    Do moving average gridding from a points data set.
+
+    Simple averaging of all points within a search radius.
+
+    Args:
+        points: Points object containing x, y, z coordinates
+        radius: Search radius in map units. If None, automatically calculated
+                based on grid resolution and point density.
+        min_points: Minimum number of points required for averaging, default 3
+        coarsen: Coarsening factor for input points
+    """
+    dfra, xcv, ycv, zcv, xiv, yiv = _points_gridding_common(
+        self, points, coarsen=coarsen
+    )
+
+    # Calculate optimal radius if not provided
+    if radius is None:
+        radius = _calculate_optimal_radius(self, xcv, ycv)
+        logger.debug("Applied radius: %s", radius)
+
+    logger.debug(
+        "Moving average gridding from %d points (radius=%.1f, min_points=%d)...",
+        len(xcv),
+        radius,
+        min_points,
+    )
+
+    # Use scipy's griddata with nearest neighbor to get initial grid
+    # Then apply moving average
+    try:
+        # First, grid the data with nearest neighbor to get point values on grid
+        znear = scipy.interpolate.griddata(
+            (xcv, ycv), zcv, (xiv, yiv), method="nearest", fill_value=np.nan
+        )
+
+        # Note: No need to grid a count map here; we derive counts via convolution below
+
+        # Now apply a true moving average using a disk-shaped kernel
+        # Convert radius to grid cells
+        radius_cells_x = radius / self.xinc
+        radius_cells_y = radius / self.yinc
+
+        # Create a circular/elliptical structuring element
+        y_kernel = int(np.ceil(radius_cells_y))
+        x_kernel = int(np.ceil(radius_cells_x))
+
+        y_grid, x_grid = np.ogrid[-y_kernel : y_kernel + 1, -x_kernel : x_kernel + 1]
+
+        # Elliptical distance for rotated/anisotropic grids
+        kernel = ((x_grid / radius_cells_x) ** 2 + (y_grid / radius_cells_y) ** 2) <= 1
+
+        # Apply uniform filter for averaging
+        # Handle NaN values by tracking valid cells
+        valid_mask = ~np.isnan(znear)
+
+        # Sum of values
+        znear_filled = np.where(valid_mask, znear, 0.0)
+        sum_grid = scipy.ndimage.convolve(
+            znear_filled, kernel.astype(float), mode="constant", cval=0.0
+        )
+
+        # Count of valid cells in each window
+        count = scipy.ndimage.convolve(
+            valid_mask.astype(float), kernel.astype(float), mode="constant", cval=0.0
+        )
+
+        # Calculate average, masking where not enough points
+        znew = np.where(count >= min_points, sum_grid / count, np.nan)
+
+    except (ValueError, TypeError) as err:
+        raise RuntimeError(f"Could not do moving average gridding: {err}")
+
+    logger.debug("Moving average gridding ... DONE")
+
+    self._ensure_correct_values(znew)
+
+
+def points_idw_gridding(
+    self: RegularSurface,
+    points: Points,
+    power: float = 2.0,
+    radius: float | None = None,
+    min_points: int = 1,
+    coarsen: int = 1,
+) -> None:
+    """
+    Do inverse distance weighted (IDW) gridding from a points data set.
+
+    Args:
+        points: Points object containing x, y, z coordinates
+        power: Power parameter for IDW (default 2.0). Higher values give more
+               weight to nearby points
+        radius: Search radius in map units. If None, uses all points for small
+               datasets (< 1000 points) or auto-calculates radius for larger datasets
+        min_points: Minimum number of points required for interpolation
+        coarsen: Coarsening factor for input points (use every Nth point)
+    """
+
+    _, xcv, ycv, zcv, xiv, yiv = _points_gridding_common(self, points, coarsen=coarsen)
+
+    npoints = len(xcv)
+
+    # For large datasets without specified radius, auto-calculate one
+    # to avoid O(n*m) complexity
+    use_kdtree = radius is not None or npoints > 1000
+
+    if use_kdtree and radius is None:
+        radius = _calculate_optimal_radius(self, xcv, ycv)
+        logger.debug(
+            "Auto-calculated IDW search radius for large dataset: %.2f", radius
+        )
+
+    # Flatten grid coordinates for processing
+    xi_flat = xiv.ravel()
+    yi_flat = yiv.ravel()
+    zi_flat = np.full(xi_flat.shape, np.nan)
+
+    if use_kdtree:
+        tree = cKDTree(np.column_stack([xcv, ycv]))
+        logger.debug(
+            "IDW gridding %d points to %d grid nodes "
+            "(radius=%.2f, power=%.2f, using KD-tree)...",
+            npoints,
+            len(xi_flat),
+            radius,
+            power,
+        )
+
+        # For each grid point, use KD-tree to find nearby points
+        for i in range(len(xi_flat)):
+            idx_nearby = tree.query_ball_point([xi_flat[i], yi_flat[i]], radius)
+
+            if len(idx_nearby) < min_points:
+                continue
+
+            # Get nearby points
+            x_nearby = xcv[idx_nearby]
+            y_nearby = ycv[idx_nearby]
+            z_nearby = zcv[idx_nearby]
+
+            # Calculate distances
+            dx = x_nearby - xi_flat[i]
+            dy = y_nearby - yi_flat[i]
+            distances = np.sqrt(dx**2 + dy**2)
+
+            # Handle coincident points
+            zero_dist = distances < 1e-10
+            if np.any(zero_dist):
+                zi_flat[i] = z_nearby[zero_dist][0]
+                continue
+
+            # IDW weights
+            weights = 1.0 / (distances**power)
+            zi_flat[i] = np.sum(weights * z_nearby) / np.sum(weights)
+    else:
+        # Simple vectorized approach for small datasets without radius
+        logger.debug(
+            "IDW gridding %d points to %d grid nodes (power=%.2f, using all points)...",
+            npoints,
+            len(xi_flat),
+            power,
+        )
+
+        for i in range(len(xi_flat)):
+            # Calculate distances from grid point to all data points
+            dx = xcv - xi_flat[i]
+            dy = ycv - yi_flat[i]
+            distances = np.sqrt(dx**2 + dy**2)
+
+            z_nearby = zcv
+
+            # Skip if not enough points
+            if len(distances) < min_points:
+                continue
+
+            # Handle coincident points (distance = 0)
+            zero_dist = distances < 1e-10
+            if np.any(zero_dist):
+                zi_flat[i] = z_nearby[zero_dist][0]
+                continue
+
+            # Calculate weights: w_i = 1 / d_i^power
+            weights = 1.0 / (distances**power)
+
+            # Normalize weights and calculate weighted average
+            zi_flat[i] = np.sum(weights * z_nearby) / np.sum(weights)
+
+    # Reshape back to grid
+    znew = zi_flat.reshape(xiv.shape)
+
+    logger.debug("IDW gridding ... DONE")
+
+    self._ensure_correct_values(znew)
+
+
+def _range_to_len_scale(
+    range_value: float | tuple[float, float],
+    variogram_model: str,
+    alpha: float | None = None,
+) -> float | tuple[float, float]:
+    """
+    For kriging. Convert RMS/Petrel-style 'range' to GSTools 'len_scale'.
+
+    Args:
+        range_value: Range parameter (distance to sill). Can be:
+            - float: isotropic range
+            - tuple of 2 floats: anisotropic range_value (range_x, range_y)
+        variogram_model: Model name
+        alpha: Shape parameter for Stable model (1.0-2.0)
+
+    Returns:
+        len_scale for GSTools (float or tuple)
+    """
+    model = variogram_model.lower()
+
+    # Determine conversion factor based on model
+    if model == "gaussian":
+        factor = np.sqrt(3)
+    elif model == "exponential":
+        factor = 3.0
+    elif model == "spherical":
+        factor = 1.0
+    elif model == "linear":
+        # The 'linear' doesn't have a traditional range/sill; use the range_value as-is
+        factor = 1.0
+    elif model == "stable":
+        if alpha is None:
+            logger.warning("Alpha not provided for Stable model, assuming alpha=1.5")
+            alpha = 1.5
+        # Linear interpolation between Exponential and Gaussian conversions
+        factor = 3.0 - (alpha - 1.0) * (3.0 - np.sqrt(3))
+    elif model == "matern":
+        factor = 3.0  # assuming nu=0.5 (exponential-like)
+    else:
+        logger.warning(f"Unknown conversion for {variogram_model}, using range_value/2")
+        factor = 2.0
+
+    # Apply conversion
+    if isinstance(range_value, (tuple, list)):
+        # Anisotropic case
+        if len(range_value) != 2:
+            raise ValueError(
+                f"Range tuple must have 2 elements, got {len(range_value)}"
+            )
+        return tuple(r / factor for r in range_value)
+
+    # Isotropic case
+    return range_value / factor
+
+
+def _create_variogram_model(
+    variogram_model: str,
+    len_scale: float | tuple[float, float],
+    nugget: float,
+    variance: float,
+    variogram_parameters: dict[str, Any] | None,
+    angle: float | None = None,
+) -> gs.CovModel:
+    """
+    Create GSTools covariance model for kriging.
+
+    Args:
+        variogram_model: Model name (e.g., 'gaussian', 'exponential')
+        len_scale: Correlation length
+        nugget: Nugget effect
+        variance: Variance/sill
+        variogram_parameters: Dict with additional model-specific parameters
+        angle: Rotation angle in degrees for anisotropy (GSTools convention).
+            In 2D, angle is measured counter-clockwise from East (X-axis).
+            Default None means no rotation (0 degrees).
+
+    Returns:
+        GSTools covariance model instance
+    """
+
+    # Create covariance model
+    model_params = {
+        "dim": 2,
+        "var": variance,
+        "len_scale": len_scale,
+        "nugget": nugget,
+    }
+
+    # Add rotation angle if specified (convert to radians for GSTools)
+    # Note: GSTools uses 'angles' parameter name in 2D (even for a single angle)
+    if angle is not None:
+        model_params["angles"] = np.deg2rad(angle)
+
+    variogram_model = variogram_model.capitalize()  # GStools use capitalized name
+    vario_params = variogram_parameters or {}
+
+    # Add model-specific parameters
+    if variogram_model == "Matern":
+        model_params["nu"] = vario_params.get("nu", 0.5)
+    elif variogram_model == "Stable":
+        model_params["alpha"] = vario_params.get("alpha", 2.0)
+
+    # Get the model class from gstools
+    model_class = getattr(gs, variogram_model, None)
+    if model_class is None:
+        raise ValueError(
+            f"Unknown variogram model: {variogram_model.lower()}. "
+            "Valid options: gaussian, exponential, spherical, matern, "
+            "stable, linear"
+        )
+
+    return model_class(**model_params)
+
+
+def _calculate_block_division(
+    self: RegularSurface, target_cells_per_block: int
+) -> tuple[int, int]:
+    """
+    Calculate optimal block division respecting grid aspect ratio, for kriging.
+
+    Args:
+        self: RegularSurface instance
+        target_cells_per_block: Target number of cells per block
+
+    Returns:
+        tuple: (n_blocks_x, n_blocks_y)
+    """
+    aspect_ratio = self.ncol / self.nrow
+    if aspect_ratio > 1:
+        # Wider than tall
+        n_blocks_y = max(
+            1,
+            int(np.sqrt(self.nrow * self.ncol / target_cells_per_block / aspect_ratio)),
+        )
+        n_blocks_x = max(1, int(n_blocks_y * aspect_ratio))
+    else:
+        # Taller than wide
+        n_blocks_x = max(
+            1,
+            int(np.sqrt(self.ncol * self.nrow / target_cells_per_block * aspect_ratio)),
+        )
+        n_blocks_y = max(1, int(n_blocks_x / aspect_ratio))
+
+    # Limit to reasonable values
+    n_blocks_x = min(20, max(1, n_blocks_x))
+    n_blocks_y = min(20, max(1, n_blocks_y))
+
+    return n_blocks_x, n_blocks_y
+
+
+def _krige_single_block(
+    self: RegularSurface,
+    i_block: int,
+    j_block: int,
+    n_blocks_x: int,
+    n_blocks_y: int,
+    xiv: FloatArray,
+    yiv: FloatArray,
+    xcv: FloatArray,
+    ycv: FloatArray,
+    zcv: FloatArray,
+    tree: cKDTree,
+    model: gs.CovModel,
+    krige_type: Literal["ordinary", "simple"],
+    mean: float | None,
+    max_points: int,
+    margin: float,
+) -> tuple[
+    FloatArray | None,
+    int,
+    int,
+    int,
+    int,
+    Literal["success", "empty", "masked", "no_valid", "fallback", "nearest_neighbor"],
+]:
+    """
+    Krige a single block of the grid.
+
+    Args:
+        self: RegularSurface instance
+        i_block, j_block: Block indices
+        n_blocks_x, n_blocks_y: Total number of blocks
+        xiv, yiv: Grid coordinate arrays
+        xcv, ycv, zcv: Point data coordinates and values
+        tree: KD-tree of point data
+        model: GSTools covariance model
+        krige_type: 'ordinary' or 'simple'
+        mean: Mean value for simple kriging
+        max_points: Maximum points to use for kriging
+        margin: Search margin around block
+
+    Returns:
+        tuple: (block_result, i_start, i_end, j_start, j_end, status)
+        where status is one of: 'success', 'empty', 'masked', 'no_valid', 'fallback'
+    """
+
+    # Calculate block bounds in index space
+    # Note: array is shaped (ncol, nrow), so first index is i (columns)
+    i_start = i_block * self.ncol // n_blocks_x
+    if i_block < n_blocks_x - 1:
+        i_end = (i_block + 1) * self.ncol // n_blocks_x
+    else:
+        i_end = self.ncol
+    j_start = j_block * self.nrow // n_blocks_y
+    if j_block < n_blocks_y - 1:
+        j_end = (j_block + 1) * self.nrow // n_blocks_y
+    else:
+        j_end = self.nrow
+
+    # Get grid coordinates for this block
+    # Array indexing: [i (ncol dimension), j (nrow dimension)]
+    xiv_block = xiv[i_start:i_end, j_start:j_end]
+    yiv_block = yiv[i_start:i_end, j_start:j_end]
+
+    # Skip truly empty blocks (shouldn't happen with proper slicing)
+    if xiv_block.size == 0 or yiv_block.size == 0:
+        logger.warning(
+            "Block (%d, %d) is empty: size=(%d, %d)",
+            i_block,
+            j_block,
+            xiv_block.size,
+            yiv_block.size,
+        )
+        return None, i_start, i_end, j_start, j_end, "empty"
+
+    # Handle masked arrays - get valid (non-masked) data for block bounds
+    # But we still want to krige ALL positions, even masked ones
+    if np.ma.is_masked(xiv_block):
+        xiv_valid = xiv_block.compressed()
+        yiv_valid = yiv_block.compressed()
+        if len(xiv_valid) == 0:
+            # Block is entirely masked - skip it as it has no coordinates
+            return None, i_start, i_end, j_start, j_end, "masked"
+        # Use valid data to determine block center for point search
+        x_block_min, x_block_max = xiv_valid.min(), xiv_valid.max()
+        y_block_min, y_block_max = yiv_valid.min(), yiv_valid.max()
+
+        # For kriging target, use ALL positions (unmasked the data)
+        # We want to fill the masked regions with kriged values
+        if hasattr(xiv_block, "data"):
+            xiv_block_data = xiv_block.data
+            yiv_block_data = yiv_block.data
+        else:
+            xiv_block_data = xiv_block
+            yiv_block_data = yiv_block
+    else:
+        x_block_min, x_block_max = xiv_block.min(), xiv_block.max()
+        y_block_min, y_block_max = yiv_block.min(), yiv_block.max()
+        xiv_block_data = xiv_block
+        yiv_block_data = yiv_block
+
+    # Calculate block center for spatial search
+    x_block_center = (x_block_min + x_block_max) / 2
+    y_block_center = (y_block_min + y_block_max) / 2
+    block_radius = (
+        np.sqrt((x_block_max - x_block_min) ** 2 + (y_block_max - y_block_min) ** 2) / 2
+        + margin
+    )
+
+    # Find points within search radius of block
+    idx_near = tree.query_ball_point([x_block_center, y_block_center], block_radius)
+
+    # Flatten block grid coordinates - use unmasked data for kriging
+    # We want to krige ALL positions, filling in masked/undefined areas
+    x_block_flat = xiv_block_data.ravel()
+    y_block_flat = yiv_block_data.ravel()
+
+    # Check for and remove any NaN coordinates (invalid grid positions)
+    valid_coords = ~(np.isnan(x_block_flat) | np.isnan(y_block_flat))
+    if not valid_coords.any():
+        return None, i_start, i_end, j_start, j_end, "no_valid"
+
+    x_krige = x_block_flat[valid_coords]
+    y_krige = y_block_flat[valid_coords]
+
+    # Handle case with too few points - use nearest neighbor fallback
+    if len(idx_near) < 3:
+        _, idx_nearest = tree.query(np.column_stack([x_krige, y_krige]), k=1)
+        block_result = np.full(xiv_block.shape, np.nan)
+        block_result_flat = block_result.ravel()
+        block_result_flat[valid_coords] = zcv[idx_nearest]
+        block_result = block_result_flat.reshape(xiv_block.shape)
+        return block_result, i_start, i_end, j_start, j_end, "nearest_neighbor"
+
+    # Limit to max_points if we have too many
+    if len(idx_near) > max_points:
+        # Take closest max_points
+        dists = np.sqrt(
+            (xcv[idx_near] - x_block_center) ** 2
+            + (ycv[idx_near] - y_block_center) ** 2
+        )
+        closest_idx = np.argsort(dists)[:max_points]
+        idx_near = [idx_near[k] for k in closest_idx]
+
+    # Extract local points for this block
+    xcv_local = xcv[idx_near]
+    ycv_local = ycv[idx_near]
+    zcv_local = zcv[idx_near]
+
+    # Perform kriging for this block
+    try:
+        if krige_type == "ordinary":
+            krige = gs.krige.Ordinary(
+                model=model,
+                cond_pos=[xcv_local, ycv_local],
+                cond_val=zcv_local,
+            )
+        else:
+            krige = gs.krige.Simple(
+                model=model,
+                cond_pos=[xcv_local, ycv_local],
+                cond_val=zcv_local,
+                mean=mean,
+            )
+
+        z_krige_result, _ = krige.unstructured([x_krige, y_krige])
+
+        # Fill results - create array and fill valid coordinate positions
+        block_result = np.full(xiv_block.shape, np.nan)
+        block_result_flat = block_result.ravel()
+        block_result_flat[valid_coords] = z_krige_result
+        block_result = block_result_flat.reshape(xiv_block.shape)
+
+        return block_result, i_start, i_end, j_start, j_end, "success"
+
+    except Exception as err:
+        logger.warning(
+            "Kriging failed for block (%d, %d), using IDW fallback: %s",
+            i_block,
+            j_block,
+            err,
+        )
+        # Fallback to inverse distance weighting
+        z_idw = np.full(len(x_krige), np.nan)
+        for idx in range(len(x_krige)):
+            dists = np.sqrt(
+                (xcv_local - x_krige[idx]) ** 2 + (ycv_local - y_krige[idx]) ** 2
+            )
+            weights = 1.0 / (dists**2 + 1e-10)
+            z_idw[idx] = np.sum(weights * zcv_local) / np.sum(weights)
+
+        # Fill results
+        block_result = np.full(xiv_block.shape, np.nan)
+        block_result_flat = block_result.ravel()
+        block_result_flat[valid_coords] = z_idw
+        block_result = block_result_flat.reshape(xiv_block.shape)
+
+        return block_result, i_start, i_end, j_start, j_end, "fallback"
+
+
+def _block_kriging(
+    self: RegularSurface,
+    xcv: FloatArray,
+    ycv: FloatArray,
+    zcv: FloatArray,
+    xiv: FloatArray,
+    yiv: FloatArray,
+    model: gs.CovModel,
+    krige_type: Literal["ordinary", "simple"],
+    mean: float | None,
+    max_points: int,
+    len_scale: float | tuple[float, float],
+    radius: float | None = None,
+) -> FloatArray | MaskedArray:
+    """
+    Perform block-based kriging for large datasets.
+
+    Args:
+        self: RegularSurface instance
+        xcv, ycv, zcv: Point data coordinates and values
+        xiv, yiv: Grid coordinate arrays
+        model: GSTools covariance model
+        krige_type: 'ordinary' or 'simple'
+        mean: Mean value for simple kriging
+        max_points: Maximum points per block
+        len_scale: Correlation length for margin calculation
+        radius: Search radius override (if None, uses 2 * len_scale)
+
+    Returns:
+        numpy array: Kriged surface values
+    """
+    npoints = len(xcv)
+
+    logger.debug(
+        "Using block-based kriging with max %d points per block (total: %d points)...",
+        max_points,
+        npoints,
+    )
+
+    # Build KD-tree for fast spatial searches
+    tree = cKDTree(np.column_stack([xcv, ycv]))
+
+    # Determine block size based on grid dimensions
+    total_cells = self.ncol * self.nrow
+    target_cells_per_block = max(100, total_cells // 100)
+
+    n_blocks_x, n_blocks_y = _calculate_block_division(self, target_cells_per_block)
+    logger.debug("Dividing grid into %d x %d blocks...", n_blocks_x, n_blocks_y)
+
+    # Initialize result array - preserve masking if input has it
+    if np.ma.is_masked(xiv):
+        znew = np.ma.array(
+            np.full(xiv.shape, np.nan),
+            mask=xiv.mask.copy() if hasattr(xiv, "mask") else False,
+        )
+    else:
+        znew = np.full(xiv.shape, np.nan)
+
+    # Calculate search margin for finding points around each block
+    # Use provided radius or auto-calculate from correlation length
+    if radius is not None:
+        margin = radius
+        logger.debug("Using provided search radius: %.1f", margin)
+    else:
+        if isinstance(len_scale, float):
+            margin = 2.0 * len_scale
+        else:
+            margin = 2.0 * np.max(len_scale)
+        logger.debug("Auto-calculated search radius: %.1f (2 * len_scale)", margin)
+
+    # Process each block
+    block_count = 0
+    skipped_empty = 0
+    skipped_masked = 0
+    skipped_no_valid = 0
+
+    for i_block in range(n_blocks_x):
+        for j_block in range(n_blocks_y):
+            result, i_start, i_end, j_start, j_end, status = _krige_single_block(
+                self,
+                i_block,
+                j_block,
+                n_blocks_x,
+                n_blocks_y,
+                xiv,
+                yiv,
+                xcv,
+                ycv,
+                zcv,
+                tree,
+                model,
+                krige_type,
+                mean,
+                max_points,
+                margin,
+            )
+
+            if status == "empty":
+                skipped_empty += 1
+            elif status == "masked":
+                skipped_masked += 1
+            elif status == "no_valid":
+                skipped_no_valid += 1
+            elif result is not None:
+                znew[i_start:i_end, j_start:j_end] = result
+                if status in ("success", "fallback"):
+                    block_count += 1
+
+    total_blocks = n_blocks_x * n_blocks_y
+    logger.debug(
+        "Block kriging completed: %d/%d blocks processed "
+        "(skipped: %d empty, %d masked, %d no valid cells)",
+        block_count,
+        total_blocks,
+        skipped_empty,
+        skipped_masked,
+        skipped_no_valid,
+    )
+
+    # Check how much of the surface was filled
+    if np.ma.is_masked(znew):
+        n_valid = (~znew.mask).sum()
+        n_nan = np.isnan(znew.data[~znew.mask]).sum() if n_valid > 0 else 0
+    else:
+        n_valid = znew.size
+        n_nan = np.isnan(znew).sum()
+
+    logger.debug(
+        "Surface coverage: %d valid cells, %d NaN cells (%.1f%% coverage)",
+        n_valid - n_nan,
+        n_nan,
+        100.0 * (n_valid - n_nan) / n_valid if n_valid > 0 else 0,
+    )
+
+    return znew
+
+
+def _global_kriging(
+    self: RegularSurface,
+    xcv: FloatArray,
+    ycv: FloatArray,
+    zcv: FloatArray,
+    xiv: FloatArray,
+    yiv: FloatArray,
+    model: gs.CovModel,
+    krige_type: Literal["ordinary", "simple"],
+    mean: float | None,
+) -> FloatArray:
+    """
+    Perform global kriging using all points.
+
+    Args:
+        self: RegularSurface instance
+        xcv, ycv, zcv: Point data coordinates and values
+        xiv, yiv: Grid coordinate arrays
+        model: GSTools covariance model
+        krige_type: 'ordinary' or 'simple'
+        mean: Mean value for simple kriging
+
+    Returns:
+        numpy array: Kriged surface values
+    """
+
+    x_coords = xiv.ravel()
+    y_coords = yiv.ravel()
+
+    if krige_type == "ordinary":
+        krige = gs.krige.Ordinary(
+            model=model,
+            cond_pos=[xcv, ycv],
+            cond_val=zcv,
+        )
+    else:
+        krige = gs.krige.Simple(
+            model=model,
+            cond_pos=[xcv, ycv],
+            cond_val=zcv,
+            mean=mean,
+        )
+
+    znew_flat, sigma2_flat = krige.unstructured([x_coords, y_coords])
+    return znew_flat.reshape(xiv.shape)
+
+
+def _enforce_exact_bilinear(
+    self: RegularSurface,
+    xcv: FloatArray,
+    ycv: FloatArray,
+    zcv: FloatArray,
+    znew: FloatArray,
+) -> int:
+    """
+    Enforce exact values using bilinear interpolation adjustment.
+
+    For each data point:
+    1. Find the 4 surrounding grid nodes
+    2. Calculate bilinear weights at the point location
+    3. Adjust the 4 node values to ensure bilinear surface = data value
+
+    This is more accurate than "nearest" because:
+    - Points are honored at their exact (x,y) location, not snapped to nodes
+    - Works for points anywhere in grid cell (not just at nodes)
+    - Smoother transitions when multiple nearby points
+
+    Args:
+        self: RegularSurface instance
+        xcv, ycv, zcv: Point data coordinates and values
+        znew: Kriged surface values (modified in-place)
+
+    Returns:
+        int: Number of data points enforced
+    """
+    # Get grid coordinate arrays - needed to find cells for rotated surfaces
+    xiv, yiv = self.get_xy_values()
+
+    # Build KD-tree of all grid nodes for fast nearest-neighbor search
+    # Flatten arrays to 1D: array is (ncol, nrow), so ravel gives ncol*nrow points
+    x_nodes = xiv.ravel()
+    y_nodes = yiv.ravel()
+    tree = cKDTree(np.column_stack([x_nodes, y_nodes]))
+
+    n_enforced = 0
+    n_outside = 0
+    n_tested = 0
+
+    for k in range(len(xcv)):
+        x, y, z = xcv[k], ycv[k], zcv[k]
+
+        # Find nearest grid node as starting point
+        _, nearest_idx = tree.query([x, y], k=1)
+
+        # Convert flat index back to (i, j) grid indices
+        # Array is shaped (ncol, nrow), stored in C-order
+        i_nearest = nearest_idx // self.nrow
+        j_nearest = nearest_idx % self.nrow
+
+        # Search in a small neighborhood to find the cell containing the point
+        # Check cells around the nearest node - expand search if needed
+        found_cell = False
+        n_tested += 1
+
+        # Try expanding search radius if point not found
+        for search_radius in [0, 1, 2]:
+            if found_cell:
+                break
+
+            for di in range(-search_radius, search_radius + 1):
+                for dj in range(-search_radius, search_radius + 1):
+                    i0 = i_nearest + di
+                    j0 = j_nearest + dj
+
+                    # Check if this cell is valid
+                    if i0 < 0 or i0 >= self.ncol - 1 or j0 < 0 or j0 >= self.nrow - 1:
+                        continue
+
+                    i1 = i0 + 1
+                    j1 = j0 + 1
+
+                    # Get the 4 corner coordinates
+                    # Grid cells: (i0,j0) is one corner, (i1,j1) is opposite
+                    # Order counter-clockwise: bottom-left, bottom-right,
+                    # top-right, top-left
+                    x00, y00 = xiv[i0, j0], yiv[i0, j0]  # bottom-left
+                    x10, y10 = xiv[i1, j0], yiv[i1, j0]  # bottom-right (i+)
+                    x11, y11 = xiv[i1, j1], yiv[i1, j1]  # top-right
+                    x01, y01 = xiv[i0, j1], yiv[i0, j1]  # top-left (j+)
+
+                    # Check if point is inside this quadrilateral
+                    def point_in_quad(px, py, x0, y0, x1, y1, x2, y2, x3, y3):
+                        """
+                        Check if point (px, py) is inside quad with corners
+                        ordered as: (x0,y0) -> (x1,y1) -> (x2,y2) -> (x3,y3)
+                        """
+
+                        # Check if point is on same side of each edge
+                        def cross_sign(ax, ay, bx, by, px, py):
+                            return (bx - ax) * (py - ay) - (by - ay) * (px - ax)
+
+                        # Check edges: 0->1, 1->2, 2->3, 3->0
+                        s0 = cross_sign(x0, y0, x1, y1, px, py)
+                        s1 = cross_sign(x1, y1, x2, y2, px, py)
+                        s2 = cross_sign(x2, y2, x3, y3, px, py)
+                        s3 = cross_sign(x3, y3, x0, y0, px, py)
+
+                        # All should have same sign (or be zero)
+                        return (s0 >= 0 and s1 >= 0 and s2 >= 0 and s3 >= 0) or (
+                            s0 <= 0 and s1 <= 0 and s2 <= 0 and s3 <= 0
+                        )
+
+                    # Pass corners in order: BL, BR, TR, TL
+                    if point_in_quad(x, y, x00, y00, x10, y10, x11, y11, x01, y01):
+                        found_cell = True
+
+                        # Calculate bilinear interpolation weights using
+                        # inverse transformation. For a bilinear surface:
+                        # f(s,t) = (1-s)(1-t)f00 + s(1-t)f10 + (1-s)t*f01
+                        #          + st*f11
+                        # where s, t are parametric coordinates in [0,1]
+                        # We need to find s, t such that coords match
+
+                        # Use iterative Newton-Raphson to find (s, t)
+                        # from (x, y). Needed for general quads (rotated
+                        # grids)
+                        s, t = 0.5, 0.5  # Initial guess at cell center
+
+                        for _ in range(10):  # Newton iterations
+                            # Current position
+                            x_curr = (
+                                (1 - s) * (1 - t) * x00
+                                + s * (1 - t) * x10
+                                + (1 - s) * t * x01
+                                + s * t * x11
+                            )
+                            y_curr = (
+                                (1 - s) * (1 - t) * y00
+                                + s * (1 - t) * y10
+                                + (1 - s) * t * y01
+                                + s * t * y11
+                            )
+
+                            # Residual
+                            rx = x - x_curr
+                            ry = y - y_curr
+
+                            if abs(rx) < 1e-6 and abs(ry) < 1e-6:
+                                break
+
+                            # Jacobian matrix
+                            dx_ds = (1 - t) * (x10 - x00) + t * (x11 - x01)
+                            dx_dt = (1 - s) * (x01 - x00) + s * (x11 - x10)
+                            dy_ds = (1 - t) * (y10 - y00) + t * (y11 - y01)
+                            dy_dt = (1 - s) * (y01 - y00) + s * (y11 - y10)
+
+                            det = dx_ds * dy_dt - dx_dt * dy_ds
+                            if abs(det) < 1e-10:
+                                break
+
+                            # Newton step
+                            ds = (dy_dt * rx - dx_dt * ry) / det
+                            dt = (-dy_ds * rx + dx_ds * ry) / det
+
+                            s += ds
+                            t += dt
+
+                            # Clamp to valid range
+                            s = np.clip(s, 0, 1)
+                            t = np.clip(t, 0, 1)
+
+                        # Calculate bilinear weights
+                        w00 = (1 - s) * (1 - t)
+                        w10 = s * (1 - t)
+                        w01 = (1 - s) * t
+                        w11 = s * t
+
+                        # Current interpolated value
+                        z_current = (
+                            w00 * znew[i0, j0]
+                            + w10 * znew[i1, j0]
+                            + w01 * znew[i0, j1]
+                            + w11 * znew[i1, j1]
+                        )
+
+                        # Calculate and distribute adjustment
+                        z_adjust = z - z_current
+                        znew[i0, j0] += w00 * z_adjust
+                        znew[i1, j0] += w10 * z_adjust
+                        znew[i0, j1] += w01 * z_adjust
+                        znew[i1, j1] += w11 * z_adjust
+
+                        n_enforced += 1
+                        break
+
+                if found_cell:
+                    break
+
+        if not found_cell:
+            n_outside += 1
+
+    logger.debug(
+        "Enforced exact values for %d/%d points using bilinear adjustment "
+        "(%d points outside grid)",
+        n_enforced,
+        n_tested,
+        n_outside,
+    )
+    return n_enforced
+
+
+def points_kriging_gridding(
+    self: RegularSurface,
+    points: Points,
+    variogram_model: str = "gaussian",
+    variogram_parameters: dict[str, Any] | None = None,
+    krige_type: Literal["ordinary", "simple"] = "ordinary",
+    mean: float | None = None,
+    coarsen: int = 1,
+    max_points: int = 500,
+    radius: float | None = None,
+    exact: bool = False,
+) -> None:
+    """
+    Do kriging gridding from a points data set using GSTools.
+
+    Kriging provides optimal spatial interpolation based on spatial correlation
+    structure (variogram). Good for sparse, spatially correlated data.
+
+    Args:
+        points: Points object containing x, y, z coordinates
+        variogram_model: Variogram/Covariance model. Options:
+            - 'gaussian': Gaussian model (smooth, good for continuous phenomena)
+            - 'exponential': Exponential model (good for geology)
+            - 'spherical': Spherical model (classic geostatistics)
+            - 'matern': Matérn model (flexible smoothness)
+            - 'stable': Stable model (generalization of Gaussian, also called
+              'general exponential')
+            - 'linear': Linear model
+        variogram_parameters: Dict with variogram model parameters:
+            - 'len_scale' (float or tuple): Correlation length (range). If None,
+              auto-estimated. Can be single value or tuple (len_scale_x, len_scale_y)
+              for anisotropy. First value is major axis (X or Easting), second is
+              minor axis (Y or Northing).
+            - 'range_value' (float or tuple): Alternative to len_scale (RMS/Petrel
+              style). If both provided, len_scale takes precedence. Can be single
+              value or tuple for anisotropy.
+            - 'angle' (float): Rotation angle in degrees for anisotropic variograms
+              (counter-clockwise from East/X-axis). Only used when len_scale or
+              range_value is a tuple. Default None (0°).
+              Examples: 0°=East, 90°=North, 45°=NE, -45°=SE.
+            - 'nugget' (float): Nugget effect (measurement error/micro-scale
+              variation), default 0.0
+            - 'variance' (float): Variance/sill of the model. If None, auto-estimated
+              from data variance.
+            - 'nu' (float): Smoothness parameter for Matern model, default 0.5
+            - 'alpha' (float): Shape parameter for Stable model, default 2.0
+        krige_type: Type of kriging, 'ordinary' (default) or 'simple'
+        mean: Mean value for simple kriging. If None and krige_type='simple',
+            auto-estimated from data. Not used for ordinary kriging.
+        coarsen: Coarsening factor for input points
+        max_points: Maximum points per block for kriging. When dataset has more
+            points, uses hybrid block-based kriging: divides grid into blocks and
+            uses nearby points for each block. This balances speed and accuracy
+            better than simple subsampling. Recommended: 500-2000.
+            If None, defaults to 500. Use a very large value to force global
+            kriging with all points.
+        radius: Search radius (in map units) for finding points around each block.
+            If None, automatically calculated as 2 * len_scale to ensure overlap
+            between blocks. Increase if blocks have too few points, decrease for
+            faster execution with dense data.
+        exact: If True, enforces exact data values at point locations using bilinear
+            interpolation adjustment. Default is False.
+            Note: Kriging is theoretically exact when nugget=0, but grid nodes
+            rarely coincide with data points, so enforcement is recommended.
+
+    Example::
+        # Simple isotropic kriging (auto-estimated parameters)
+        surf.gridding(points, method='kriging')
+
+        # Isotropic with explicit range
+        surf.gridding(points, method='kriging',
+                     method_options={
+                         'variogram_model': 'exponential',
+                         'variogram_parameters': {'range_value': 1500.0}
+                     })
+
+        # Anisotropic kriging with rotation
+        surf.gridding(points, method='kriging',
+                     method_options={
+                         'variogram_model': 'gaussian',
+                         'variogram_parameters': {
+                             'len_scale': (2000, 500),  # major, minor
+                             'angle': 45,  # NE direction
+                             'nugget': 0.1
+                         }
+                     })
+
+        # Full control with all parameters
+        surf.gridding(points, method='kriging',
+                     method_options={
+                         'variogram_model': 'matern',
+                         'variogram_parameters': {
+                             'range_value': (3000, 1200),
+                             'angle': 30,
+                             'nugget': 0.05,
+                             'variance': 100.0,
+                             'nu': 1.5  # Matern-specific
+                         },
+                         'krige_type': 'simple',
+                         'mean': 1700.0,
+                         'exact': True
+                     })
+
+        # Block-based kriging for large datasets
+        surf.gridding(points, method='kriging',
+                     method_options={
+                         'max_points': 500,
+                         'radius': 5000.0
+                     })
+    """
+
+    logger.debug("Do kriging...")
+    dfra, xcv, ycv, zcv, xiv, yiv = _points_gridding_common(
+        self, points, coarsen=coarsen
+    )
+
+    # Check for close points that may cause numerical issues
+    _check_close_points_warning(self, points, threshold_factor=0.1)
+
+    npoints = len(xcv)
+
+    # Extract variogram parameters from dict
+    vario_params = variogram_parameters or {}
+
+    len_scale = vario_params.get("len_scale", None)
+    range_value = vario_params.get("range_value", None)
+    nugget = vario_params.get("nugget", 0.0)
+    angle = vario_params.get("angle", None)
+
+    # Validate kriging type
+    if krige_type not in ("ordinary", "simple"):
+        raise ValueError(
+            f"krige_type must be 'ordinary' or 'simple', got '{krige_type}'"
+        )
+
+    # For simple kriging, estimate or use provided mean
+    if krige_type == "simple":
+        if mean is None:
+            mean = np.mean(zcv)
+            logger.debug("Auto-estimated mean for simple kriging: %.2f", mean)
+        else:
+            logger.debug("Using provided mean for simple kriging: %.2f", mean)
+
+    # Handle range_value vs len_scale
+    if range_value is not None and len_scale is None:
+        # Extract alpha for Stable model if needed
+        alpha = None
+        if variogram_model.lower() == "stable" and variogram_parameters:
+            alpha = variogram_parameters.get("alpha", None)
+
+        len_scale = _range_to_len_scale(range_value, variogram_model, alpha=alpha)
+
+        if isinstance(len_scale, tuple):
+            logger.debug(
+                "Converted RMS range=(%s, %s) to GSTools len_scale=(%s, %s) "
+                "for %s model%s",
+                range_value[0],
+                range_value[1],
+                len_scale[0],
+                len_scale[1],
+                variogram_model,
+                f" (alpha={alpha})" if alpha is not None else "",
+            )
+        else:
+            logger.debug(
+                "Converted RMS range=%.1f to GSTools len_scale=%.1f for %s model%s",
+                range_value,
+                len_scale,
+                variogram_model,
+                f" (alpha={alpha})" if alpha is not None else "",
+            )
+
+    # Auto-estimate len_scale if not provided
+    if len_scale is None:
+        len_scale = _estimate_correlation_length(xcv, ycv, zcv)
+        logger.debug("Auto-estimated correlation length: %.2f", len_scale)
+
+    # Extract variance if provided
+    variance = vario_params.get("variance", None)
+
+    # Auto-estimate variance if not provided
+    if variance is None:
+        variance = np.var(zcv)
+        logger.debug("Auto-estimated variance: %.2f", variance)
+
+    # Create covariance model
+    model = _create_variogram_model(
+        variogram_model, len_scale, nugget, variance, variogram_parameters, angle
+    )
+
+    # Determine kriging strategy based on max_points and dataset size
+    if max_points is None:
+        max_points = 500
+
+    use_block_kriging = npoints > max_points
+
+    if use_block_kriging:
+        # Hybrid block-based approach
+        znew = _block_kriging(
+            self,
+            xcv,
+            ycv,
+            zcv,
+            xiv,
+            yiv,
+            model,
+            krige_type,
+            mean,
+            max_points,
+            len_scale,
+            radius,
+        )
+    else:
+        # Global kriging - use all points (fast for small datasets)
+        logger.debug(
+            "Global kriging from %d points (type=%s, model=%s, len_scale=%s, "
+            "nugget=%.2f, var=%.2f)...",
+            npoints,
+            krige_type,
+            variogram_model,
+            len_scale,
+            nugget,
+            variance,
+        )
+        znew = _global_kriging(self, xcv, ycv, zcv, xiv, yiv, model, krige_type, mean)
+
+    # Enforce exact values at data points
+    if exact:
+        logger.debug("Enforcing exact data values...")
+        n_enforced = _enforce_exact_bilinear(self, xcv, ycv, zcv, znew)
+        if n_enforced > 0:
+            logger.debug(
+                "Enforced exact values at %d locations using '%s' method",
+                n_enforced,
+                exact,
+            )
+
+    logger.debug("Kriging gridding ... DONE")
+    self._ensure_correct_values(znew)
+
+
+# ======================================================================================
+# FUNCTIONS doing gridding from 3D properties
+# ======================================================================================
+
+
 def avgsum_from_3dprops_gridding(
-    self,
-    summing=False,
-    xprop=None,
-    yprop=None,
-    mprop=None,
-    dzprop=None,
-    truncate_le=None,
-    zoneprop=None,
-    zone_minmax=None,
-    coarsen=1,
-    zone_avg=False,
-    mask_outside=False,
-):
+    self: RegularSurface,
+    summing: bool = False,
+    xprop: Any = None,
+    yprop: Any = None,
+    mprop: Any = None,
+    dzprop: Any = None,
+    truncate_le: Any = None,
+    zoneprop: Any = None,
+    zone_minmax: tuple[int, int] | None = None,
+    coarsen: int = 1,
+    zone_avg: bool = False,
+    mask_outside: bool = False,
+) -> None:
     """Get surface average from a 3D grid prop."""
     # NOTE:
     # This do _either_ averaging _or_ sum gridding (if summing is True)
@@ -78,7 +1731,7 @@ def avgsum_from_3dprops_gridding(
     # - Xprop and yprop must be made for all cells
     # - Also dzprop for all cells, and dzprop = 0 for inactive cells!
 
-    logger.info("Avgsum calculation %s", __name__)
+    logger.debug("Avgsum calculation %s", __name__)
 
     if zone_minmax is None:
         raise ValueError("zone_minmax is required")
@@ -141,12 +1794,12 @@ def avgsum_from_3dprops_gridding(
         if summing:
             propsum = mprop[:, :, klay0].sum()
             if abs(propsum) < 1e-12:
-                logger.info("Too little HC, skip layer K = %s", k1lay)
+                logger.debug("Too little HC, skip layer K = %s", k1lay)
                 qmcompute = False
             else:
                 logger.debug("Z property sum is %s", propsum)
 
-        logger.info("Mapping for layer or zone %s ....", k1lay)
+        logger.debug("Mapping for layer or zone %s ....", k1lay)
 
         xcv = xprop[::, ::, klay0].ravel(order="C")
         ycv = yprop[::, ::, klay0].ravel(order="C")
@@ -201,14 +1854,22 @@ def avgsum_from_3dprops_gridding(
         vvz = ma.masked_less(vvz, truncate_le)
 
     self.values = vvz
-    logger.info("Avgsum calculation done! %s", __name__)
+    logger.debug("Avgsum calculation done! %s", __name__)
 
     return True
 
 
 def _zone_averaging(
-    xprop, yprop, zoneprop, zone_minmax, coarsen, zone_avg, dzprop, mprop, summing=False
-):
+    xprop: Any,
+    yprop: Any,
+    zoneprop: Any,
+    zone_minmax: tuple[int, int] | None,
+    coarsen: int,
+    zone_avg: bool,
+    dzprop: Any,
+    mprop: Any,
+    summing: bool = False,
+) -> tuple[FloatArray, FloatArray, FloatArray]:
     # General preprocessing, and...
     # Change the 3D numpy array so they get layers by
     # averaging across zones. This may speed up a lot,
@@ -249,7 +1910,7 @@ def _zone_averaging(
         newd = []
 
         for izv in range(zmin, zmax + 1):
-            logger.info("Averaging for zone %s ...", izv)
+            logger.debug("Averaging for zone %s ...", izv)
             xpr2 = ma.masked_where(zpr != izv, xpr)
             ypr2 = ma.masked_where(zpr != izv, ypr)
             zpr2 = ma.masked_where(zpr != izv, zpr)
@@ -296,17 +1957,34 @@ def _zone_averaging(
     return xpr, ypr, zpr, mpr, dpr
 
 
-def surf_fill(self, fill_value=None):
+# ======================================================================================
+# FUNCTIONS doing post-processing on surfaces
+# ======================================================================================
+
+
+def surf_fill(
+    self: RegularSurface, fill_value: float | None = None, method: str = "nearest"
+) -> None:
     """Replace the value of invalid 'data' cells (indicated by 'invalid')
-    by the value of the nearest valid data cell or a constant.
+    by the value of the nearest valid data cell, a constant, or smooth extrapolation.
 
     This is a quite fast method to fill undefined areas of the map.
     The surface values are updated 'in-place'
 
+    Args:
+        fill_value: If numeric, fill with this constant value
+        method: Extrapolation method if fill_value is None:
+            - 'nearest': Use nearest valid cell (fast, blocky)
+            - 'linear': Linear interpolation/extrapolation (smooth)
+            - 'cubic': Cubic interpolation/extrapolation (very smooth)
+            - 'radial_basis': RBF with thin plate spline (smooth, best quality)
+
     .. versionadded:: 2.1
     .. versionchanged:: 2.6 Added fill_value
     """
-    logger.info("Do fill...")
+    logger.debug(
+        "Do fill with method '%s'...", method if fill_value is None else "constant"
+    )
 
     if fill_value is not None:
         if np.isscalar(fill_value) and not isinstance(fill_value, str):
@@ -314,18 +1992,79 @@ def surf_fill(self, fill_value=None):
         else:
             raise ValueError("Keyword fill_value must be int or float")
     else:
-        invalid = ma.getmaskarray(self.values)
+        valid_mask = ~ma.getmaskarray(self.values)
 
-        ind = scipy.ndimage.distance_transform_edt(
-            invalid, return_distances=False, return_indices=True
-        )
-        self._values = self._values[tuple(ind)]
-        logger.info("Do fill... DONE")
+        if method == "nearest":
+            # Original fast method
+            invalid = ~valid_mask
+            ind = scipy.ndimage.distance_transform_edt(
+                invalid, return_distances=False, return_indices=True
+            )
+            self._values = self._values[tuple(ind)]
+
+        elif method in ("linear", "cubic", "radial_basis"):
+            # Get valid data points
+            xiv, yiv = self.get_xy_values()
+
+            xcv = xiv[valid_mask]
+            ycv = yiv[valid_mask]
+            zcv = self.values[valid_mask]
+
+            # Interpolate/extrapolate to all grid points
+            if method in ("linear", "cubic"):
+                znew = scipy.interpolate.griddata(
+                    (xcv, ycv),
+                    zcv,
+                    (xiv, yiv),
+                    method=method,
+                    fill_value=np.nan,  # Will still have NaN at far extrapolation
+                )
+
+                # For remaining NaN, fall back to nearest
+                remaining_nan = np.isnan(znew)
+                if np.any(remaining_nan):
+                    znear = scipy.interpolate.griddata(
+                        (xcv, ycv), zcv, (xiv, yiv), method="nearest"
+                    )
+                    znew[remaining_nan] = znear[remaining_nan]
+
+            elif method == "radial_basis":
+                # RBF can be slow - optimize for large datasets
+                max_points = 5000
+
+                if len(xcv) > max_points:
+                    logger.debug(
+                        "Sampling %d points from %d for RBF fill", max_points, len(xcv)
+                    )
+                    step = max(1, len(xcv) // max_points)
+                    xcv = xcv[::step][:max_points]
+                    ycv = ycv[::step][:max_points]
+                    zcv = zcv[::step][:max_points]
+
+                rbf = scipy.interpolate.RBFInterpolator(
+                    np.column_stack([xcv, ycv]),
+                    zcv,
+                    kernel="thin_plate_spline",
+                    smoothing=0.0,
+                    degree=1,
+                )
+                znew = rbf(np.column_stack([xiv.ravel(), yiv.ravel()])).reshape(
+                    xiv.shape
+                )
+            self._values = znew
+
+        else:
+            raise ValueError(
+                f"Invalid method '{method}'. "
+                "Valid options: 'nearest', 'linear', 'cubic', 'radial_basis'"
+            )
+
+    logger.debug("Do fill... DONE")
 
 
 def _smooth(
     self: RegularSurface,
-    window_function: Callable[[np.ndarray], np.ndarray],
+    window_function: Callable[[NDArray[np.float64]], NDArray[np.float64]],
     iterations: int = 1,
 ) -> None:
     """

--- a/src/xtgeo/well/_well_io.py
+++ b/src/xtgeo/well/_well_io.py
@@ -36,10 +36,8 @@ def import_rms_ascii(
     lnum = 1
     with open(wfile.file, "r", encoding="UTF-8") as fwell:
         for line in fwell:
-            if lnum == 1:
-                _ffver = line.strip()  # noqa, file version
-            elif lnum == 2:
-                _wtype = line.strip()  # noqa, well type
+            if lnum <= 2:
+                pass
             elif lnum == 3:
                 # usually 4 fields, but last (rkb) can be missing. A
                 # complication is that first field (well name) may have spaces,

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -696,3 +696,24 @@ class Points(XYZ):
     @inherit_docstring(inherit_from=XYZ.get_xyz_arrays)
     def get_xyz_arrays(self):
         return super().get_xyz_arrays()
+
+    def merge_close_points(
+        self,
+        min_distance: float,
+        method: str = "average",
+    ):
+        """Merge close points based on a minimum distance.
+
+        Args:
+            min_distance (float): Minimum distance to consider points as close.
+            method (str): Merge method, one of 'average', 'median', 'first',
+                'min_z', 'max_z'.
+
+        Note:
+            Any points attributes will be removed when merging points, as it is not
+            possible to know how to merge such values. E.g. an attribute can be
+            categorical strings which cannot be averaged.
+
+        """
+        # Implementation of the merging logic goes here
+        _xyz_oper.merge_close_points(self, min_distance, method)

--- a/tests/test_surface/test_regular_surface_gridding.py
+++ b/tests/test_surface/test_regular_surface_gridding.py
@@ -1,0 +1,1608 @@
+"""Test suite for RegularSurface.gridding() with all methods."""
+
+import pathlib
+
+import numpy as np
+import pytest
+
+import xtgeo
+
+POINTSET2 = pathlib.Path("points/reek/1/pointset2.poi")
+
+
+@pytest.fixture
+def simple_surface():
+    """Create a simple regular surface template for testing."""
+    return xtgeo.RegularSurface(
+        ncol=50,
+        nrow=50,
+        xinc=10.0,
+        yinc=10.0,
+        xori=0.0,
+        yori=0.0,
+        values=np.zeros((50, 50)),
+    )
+
+
+@pytest.fixture
+def simple_points():
+    """Create simple test points on a tilted plane."""
+    np.random.seed(42)
+    n_points = 100
+    x = np.random.uniform(50, 450, n_points)
+    y = np.random.uniform(50, 450, n_points)
+    # Create a tilted plane: z = 100 + 0.1*x + 0.05*y
+    z = 100 + 0.1 * x + 0.05 * y + np.random.normal(0, 1, n_points)
+
+    return xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+
+@pytest.fixture
+def sparse_points():
+    """Create sparse test points for testing methods that work well with few points."""
+    # Non-collinear points to avoid singular matrix issues with RBF
+    x = [100, 200, 300, 400, 150, 250, 350]
+    y = [100, 150, 250, 300, 200, 350, 150]
+    z = [100, 110, 105, 115, 120, 125, 130]
+
+    return xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+
+@pytest.fixture
+def close_points():
+    """Create points with some very close together."""
+    # Non-collinear points with first two very close
+    x = [100.0, 100.1, 200.0, 300.0, 400.0]  # First two are very close
+    y = [100.0, 100.1, 250.0, 150.0, 350.0]  # Not on diagonal
+    z = [50.0, 51.0, 60.0, 70.0, 80.0]
+
+    return xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+
+@pytest.fixture
+def pointset2(testdata_path):
+    """Use POINTSET2 data."""
+
+    return xtgeo.points_from_file(testdata_path / POINTSET2)
+
+
+@pytest.fixture
+def pointset2_thinned(pointset2):
+    """Use POINTSET2 data but thinned to every 4rd point for faster tests."""
+    points = pointset2.copy()
+    # Thin the points by taking every 3rd point (keeps ~33% of points)
+    points.set_dataframe(points._df.iloc[::4].reset_index(drop=True))
+    return points
+
+
+@pytest.fixture
+def surface_for_pointset2():
+    return xtgeo.RegularSurface(
+        ncol=280,
+        nrow=440,
+        xinc=25,
+        yinc=25,
+        xori=461500,
+        yori=5926500,
+        rotation=30,
+    )
+
+
+# ======================================================================================
+# Test: linear method
+# ======================================================================================
+
+
+def test_gridding_linear_basic(simple_surface, simple_points):
+    """Test linear interpolation gridding."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="linear")
+
+    # Check that surface has been populated
+    assert not np.all(np.isnan(surf.values))
+    assert surf.values.mask.sum() < surf.ncol * surf.nrow  # Some nodes should be valid
+
+
+def test_gridding_linear_with_extrapolate(simple_surface, simple_points):
+    """Test linear interpolation with extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="linear", method_options={"extrapolate": True})
+
+    # With extrapolate, should have fewer undefined nodes
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_linear_without_extrapolate(simple_surface, simple_points):
+    """Test linear interpolation without extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="linear", method_options={"extrapolate": False})
+
+    # Without extrapolate, may have more undefined nodes at edges
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: nearest method
+# ======================================================================================
+
+
+def test_gridding_nearest_basic(simple_surface, simple_points):
+    """Test nearest neighbor gridding."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="nearest")
+
+    # Check that surface has been populated
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_nearest_preserves_values(simple_surface):
+    """Test that nearest neighbor preserves exact point values."""
+    # Create points with known values
+    x = [100, 200, 300]
+    y = [100, 200, 300]
+    z = [10.0, 20.0, 30.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="nearest")
+
+    # Values near the points should be close to the point values
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: cubic method
+# ======================================================================================
+
+
+def test_gridding_cubic_basic(simple_surface, simple_points):
+    """Test cubic interpolation gridding."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="cubic")
+
+    # Check that surface has been populated
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_cubic_smooth(simple_surface, simple_points):
+    """Test that cubic produces smooth results."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="cubic")
+
+    # Cubic should produce smoother results than linear
+    # (This is a qualitative check - just ensure it runs)
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: inverse_distance (IDW) method
+# ======================================================================================
+
+
+def test_gridding_idw_default(simple_surface, simple_points):
+    """Test IDW with default parameters."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="inverse_distance")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_idw_custom_power(simple_surface, simple_points):
+    """Test IDW with custom power parameter."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points, method="inverse_distance", method_options={"power": 3.0}
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_idw_with_radius(simple_surface, simple_points):
+    """Test IDW with search radius."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="inverse_distance",
+        method_options={"power": 2.0, "radius": 100.0, "min_points": 3},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: radial_basis (RBF) method
+# ======================================================================================
+
+
+def test_gridding_rbf_default(simple_surface, sparse_points):
+    """Test RBF with default parameters (thin_plate_spline)."""
+    surf = simple_surface.copy()
+    surf.gridding(sparse_points, method="radial_basis")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_rbf_functions(simple_surface, sparse_points):
+    """Test different RBF kernel functions."""
+    functions = [
+        "thin_plate_spline",
+        "cubic",
+        "quintic",
+        "linear",
+        "multiquadric",
+        "inverse_multiquadric",
+        "inverse_quadratic",
+        "gaussian",
+    ]
+
+    for func in functions:
+        surf = simple_surface.copy()
+        surf.gridding(
+            sparse_points, method="radial_basis", method_options={"function": func}
+        )
+        assert not np.all(np.isnan(surf.values)), f"Failed for function={func}"
+
+
+def test_gridding_rbf_with_smoothing(simple_surface, simple_points):
+    """Test RBF with smoothing parameter."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points, method="radial_basis", method_options={"smoothing": 0.1}
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: moving_average method
+# ======================================================================================
+
+
+def test_gridding_moving_average_default(simple_surface, simple_points):
+    """Test moving average with default parameters."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="moving_average")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_moving_average_custom_radius(simple_surface, simple_points):
+    """Test moving average with custom radius."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="moving_average",
+        method_options={"radius": 50.0, "min_points": 5},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: kriging method
+# ======================================================================================
+
+
+def test_gridding_kriging_default(simple_surface, simple_points):
+    """Test kriging with default parameters."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="kriging")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_kriging_variogram_models(simple_surface, sparse_points):
+    """Test different variogram models."""
+    models = ["Gaussian", "Exponential", "Spherical"]
+
+    for model in models:
+        surf = simple_surface.copy()
+        surf.gridding(
+            sparse_points,
+            method="kriging",
+            method_options={"variogram_model": model},
+        )
+        assert not np.all(np.isnan(surf.values)), f"Failed for model={model}"
+
+
+def test_gridding_kriging_with_nugget(simple_surface, simple_points):
+    """Test kriging with nugget effect."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="kriging",
+        method_options={"variogram_parameters": {"nugget": 0.1}},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_kriging_simple(simple_surface, simple_points):
+    """Test simple kriging."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="kriging",
+        method_options={"krige_type": "simple", "mean": 110.0},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_kriging_with_len_scale(simple_surface, simple_points):
+    """Test kriging with explicit len_scale."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="kriging",
+        method_options={"variogram_parameters": {"len_scale": 100.0}},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_kriging_with_range_value(simple_surface, simple_points):
+    """Test kriging with range_value instead of len_scale."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="kriging",
+        method_options={"variogram_parameters": {"range_value": 150.0}},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_kriging_exact(simple_surface, sparse_points):
+    """Test kriging with exact=True."""
+    surf = simple_surface.copy()
+    surf.gridding(sparse_points, method="kriging", method_options={"exact": True})
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: coarsen parameter
+# ======================================================================================
+
+
+def test_gridding_with_coarsen(simple_surface, simple_points):
+    """Test gridding with coarsening factor."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="linear", coarsen=2)
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: error handling
+# ======================================================================================
+
+
+def test_gridding_invalid_method(simple_surface, simple_points):
+    """Test that invalid method raises ValueError."""
+    surf = simple_surface.copy()
+
+    with pytest.raises(ValueError, match="Invalid gridding method"):
+        surf.gridding(simple_points, method="invalid_method")
+
+
+def test_gridding_not_points_instance(simple_surface):
+    """Test that invalid input type raises ValueError."""
+    surf = simple_surface.copy()
+
+    with pytest.raises(
+        ValueError, match="Input must be a Points, Polygons, or RegularSurface instance"
+    ):
+        surf.gridding("not_a_points_object", method="linear")
+
+
+def test_gridding_from_polygons(simple_surface):
+    """Test gridding from Polygons instance."""
+
+    surf = simple_surface.copy()
+
+    # Create a simple polygon as list of tuples (x, y, z, poly_id)
+    poly_data = [
+        (100.0, 100.0, 1000.0, 1),
+        (300.0, 100.0, 1100.0, 1),
+        (500.0, 300.0, 1200.0, 1),
+        (300.0, 500.0, 1300.0, 1),
+        (100.0, 100.0, 1000.0, 1),
+    ]
+    polygons = xtgeo.Polygons(poly_data)
+
+    # Should work without error
+    surf.gridding(polygons, method="nearest")
+
+    # Check that some values were set
+    assert not surf.values.mask.all(), "All values are masked after gridding"
+
+
+def test_gridding_from_surface(simple_surface):
+    """Test gridding from RegularSurface instance."""
+    import numpy as np
+
+    surf = simple_surface.copy()
+
+    # Create a source surface with some data
+    source = xtgeo.RegularSurface(
+        ncol=10,
+        nrow=10,
+        xinc=50.0,
+        yinc=50.0,
+        xori=0.0,
+        yori=0.0,
+        values=np.random.uniform(1000, 2000, (10, 10)),
+    )
+
+    # Should work without error
+    surf.gridding(source, method="nearest")
+
+    # Check that some values were set
+    assert not surf.values.mask.all(), "All values are masked after gridding"
+
+
+# ======================================================================================
+# Test: method combinations
+# ======================================================================================
+
+
+def test_gridding_linear_then_fill(simple_surface, sparse_points):
+    """Test linear gridding followed by fill."""
+    surf = simple_surface.copy()
+    surf.gridding(sparse_points, method="linear")
+
+    # Count undefined before fill
+    undefined_before = surf.values.mask.sum()
+
+    surf.fill()
+
+    # Should have fewer undefined after fill
+    undefined_after = surf.values.mask.sum()
+    assert undefined_after <= undefined_before
+
+
+def test_gridding_rbf_with_merge(simple_surface, close_points):
+    """Test RBF gridding with close points merging."""
+    surf = simple_surface.copy()
+
+    # Test that RBF can handle close points
+    # (previously would need merging, but now user should preprocess)
+    surf.gridding(
+        close_points,
+        method="radial_basis",
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: numerical correctness
+# ======================================================================================
+
+
+def test_gridding_preserves_point_values_nearest(simple_surface):
+    """Test that nearest method preserves point values exactly at point locations."""
+    # Create a few points with known values
+    x = [100, 200, 300]
+    y = [100, 200, 300]
+    z = [50.0, 60.0, 70.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="nearest")
+
+    # Get values at point locations (approximately)
+    # This is a rough check - exact values depend on grid alignment
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_linear_interpolation_properties(simple_surface):
+    """Test that linear interpolation behaves correctly."""
+    # Create 4 corner points
+    x = [100, 100, 300, 300]
+    y = [100, 300, 100, 300]
+    z = [10.0, 20.0, 30.0, 40.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="linear")
+
+    # Linear interpolation should produce values within the range of input
+    valid_values = surf.values[~surf.values.mask]
+    if len(valid_values) > 0:
+        assert valid_values.min() >= 10.0 - 5.0  # Allow some tolerance
+        assert valid_values.max() <= 40.0 + 5.0
+
+
+# ======================================================================================
+# Test: edge cases
+# ======================================================================================
+
+
+def test_gridding_single_point(simple_surface):
+    """Test gridding with a single point."""
+    x = [250]
+    y = [250]
+    z = [100.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Nearest should work with single point
+    surf.gridding(points, method="nearest")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_few_points(simple_surface):
+    """Test gridding with very few points."""
+    x = [100, 400]
+    y = [100, 400]
+    z = [50.0, 150.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="nearest")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: method-specific edge cases
+# ======================================================================================
+
+
+def test_gridding_idw_min_points_not_met(simple_surface):
+    """Test IDW when minimum points requirement cannot be met everywhere."""
+    # Very sparse points
+    x = [100, 400]
+    y = [100, 400]
+    z = [50.0, 150.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Should handle gracefully
+    surf.gridding(
+        points,
+        method="inverse_distance",
+        method_options={"min_points": 1, "radius": 200.0},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: additional edge cases
+# ======================================================================================
+
+
+def test_gridding_empty_points(simple_surface):
+    """Test gridding with empty points object raises appropriate error."""
+    # Create a Points object with zero points (but proper structure)
+    empty_points = xtgeo.Points(
+        values=np.empty((0, 3)),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # With no points, gridding should raise an error or handle gracefully
+    # Catching any exception as this is an edge case with undefined behavior
+    with pytest.raises((ValueError, RuntimeError, TypeError, SystemError, Exception)):
+        surf.gridding(empty_points, method="linear")
+
+
+def test_gridding_points_outside_surface(simple_surface):
+    """Test gridding when all points are outside surface extent."""
+    # Points far outside the surface bounds (surface is 0-490, 0-490)
+    x = [1000, 1100, 1200]
+    y = [1000, 1100, 1200]
+    z = [50.0, 60.0, 70.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # When all points are outside the surface, they get filtered out
+    # This should raise an error since there are no points to grid
+    with pytest.raises(RuntimeError, match="Could not do gridding"):
+        surf.gridding(points, method="linear", method_options={"extrapolate": False})
+
+
+def test_gridding_points_at_surface_edges(simple_surface):
+    """Test gridding with points exactly at surface boundaries."""
+    # Points at the corners and edges of the surface
+    x = [0, 490, 0, 490, 245]  # xori=0, xmax=0+50*10-10=490
+    y = [0, 0, 490, 490, 245]
+    z = [10.0, 20.0, 30.0, 40.0, 25.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="linear")
+
+    # Should have some valid values
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_duplicate_points_no_merge(simple_surface):
+    """Test gridding with exact duplicate points without merging."""
+    # Exact duplicate points
+    x = [100, 100, 200, 300]  # First two are identical
+    y = [100, 100, 200, 300]
+    z = [50.0, 55.0, 60.0, 70.0]  # Different Z values
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Scipy's triangulation doesn't handle duplicate points well
+    # This should raise an error - duplicates need to be merged first
+    with pytest.raises((RuntimeError, ValueError)):
+        surf.gridding(points, method="linear")
+
+
+def test_gridding_duplicate_points_with_merge(simple_surface):
+    """Test gridding with exact duplicate points using merge."""
+    # Exact duplicate points with non-collinear result after merge
+    x = [100, 100, 200, 300, 150]  # First two are identical
+    y = [100, 100, 250, 150, 200]  # Non-collinear after merge
+    z = [50.0, 55.0, 60.0, 70.0, 58.0]  # Different Z values
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Duplicates should be handled by the gridding method
+    surf.gridding(points, method="linear")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_collinear_points(simple_surface):
+    """Test gridding with all points on a line."""
+    # All points on a diagonal line
+    coords = [(100 + i * 50, 100 + i * 50, 10.0 + i * 5) for i in range(6)]
+    x, y, z = zip(*coords)
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Some methods may struggle with collinear points
+    surf.gridding(points, method="nearest")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_extreme_z_values(simple_surface):
+    """Test gridding with very large or very small Z values."""
+    # Non-collinear points with extreme Z values
+    x = [100, 200, 300, 400, 150]
+    y = [100, 250, 150, 350, 200]
+    z = [1e6, -1e6, 1e-6, -1e-6, 0.0]  # Extreme values
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="linear")
+
+    # Should handle extreme values
+    valid_values = (
+        surf.values[~surf.values.mask]
+        if hasattr(surf.values, "mask")
+        else surf.values[~np.isnan(surf.values)]
+    )
+    if len(valid_values) > 0:
+        assert not np.all(np.isnan(valid_values))
+
+
+def test_gridding_uniform_z_values(simple_surface):
+    """Test gridding when all Z values are identical."""
+    # Non-collinear points with uniform Z
+    x = [100, 200, 300, 400, 150, 250]
+    y = [100, 250, 150, 350, 200, 300]
+    z = [100.0] * 6  # All same value
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="linear")
+
+    # All interpolated values should be approximately 100.0
+    valid_values = (
+        surf.values[~surf.values.mask]
+        if hasattr(surf.values, "mask")
+        else surf.values[~np.isnan(surf.values)]
+    )
+    if len(valid_values) > 0:
+        assert np.allclose(valid_values, 100.0, rtol=0.01)
+
+
+def test_gridding_very_dense_points(simple_surface):
+    """Test gridding with very dense point cloud."""
+    np.random.seed(123)
+    n_points = 5000  # Very dense
+    x = np.random.uniform(100, 400, n_points)
+    y = np.random.uniform(100, 400, n_points)
+    z = 100 + 0.1 * x + 0.05 * y
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Should handle large number of points
+    surf.gridding(points, method="linear")
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_nan_values_in_points(simple_surface):
+    """Test gridding when points contain NaN values."""
+    # Non-collinear points with some NaN values
+    x = [100, 200, 300, np.nan, 400, 150]
+    y = [100, 250, np.nan, 300, 350, 200]
+    z = [50.0, 60.0, 70.0, 80.0, 90.0, 65.0]
+
+    # Points should filter out NaN values automatically
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    surf.gridding(points, method="linear")
+
+    # Should work with remaining valid points
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_with_coarsen_edge_cases(simple_surface):
+    """Test coarsen parameter with edge cases."""
+    # Use simple_points which has many points
+    np.random.seed(42)
+    n_points = 50
+    x = np.random.uniform(50, 450, n_points)
+    y = np.random.uniform(50, 450, n_points)
+    z = 100 + 0.1 * x + 0.05 * y
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    # Test with coarsen factor - with enough points, this should work
+    surf = simple_surface.copy()
+    surf.gridding(points, method="linear", coarsen=2)
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_snap_surface_roundtrip(simple_surface, simple_points):
+    """Test gridding followed by snap_surface to verify consistency."""
+    # Grid points to create a surface
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="linear")
+
+    # Create new points from a subset of the original
+    test_points = simple_points.copy()
+    test_points._df = test_points._df.iloc[:10].copy()  # Take first 10 points
+
+    # Snap these points to the gridded surface
+    test_points.snap_surface(surf, activeonly=True)
+    snapped_z = test_points._df["Z_TVDSS"].values
+
+    # The snapped Z values should be close to interpolated surface values
+    # (within reasonable tolerance due to interpolation)
+    if len(snapped_z) > 0:
+        assert not np.all(np.isnan(snapped_z))
+
+
+def test_gridding_rbf_with_noise(simple_surface):
+    """Test RBF gridding with noisy data and smoothing."""
+    np.random.seed(42)
+    n_points = 50
+    x = np.random.uniform(100, 400, n_points)
+    y = np.random.uniform(100, 400, n_points)
+    # True function + significant noise
+    z = 100 + 0.1 * x + 0.05 * y + np.random.normal(0, 10, n_points)
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Use smoothing to handle noise
+    surf.gridding(
+        points,
+        method="radial_basis",
+        method_options={"smoothing": 1.0, "function": "thin_plate_spline"},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_merge_all_points_merged(simple_surface):
+    """Test when points are very close together (previously would merge)."""
+    x = [100, 110, 120, 130]
+    y = [100, 110, 120, 130]
+    z = [50.0, 60.0, 70.0, 80.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    surf = simple_surface.copy()
+    # Use nearest method which handles close points well
+    surf.gridding(points, method="nearest")
+
+    # Should produce a valid result
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_moving_average_zero_radius(simple_surface, simple_points):
+    """Test moving average with very small radius."""
+    surf = simple_surface.copy()
+
+    # Very small radius - should still work but may produce sparse results
+    surf.gridding(
+        simple_points,
+        method="moving_average",
+        method_options={"radius": 1.0, "min_points": 1},
+    )
+
+    # May have many undefined nodes but should not crash
+    assert True  # Just verify it doesn't crash
+
+
+def test_gridding_idw_zero_power(simple_surface, simple_points):
+    """Test IDW with power close to zero (uniform weighting)."""
+    surf = simple_surface.copy()
+
+    # Very small power approaches uniform weighting
+    surf.gridding(
+        simple_points,
+        method="inverse_distance",
+        method_options={"power": 0.1},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_idw_very_high_power(simple_surface, simple_points):
+    """Test IDW with very high power (nearest neighbor-like)."""
+    surf = simple_surface.copy()
+
+    # Very high power makes it behave like nearest neighbor
+    surf.gridding(
+        simple_points,
+        method="inverse_distance",
+        method_options={"power": 10.0},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_different_surface_sizes(simple_points):
+    """Test gridding on surfaces with different dimensions."""
+    dimensions = [(10, 10), (100, 100), (20, 50)]
+
+    for ncol, nrow in dimensions:
+        surf = xtgeo.RegularSurface(
+            ncol=ncol,
+            nrow=nrow,
+            xinc=10.0,
+            yinc=10.0,
+            xori=0.0,
+            yori=0.0,
+            values=np.zeros((ncol, nrow)),
+        )
+
+        surf.gridding(simple_points, method="linear")
+        assert not np.all(np.isnan(surf.values)), f"Failed for {ncol}x{nrow}"
+
+
+def test_gridding_different_increments():
+    """Test gridding with different xinc and yinc values."""
+    # Non-collinear points
+    x = [100, 200, 300, 400, 150]
+    y = [100, 250, 150, 350, 200]
+    z = [50.0, 60.0, 70.0, 80.0, 65.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    # Very different xinc and yinc (anisotropic grid)
+    surf = xtgeo.RegularSurface(
+        ncol=50,
+        nrow=50,
+        xinc=5.0,  # Fine in X
+        yinc=20.0,  # Coarse in Y
+        xori=0.0,
+        yori=0.0,
+        values=np.zeros((50, 50)),
+    )
+
+    surf.gridding(points, method="linear")
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_rotated_surface():
+    """Test gridding on a rotated surface."""
+    # Non-collinear points
+    x = [100, 200, 300, 400, 150]
+    y = [100, 250, 150, 350, 200]
+    z = [50.0, 60.0, 70.0, 80.0, 65.0]
+
+    points = xtgeo.Points(
+        values=np.column_stack([x, y, z]),
+        xname="X_UTME",
+        yname="Y_UTMN",
+        zname="Z_TVDSS",
+    )
+
+    # Rotated surface (30 degrees)
+    surf = xtgeo.RegularSurface(
+        ncol=50,
+        nrow=50,
+        xinc=10.0,
+        yinc=10.0,
+        xori=0.0,
+        yori=0.0,
+        rotation=30.0,
+        values=np.zeros((50, 50)),
+    )
+
+    surf.gridding(points, method="linear")
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_multiple_methods_same_data(simple_surface, simple_points):
+    """Test that different methods produce different but valid results."""
+    methods = ["linear", "nearest", "cubic"]
+    results = []
+
+    for method in methods:
+        surf = simple_surface.copy()
+        surf.gridding(simple_points, method=method)
+        results.append(surf.values.copy())
+
+        # Each method should produce valid results
+        assert not np.all(np.isnan(surf.values)), f"Failed for method={method}"
+
+    # Results from different methods should generally be different
+    # (at least nearest vs linear/cubic)
+    # This is a qualitative check
+    assert not np.array_equal(results[0], results[1]) or not np.array_equal(
+        results[1], results[2]
+    )
+
+
+def test_gridding_points_from_surface_roundtrip(simple_surface, simple_points):
+    """Test creating points from surface then gridding back."""
+    # First, grid points to surface
+    surf1 = simple_surface.copy()
+    surf1.gridding(simple_points, method="linear")
+
+    # Convert surface back to points
+    from xtgeo import points_from_surface
+
+    roundtrip_points = points_from_surface(surf1)
+
+    # Grid again
+    surf2 = simple_surface.copy()
+    surf2.gridding(roundtrip_points, method="linear")
+
+    # Results should be similar (surfaces should be close)
+    # Check that both have similar coverage
+    mask1 = (
+        surf1.values.mask if hasattr(surf1.values, "mask") else np.isnan(surf1.values)
+    )
+    mask2 = (
+        surf2.values.mask if hasattr(surf2.values, "mask") else np.isnan(surf2.values)
+    )
+
+    # Should have similar number of defined nodes
+    defined1 = np.sum(~mask1)
+    defined2 = np.sum(~mask2)
+    assert defined1 > 0 and defined2 > 0
+
+
+# ======================================================================================
+# Using pointset2 with result verified outside
+# ======================================================================================
+
+
+def test_gridding_pset2_simple(pointset2, surface_for_pointset2):
+    """Test simple basic gridding on pointset2 with external verification."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(pointset2, method="linear")
+
+    assert surf.values.mean() == pytest.approx(1691.65, abs=1e-2)
+
+    # check number of masked values
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 65729
+
+    surf.gridding(pointset2, method="cubic")
+
+    assert surf.values.mean() == pytest.approx(1688.02, abs=1e-2)
+
+    # check number of masked values
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 65729
+
+    surf.gridding(pointset2, method="nearest")
+
+    assert surf.values.mean() == pytest.approx(1709.92, abs=1e-2)
+
+    # check number of masked values, which shall be 0 with "nearest"
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 0
+
+
+def test_gridding_pset2_radial_basis(pointset2, surface_for_pointset2):
+    """Test radial basis function gridding on pointset2 with external verification."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(pointset2, method="radial_basis")
+
+    assert surf.values.mean() == pytest.approx(1712.44, abs=1e-2)
+
+    surf.gridding(
+        pointset2,
+        method="radial_basis",
+        method_options={"function": "linear", "smoothing": 2.0},
+    )
+
+    assert surf.values.mean() == pytest.approx(1711.40, abs=1e-2)
+
+
+def test_gridding_pset2_kriging(pointset2, surface_for_pointset2):
+    """Test kriging gridding on pointset2 with external verification."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(pointset2, method="kriging")
+
+    assert surf.values.mean() == pytest.approx(1699.79, abs=1e-2)
+
+    surf.gridding(
+        pointset2,
+        method="kriging",
+        method_options={
+            "variogram_model": "spherical",
+            "variogram_parameters": {
+                "range_value": (3000, 1200),
+                "angle": 30,
+                "nugget": 0.0,
+            },
+        },
+    )
+
+    assert surf.values.mean() == pytest.approx(1705.53, abs=1e-2)
+
+
+# ======================================================================================
+# Test: cubic method with extrapolation options
+# ======================================================================================
+
+
+def test_gridding_cubic_no_extrapolate(simple_surface, simple_points):
+    """Test cubic interpolation without extrapolation (default)."""
+    surf = simple_surface.copy()
+    surf.gridding(simple_points, method="cubic", method_options={"extrapolate": False})
+
+    # Without extrapolate, should have undefined nodes outside convex hull
+    assert not np.all(np.isnan(surf.values))
+    assert surf.values.mask.sum() > 0  # Some nodes should be masked
+
+
+def test_gridding_cubic_with_extrapolate_nearest(simple_surface, simple_points):
+    """Test cubic interpolation with nearest neighbor extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "nearest"},
+    )
+
+    # With nearest extrapolation, should have fewer or no undefined nodes
+    assert not np.all(np.isnan(surf.values))
+    # May still have some masked if points don't cover full surface
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked >= 0
+
+
+def test_gridding_cubic_with_extrapolate_linear(simple_surface, simple_points):
+    """Test cubic interpolation with linear extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "linear"},
+    )
+
+    # Linear extrapolation should fill remaining undefined areas
+    assert not np.all(np.isnan(surf.values))
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked >= 0
+
+
+def test_gridding_cubic_with_extrapolate_cubic(simple_surface, simple_points):
+    """Test cubic interpolation with cubic extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "cubic"},
+    )
+
+    # Cubic extrapolation should fill remaining undefined areas
+    assert not np.all(np.isnan(surf.values))
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked >= 0
+
+
+def test_gridding_cubic_with_extrapolate_rbf(simple_surface, simple_points):
+    """Test cubic interpolation with radial_basis extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "radial_basis"},
+    )
+
+    # RBF extrapolation should fill remaining undefined areas smoothly
+    assert not np.all(np.isnan(surf.values))
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked >= 0
+
+
+def test_gridding_cubic_extrapolate_default_method(simple_surface, simple_points):
+    """Test that default extrapolation method is 'nearest' when extrapolate=True."""
+    surf = simple_surface.copy()
+    # Only specify extrapolate=True, not extrapolation_method
+    surf.gridding(simple_points, method="cubic", method_options={"extrapolate": True})
+
+    # Should use default extrapolation method (nearest)
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_cubic_compare_extrapolation_methods(simple_surface, simple_points):
+    """Compare different extrapolation methods after cubic gridding."""
+    methods = ["nearest", "linear", "cubic", "radial_basis"]
+    results = {}
+
+    for extr_method in methods:
+        surf = simple_surface.copy()
+        surf.gridding(
+            simple_points,
+            method="cubic",
+            method_options={
+                "extrapolate": True,
+                "extrapolation_method": extr_method,
+            },
+        )
+        results[extr_method] = {
+            "mean": surf.values.mean(),
+            "std": surf.values.std(),
+            "n_masked": surf.values.mask.sum() if hasattr(surf.values, "mask") else 0,
+        }
+
+    # All methods should produce valid results
+    for method, stats in results.items():
+        assert not np.isnan(stats["mean"]), f"Failed for method={method}"
+        assert stats["n_masked"] >= 0, f"Invalid mask count for method={method}"
+
+
+# ======================================================================================
+# Test: linear method with extrapolation options
+# ======================================================================================
+
+
+def test_gridding_linear_with_extrapolate_nearest(simple_surface, simple_points):
+    """Test linear interpolation with nearest neighbor extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="linear",
+        method_options={"extrapolate": True, "extrapolation_method": "nearest"},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_linear_with_extrapolate_linear(simple_surface, simple_points):
+    """Test linear interpolation with linear extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="linear",
+        method_options={"extrapolate": True, "extrapolation_method": "linear"},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_linear_with_extrapolate_cubic(simple_surface, simple_points):
+    """Test linear interpolation with cubic extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="linear",
+        method_options={"extrapolate": True, "extrapolation_method": "cubic"},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_linear_with_extrapolate_rbf(simple_surface, simple_points):
+    """Test linear interpolation with RBF extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="linear",
+        method_options={"extrapolate": True, "extrapolation_method": "radial_basis"},
+    )
+
+    assert not np.all(np.isnan(surf.values))
+
+
+# ======================================================================================
+# Test: nearest method with extrapolation options
+# ======================================================================================
+
+
+def test_gridding_nearest_with_extrapolate(simple_surface, simple_points):
+    """Test nearest neighbor with extrapolation enabled."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points,
+        method="nearest",
+        method_options={"extrapolate": True, "extrapolation_method": "nearest"},
+    )
+
+    # Nearest neighbor typically fills all nodes anyway
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 0  # Nearest should fill everything
+
+
+def test_gridding_nearest_without_extrapolate(simple_surface, simple_points):
+    """Test nearest neighbor without extrapolation."""
+    surf = simple_surface.copy()
+    surf.gridding(
+        simple_points, method="nearest", method_options={"extrapolate": False}
+    )
+
+    # Even without extrapolate, nearest fills all nodes
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 0
+
+
+# ======================================================================================
+# Test: extrapolation with sparse points
+# ======================================================================================
+
+
+def test_gridding_cubic_sparse_with_extrapolate(simple_surface, sparse_points):
+    """Test cubic with sparse points and various extrapolation methods."""
+    extrapolation_methods = ["nearest", "linear", "cubic", "radial_basis"]
+
+    for extr_method in extrapolation_methods:
+        surf = simple_surface.copy()
+        surf.gridding(
+            sparse_points,
+            method="cubic",
+            method_options={
+                "extrapolate": True,
+                "extrapolation_method": extr_method,
+            },
+        )
+
+        # With sparse points and extrapolation, should fill most/all of surface
+        assert not np.all(np.isnan(surf.values)), f"Failed for method={extr_method}"
+
+
+def test_gridding_linear_sparse_with_extrapolate(simple_surface, sparse_points):
+    """Test linear with sparse points and various extrapolation methods."""
+    extrapolation_methods = ["nearest", "linear", "cubic", "radial_basis"]
+
+    for extr_method in extrapolation_methods:
+        surf = simple_surface.copy()
+        surf.gridding(
+            sparse_points,
+            method="linear",
+            method_options={
+                "extrapolate": True,
+                "extrapolation_method": extr_method,
+            },
+        )
+
+        # With sparse points and extrapolation, should fill most/all of surface
+        assert not np.all(np.isnan(surf.values)), f"Failed for method={extr_method}"
+
+
+# ======================================================================================
+# Test: extrapolation edge cases
+# ======================================================================================
+
+
+def test_gridding_extrapolate_invalid_method(simple_surface, simple_points):
+    """Test that invalid extrapolation method raises appropriate error."""
+    surf = simple_surface.copy()
+
+    # Invalid extrapolation_method should be caught by fill() method
+    with pytest.raises(Exception):  # Could be ValueError or other
+        surf.gridding(
+            simple_points,
+            method="cubic",
+            method_options={
+                "extrapolate": True,
+                "extrapolation_method": "invalid_method",
+            },
+        )
+
+
+def test_gridding_cubic_extrapolate_consistency(simple_surface, simple_points):
+    """Test that extrapolate=True fills more nodes than extrapolate=False."""
+    # Grid without extrapolation
+    surf_no_extr = simple_surface.copy()
+    surf_no_extr.gridding(
+        simple_points, method="cubic", method_options={"extrapolate": False}
+    )
+    n_masked_no_extr = (
+        surf_no_extr.values.mask.sum()
+        if hasattr(surf_no_extr.values, "mask")
+        else np.isnan(surf_no_extr.values).sum()
+    )
+
+    # Grid with extrapolation
+    surf_with_extr = simple_surface.copy()
+    surf_with_extr.gridding(
+        simple_points,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "nearest"},
+    )
+    n_masked_with_extr = (
+        surf_with_extr.values.mask.sum()
+        if hasattr(surf_with_extr.values, "mask")
+        else np.isnan(surf_with_extr.values).sum()
+    )
+
+    # With extrapolation should have equal or fewer masked nodes
+    assert n_masked_with_extr <= n_masked_no_extr
+
+
+def test_gridding_linear_extrapolate_consistency(simple_surface, simple_points):
+    """Test that extrapolate=True fills more nodes than extrapolate=False for linear."""
+    # Grid without extrapolation
+    surf_no_extr = simple_surface.copy()
+    surf_no_extr.gridding(
+        simple_points, method="linear", method_options={"extrapolate": False}
+    )
+    n_masked_no_extr = (
+        surf_no_extr.values.mask.sum()
+        if hasattr(surf_no_extr.values, "mask")
+        else np.isnan(surf_no_extr.values).sum()
+    )
+
+    # Grid with extrapolation
+    surf_with_extr = simple_surface.copy()
+    surf_with_extr.gridding(
+        simple_points,
+        method="linear",
+        method_options={"extrapolate": True, "extrapolation_method": "linear"},
+    )
+    n_masked_with_extr = (
+        surf_with_extr.values.mask.sum()
+        if hasattr(surf_with_extr.values, "mask")
+        else np.isnan(surf_with_extr.values).sum()
+    )
+
+    # With extrapolation should have equal or fewer masked nodes
+    assert n_masked_with_extr <= n_masked_no_extr
+
+
+# ======================================================================================
+# Test: extrapolation with pointset2 (real data)
+# ======================================================================================
+
+
+def test_gridding_pset2_cubic_no_extrapolate(pointset2_thinned, surface_for_pointset2):
+    """Test cubic on pointset2 without extrapolation."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(
+        pointset2_thinned, method="cubic", method_options={"extrapolate": False}
+    )
+
+    # Should have some masked nodes outside convex hull
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked > 0
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_pset2_cubic_with_extrapolate_nearest(
+    pointset2_thinned, surface_for_pointset2
+):
+    """Test cubic on pointset2 with nearest extrapolation."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(
+        pointset2_thinned,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "nearest"},
+    )
+
+    # With extrapolation, should have no masked nodes
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 0
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_pset2_cubic_with_extrapolate_linear(
+    pointset2_thinned, surface_for_pointset2
+):
+    """Test cubic on pointset2 with linear extrapolation."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(
+        pointset2_thinned,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "linear"},
+    )
+
+    # With extrapolation, should have no masked nodes
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 0
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_pset2_cubic_with_extrapolate_rbf(
+    pointset2_thinned, surface_for_pointset2
+):
+    """Test cubic on pointset2 with RBF extrapolation."""
+    surf = surface_for_pointset2.copy()
+    surf.gridding(
+        pointset2_thinned,
+        method="cubic",
+        method_options={"extrapolate": True, "extrapolation_method": "radial_basis"},
+    )
+
+    # With RBF extrapolation, should have no masked nodes
+    n_masked = surf.values.mask.sum() if hasattr(surf.values, "mask") else 0
+    assert n_masked == 0
+    assert not np.all(np.isnan(surf.values))
+
+
+def test_gridding_pset2_linear_extrapolate_comparison(
+    pointset2_thinned, surface_for_pointset2
+):
+    """Compare different extrapolation methods on pointset2 with linear gridding."""
+    results = {}
+
+    # Without extrapolation
+    surf = surface_for_pointset2.copy()
+    surf.gridding(
+        pointset2_thinned, method="linear", method_options={"extrapolate": False}
+    )
+    results["no_extrapolate"] = {
+        "mean": surf.values.mean(),
+        "n_masked": surf.values.mask.sum() if hasattr(surf.values, "mask") else 0,
+    }
+
+    # With different extrapolation methods
+    for extr_method in ["nearest", "linear", "cubic", "radial_basis"]:
+        surf = surface_for_pointset2.copy()
+        surf.gridding(
+            pointset2_thinned,
+            method="linear",
+            method_options={"extrapolate": True, "extrapolation_method": extr_method},
+        )
+        results[extr_method] = {
+            "mean": surf.values.mean(),
+            "n_masked": surf.values.mask.sum() if hasattr(surf.values, "mask") else 0,
+        }
+
+    # All extrapolated versions should have no masked values
+    assert results["no_extrapolate"]["n_masked"] > 0
+    for method in ["nearest", "linear", "cubic", "radial_basis"]:
+        assert results[method]["n_masked"] == 0, f"Failed for {method}"
+        assert not np.isnan(results[method]["mean"]), f"Mean is NaN for {method}"

--- a/tests/test_xyz/test_points_merge_close.py
+++ b/tests/test_xyz/test_points_merge_close.py
@@ -1,0 +1,436 @@
+import pathlib
+
+import numpy as np
+import pytest
+from pandas.testing import assert_frame_equal
+
+from xtgeo.xyz import Points
+
+PFILE = pathlib.Path("points/eme/1/emerald_10_random.poi")
+PFILE2 = pathlib.Path("polygons/reek/1/top_upper_reek_faultpoly.zmap")
+POINTSET2 = pathlib.Path("points/reek/1/pointset2.poi")
+POINTSET3 = pathlib.Path("points/battle/1/many.rmsattr")
+POINTSET4 = pathlib.Path("points/reek/1/poi_attr.rmsattr")
+POINTSET4_CSV = pathlib.Path("points/reek/1/poi_attr.csv")
+CSV1 = pathlib.Path("3dgrids/etc/gridqc1_rms_cellcenter.csv")
+
+
+@pytest.fixture
+def points_with_attrs():
+    plist = [
+        (234.0, 556.0, 11.0, 0, "some", 1.0),
+        (235.0, 559.0, 14.0, 1, "attr", 1.1),
+        (255.0, 577.0, 12.0, 1, "here", 1.2),
+    ]
+    attrs = {
+        "some_int": "int",
+        "sometxt": "str",
+        "somefloat": "float",
+    }
+    return plist, attrs
+
+
+def test_merge_close_points_no_merge():
+    """Test merge_close_points when no points are close enough."""
+    plist = [
+        (0.0, 0.0, 10.0),
+        (100.0, 100.0, 20.0),
+        (200.0, 200.0, 30.0),
+    ]
+    mypoints = Points(plist)
+    original_nrow = mypoints.nrow
+
+    # Merge with very small distance - should not merge anything
+    mypoints.merge_close_points(min_distance=1.0, method="average")
+
+    assert mypoints.nrow == original_nrow
+
+
+def test_merge_close_points_simple_average():
+    """Test merge_close_points with average method."""
+    plist = [
+        (0.0, 0.0, 10.0),
+        (1.0, 1.0, 20.0),  # Close to first point
+        (100.0, 100.0, 30.0),
+    ]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=2.0, method="average")
+
+    assert mypoints.nrow == 2  # Two points merged into one
+
+    # Check that merged point has average coordinates
+    dfr = mypoints.get_dataframe()
+    merged_point = dfr[dfr["Z_TVDSS"] == 15.0]  # Average of 10 and 20
+
+    assert len(merged_point) == 1
+    assert merged_point["X_UTME"].to_numpy()[0] == pytest.approx(0.5)
+    assert merged_point["Y_UTMN"].to_numpy()[0] == pytest.approx(0.5)
+
+
+def test_merge_close_points_median():
+    """Test merge_close_points with median method."""
+    plist = [
+        (0.0, 0.0, 10.0),
+        (1.0, 1.0, 20.0),
+        (1.5, 1.5, 30.0),  # All three close together
+    ]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=3.0, method="median")
+
+    assert mypoints.nrow == 1
+
+    # Check median values
+    dfr = mypoints.get_dataframe()
+    assert dfr["X_UTME"].to_numpy()[0] == pytest.approx(1.0)
+    assert dfr["Y_UTMN"].to_numpy()[0] == pytest.approx(1.0)
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(20.0)
+
+
+def test_merge_close_points_first():
+    """Test merge_close_points with first method."""
+    plist = [
+        (0.0, 0.0, 10.0),
+        (1.0, 1.0, 20.0),
+        (1.5, 1.5, 30.0),
+    ]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=3.0, method="first")
+
+    assert mypoints.nrow == 1
+
+    # Should keep first point
+    dfr = mypoints.get_dataframe()
+    assert dfr["X_UTME"].to_numpy()[0] == pytest.approx(0.0)
+    assert dfr["Y_UTMN"].to_numpy()[0] == pytest.approx(0.0)
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(10.0)
+
+
+def test_merge_close_points_min_z():
+    """Test merge_close_points with min_z method."""
+    plist = [
+        (0.0, 0.0, 30.0),
+        (1.0, 1.0, 10.0),  # Minimum z
+        (1.5, 1.5, 20.0),
+    ]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=3.0, method="min_z")
+
+    assert mypoints.nrow == 1
+
+    # Should keep point with minimum z
+    dfr = mypoints.get_dataframe()
+    assert dfr["X_UTME"].to_numpy()[0] == pytest.approx(1.0)
+    assert dfr["Y_UTMN"].to_numpy()[0] == pytest.approx(1.0)
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(10.0)
+
+
+def test_merge_close_points_max_z():
+    """Test merge_close_points with max_z method."""
+    plist = [
+        (0.0, 0.0, 10.0),
+        (1.0, 1.0, 30.0),  # Maximum z
+        (1.5, 1.5, 20.0),
+    ]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=3.0, method="max_z")
+
+    assert mypoints.nrow == 1
+
+    # Should keep point with maximum z
+    dfr = mypoints.get_dataframe()
+    assert dfr["X_UTME"].to_numpy()[0] == pytest.approx(1.0)
+    assert dfr["Y_UTMN"].to_numpy()[0] == pytest.approx(1.0)
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(30.0)
+
+
+def test_merge_close_points_multiple_clusters():
+    """Test merge_close_points with multiple separate clusters."""
+    plist = [
+        # Cluster 1
+        (0.0, 0.0, 10.0),
+        (1.0, 1.0, 20.0),
+        # Cluster 2
+        (100.0, 100.0, 30.0),
+        (101.0, 101.0, 40.0),
+        # Isolated point
+        (200.0, 200.0, 50.0),
+    ]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=2.0, method="average")
+
+    assert mypoints.nrow == 3  # Two clusters merged + one isolated
+
+    dfr = mypoints.get_dataframe()
+    z_values = sorted(dfr["Z_TVDSS"].to_numpy())
+
+    # Check merged z-values
+    assert z_values[0] == pytest.approx(15.0)  # (10+20)/2
+    assert z_values[1] == pytest.approx(35.0)  # (30+40)/2
+    assert z_values[2] == pytest.approx(50.0)  # Isolated point
+
+
+def test_merge_close_points_transitive_closure():
+    """Test that merge handles transitive closure correctly.
+
+    Points A-B close, B-C close, but A-C not close.
+    All three should still be merged into one cluster.
+    """
+    plist = [
+        (0.0, 0.0, 10.0),  # A
+        (1.0, 0.0, 20.0),  # B - close to A
+        (2.0, 0.0, 30.0),  # C - close to B, not to A
+    ]
+    mypoints = Points(plist)
+
+    # Distance 1.5 means A-B merge, B-C merge, but A-C distance is 2.0
+    mypoints.merge_close_points(min_distance=1.5, method="average")
+
+    # All three should be merged due to transitive closure
+    assert mypoints.nrow == 1
+
+    dfr = mypoints.get_dataframe()
+    assert dfr["X_UTME"].to_numpy()[0] == pytest.approx(1.0)  # (0+1+2)/3
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(20.0)  # (10+20+30)/3
+
+
+def test_merge_close_points_with_attributes():
+    """Test that attributes are removed during merge."""
+    plist = [
+        (0.0, 0.0, 10.0, "well1", 100),
+        (1.0, 1.0, 20.0, "well2", 200),  # Close to first
+        (100.0, 100.0, 30.0, "well3", 300),
+    ]
+    attrs = {"wellname": "str", "depth": "int"}
+    mypoints = Points(plist, attributes=attrs)
+
+    # Verify attributes exist before merge
+    dfr_before = mypoints.get_dataframe()
+    assert "wellname" in dfr_before.columns
+    assert "depth" in dfr_before.columns
+
+    mypoints.merge_close_points(min_distance=2.0, method="average")
+
+    assert mypoints.nrow == 2
+    dfr = mypoints.get_dataframe()
+
+    # Attributes should be removed - only X, Y, Z columns remain
+    assert "wellname" not in dfr.columns
+    assert "depth" not in dfr.columns
+    assert set(dfr.columns) == {"X_UTME", "Y_UTMN", "Z_TVDSS"}
+
+    # Verify merged coordinates are correct
+    merged = dfr[np.isclose(dfr["Z_TVDSS"], 15.0)]
+    assert len(merged) == 1
+    assert np.isclose(merged["X_UTME"].to_numpy()[0], 0.5)
+    assert np.isclose(merged["Y_UTMN"].to_numpy()[0], 0.5)
+
+
+def test_merge_close_points_empty():
+    """Test merge_close_points with empty points."""
+    mypoints = Points([])
+
+    # Should handle empty gracefully
+    mypoints.merge_close_points(min_distance=5.0, method="average")
+
+    assert mypoints.nrow == 0
+
+
+def test_merge_close_points_single_point():
+    """Test merge_close_points with single point."""
+    plist = [(0.0, 0.0, 10.0)]
+    mypoints = Points(plist)
+
+    mypoints.merge_close_points(min_distance=5.0, method="average")
+
+    assert mypoints.nrow == 1
+    dfr = mypoints.get_dataframe()
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(10.0)
+
+
+def test_merge_close_points_invalid_method():
+    """Test merge_close_points with invalid method."""
+    plist = [(0.0, 0.0, 10.0), (1.0, 1.0, 20.0)]
+    mypoints = Points(plist)
+
+    with pytest.raises(ValueError, match="Unknown merge method"):
+        mypoints.merge_close_points(min_distance=5.0, method="invalid_method")
+
+
+def test_merge_close_points_preserves_column_order():
+    """Test that X, Y, Z column order is preserved after merge (attributes removed)."""
+    plist = [
+        (0.0, 0.0, 10.0, "A", 1.5),
+        (1.0, 1.0, 20.0, "B", 2.5),
+    ]
+    attrs = {"name": "str", "value": "float"}
+    mypoints = Points(plist, attributes=attrs)
+
+    # Get the coordinate column names before merge
+    coord_columns = [mypoints.xname, mypoints.yname, mypoints.zname]
+
+    mypoints.merge_close_points(min_distance=2.0, method="average")
+
+    # After merge, should have only X, Y, Z columns in same order
+    assert list(mypoints.get_dataframe().columns) == coord_columns
+
+
+def test_merge_close_points_2d_distance_only():
+    """Test that merge uses only X-Y distance, not Z."""
+    plist = [
+        (0.0, 0.0, 10.0),
+        (0.0, 0.0, 1000.0),  # Same X-Y, very different Z
+    ]
+    mypoints = Points(plist)
+
+    # These should merge despite large Z difference
+    mypoints.merge_close_points(min_distance=1.0, method="average")
+
+    assert mypoints.nrow == 1
+    dfr = mypoints.get_dataframe()
+    assert dfr["Z_TVDSS"].to_numpy()[0] == pytest.approx(505.0)  # (10+1000)/2
+
+
+def test_merge_close_points_many_points():
+    """Test merge_close_points with larger dataset."""
+    np.random.seed(42)
+
+    # Create points in 3 clusters
+    cluster1 = [
+        (x, y, z)
+        for x, y, z in zip(
+            np.random.uniform(0, 5, 20),
+            np.random.uniform(0, 5, 20),
+            np.random.uniform(100, 110, 20),
+        )
+    ]
+    cluster2 = [
+        (x, y, z)
+        for x, y, z in zip(
+            np.random.uniform(50, 55, 20),
+            np.random.uniform(50, 55, 20),
+            np.random.uniform(200, 210, 20),
+        )
+    ]
+    cluster3 = [
+        (x, y, z)
+        for x, y, z in zip(
+            np.random.uniform(100, 105, 20),
+            np.random.uniform(100, 105, 20),
+            np.random.uniform(300, 310, 20),
+        )
+    ]
+
+    plist = cluster1 + cluster2 + cluster3
+    mypoints = Points(plist)
+
+    # Each cluster should merge into one point
+    mypoints.merge_close_points(min_distance=10.0, method="average")
+
+    # Should have approximately 3 points (one per cluster)
+    assert 1 <= mypoints.nrow <= 10  # Allow some variation due to randomness
+
+
+@pytest.mark.bigtest
+def test_merge_close_points_performance_1m():
+    """Test performance with 1 million points."""
+    import time
+
+    n_points = 1_000_000
+    print(f"\nGenerating {n_points:,} random points...")
+
+    # Generate 1 million random points spread across a 10,000 x 10,000 area
+    np.random.seed(42)
+    x = np.random.uniform(0, 10000, n_points)
+    y = np.random.uniform(0, 10000, n_points)
+    z = np.random.uniform(0, 100, n_points)
+
+    plist = list(zip(x, y, z))
+
+    print("Creating Points object...")
+    start = time.time()
+    mypoints = Points(plist)
+    create_time = time.time() - start
+    print(f"  Created in {create_time:.2f} seconds")
+
+    print(f"Initial points: {mypoints.nrow:,}")
+
+    # Merge points closer than 5 units using average method
+    min_distance = 5.0
+    print(f"\nMerging points closer than {min_distance} units (method='average')...")
+    start = time.time()
+    mypoints.merge_close_points(min_distance=min_distance, method="average")
+    merge_time = time.time() - start
+
+    print(f"  Merged in {merge_time:.2f} seconds")
+    print(f"  Final points: {mypoints.nrow:,}")
+    print(f"  Points merged: {n_points - mypoints.nrow:,}")
+    print(f"  Reduction: {100 * (n_points - mypoints.nrow) / n_points:.1f}%")
+    print(f"  Processing rate: {n_points / merge_time:,.0f} points/second")
+
+    # Verify we have fewer points than we started with
+
+    assert mypoints.nrow < n_points
+    assert mypoints.nrow > 0
+
+
+def test_merge_close_points_order_independent_average():
+    """Test that point order doesn't affect result when method='average'."""
+    # Create a set of points with known clusters
+    plist1 = [
+        (0.0, 0.0, 10.0),
+        (1.0, 1.0, 20.0),  # Close to first
+        (100.0, 100.0, 30.0),
+        (101.0, 101.0, 40.0),  # Close to third
+    ]
+
+    # Same points but in different order
+    plist2 = [
+        (101.0, 101.0, 40.0),  # Was fourth
+        (0.0, 0.0, 10.0),  # Was first
+        (100.0, 100.0, 30.0),  # Was third
+        (1.0, 1.0, 20.0),  # Was second
+    ]
+
+    # Create Points objects
+    points1 = Points(plist1)
+    points2 = Points(plist2)
+
+    # Merge with same parameters
+    min_distance = 2.0
+    points1.merge_close_points(min_distance=min_distance, method="average")
+    points2.merge_close_points(min_distance=min_distance, method="average")
+
+    # Both should have same number of points
+    assert points1.nrow == points2.nrow
+    assert points1.nrow == 2  # Two clusters
+
+    # Get dataframes sorted by X coordinate for comparison
+    df1 = points1.get_dataframe().sort_values("X_UTME").reset_index(drop=True)
+    df2 = points2.get_dataframe().sort_values("X_UTME").reset_index(drop=True)
+
+    # The merged points should be identical (within numerical precision)
+    # First cluster average: (0+1)/2=0.5, (0+1)/2=0.5, (10+20)/2=15.0
+    # Second cluster average: (100+101)/2=100.5, (100+101)/2=100.5, (30+40)/2=35.0
+    assert np.isclose(df1["X_UTME"].to_numpy()[0], 0.5)
+
+    assert np.isclose(df2["X_UTME"].to_numpy()[0], 0.5)
+    assert np.isclose(df1["Y_UTMN"].to_numpy()[0], 0.5)
+    assert np.isclose(df2["Y_UTMN"].to_numpy()[0], 0.5)
+    assert np.isclose(df1["Z_TVDSS"].to_numpy()[0], 15.0)
+    assert np.isclose(df2["Z_TVDSS"].to_numpy()[0], 15.0)
+
+    assert np.isclose(df1["X_UTME"].to_numpy()[1], 100.5)
+    assert np.isclose(df2["X_UTME"].to_numpy()[1], 100.5)
+    assert np.isclose(df1["Y_UTMN"].to_numpy()[1], 100.5)
+    assert np.isclose(df2["Y_UTMN"].to_numpy()[1], 100.5)
+    assert np.isclose(df1["Z_TVDSS"].to_numpy()[1], 35.0)
+    assert np.isclose(df2["Z_TVDSS"].to_numpy()[1], 35.0)
+
+    # Verify the dataframes are equal
+    assert_frame_equal(df1, df2)


### PR DESCRIPTION
This PR adds comprehensive gridding functionality to xtgeo, including multiple interpolation methods, point merging capabilities, and improved surface filling options. The changes support various use cases from sparse to dense point datasets.

Closes #1416 

Key changes:

- Implemented point merging functionality to handle close/duplicate points
- Added multiple gridding methods: inverse distance weighting (IDW), radial basis functions (RBF), moving average, and kriging
- Extended surface fill method with additional interpolation options
- Added gstools dependency for kriging support
- Extend input; not just Points, but also Polygons and existing RegularSurface (would be tempting to add a 3D grid property layer also, but can be a later PR)

Consider in review:
- Should `gstools` be added as an explicit dependency? I think it also caan be valuable for kriging properties in 3D grids in addition to surfaces
- Is the documentation sufficient?