### PR TITLE
BLD: Bump fmt version

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
   FetchContent_Declare(
     fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG 11.2.0)
+    GIT_TAG 12.1.0)
   set(FMT_MASTER_PROJECT OFF)
   set(BUILD_SHARED_LIBS OFF)
   FetchContent_MakeAvailable(fmt)


### PR DESCRIPTION
llvm/clang 21+ no longer transitively included malloc/free. This broke on the latest macOS versions with newer llvm installations.

Resolves #issue

Briefly describe changes here, e.g. "Added a precise description about the
changes made to the code, and what the PR is solving."

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
