### PR TITLE
TST: Revert to relative path for test file

### DIFF
--- a/examples/multiprocess_surfs.py
+++ b/examples/multiprocess_surfs.py
@@ -12,10 +12,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-TESTFILE = (
-    Path(__file__).parent.parent.parent
-    / "xtgeo-testdata/surfaces/reek/1/basereek_rota.gri"
-)
+TESTFILE = Path("../../xtgeo-testdata/surfaces/reek/1/basereek_rota.gri")
 NTHREAD = 20
 
 


### PR DESCRIPTION
The location of `__file__` does not work in Komodo testing due to test files being copied to a different directory.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
