### PR TITLE
TST: Refactor fork test

### DIFF
--- a/tests/test_surface/test_forks.py
+++ b/tests/test_surface/test_forks.py
@@ -1,31 +1,33 @@
 import logging
 import subprocess
+import sys
+
+import pytest
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-def test_surface_forks():
+@pytest.mark.skipif(sys.platform == "darwin", reason="Multiprocessing issues on macOS")
+def test_surface_forks() -> None:
     """Testing when surfaces are read by multiple forks"""
 
     process = subprocess.Popen(
-        ["python", "multiprocess_surfs.py"],
+        [sys.executable, "multiprocess_surfs.py"],
         cwd="examples",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    try:
-        stdout, stderr = process.communicate(timeout=60)  # timeout to prevent hanging
-        ret_code = process.returncode
-    except subprocess.TimeoutExpired:
-        process.kill()
-        stdout, stderr = process.communicate()
-        ret_code = -1  # Use a custom return code for timeouts
+    stdout, stderr = process.communicate(timeout=60)
+    ret_code = process.returncode
 
-        # Log more information for debugging
+    if ret_code != 0:
         logger.info("Return code: %d", ret_code)
         logger.info("STDOUT: %s", stdout.decode())
         logger.info("STDERR: %s", stderr.decode())
 
-    assert ret_code == 0, f"Subprocess failed with exit code {ret_code}\n"
-    f"STDOUT: {stdout.decode()}\nSTDERR: {stderr.decode()}"
+    assert ret_code == 0, (
+        f"Subprocess failed with exit code {ret_code}\n"
+        f"STDOUT: {stdout.decode()}\n"
+        f"STDERR: {stderr.decode()}"
+    )


### PR DESCRIPTION
Resolves #1449

This may not _fully_ solve the problem. The root cause is that macOS `fork()` behaves a bit differently than Posix `fork()`: https://github.com/python/cpython/issues/77906 but this should have been fixed long ago, so it's odd that it re-appears now.

It can be forced if needed, for macOS only

```python
import multiprocessing
multiprocessing.set_start_method("spawn", force=True)
```

But the docs say that this is the default for macOS

> Changed in version 3.8: On macOS, the spawn start method is now the default. The fork start method should be considered unsafe as it can lead to crashes of the subprocess as macOS system libraries may start threads. See [bpo-33725](https://bugs.python.org/issue?@action=redirect&bpo=33725).

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
