### PR TITLE
CI: dismiss coverage reports from logging, TYPE_CHECKING and tests/*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,3 +184,18 @@ select = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+
+[tool.coverage.run]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_also = [
+    # Exclude TYPE_CHECKING blocks
+    "if TYPE_CHECKING:",
+    # Exclude logging statements
+    "logger\\.debug\\(",
+    "logger\\.info\\(",
+    "logger\\.warning\\(",
+    "logger\\.error\\(",
+    "logger\\.critical\\(",
+]

--- a/src/xtgeo/grid3d/_ecl_inte_head.py
+++ b/src/xtgeo/grid3d/_ecl_inte_head.py
@@ -9,7 +9,7 @@ from xtgeo.common.log import null_logger
 
 from ._ecl_output_file import Phases, Simulator, TypeOfGrid, UnitSystem
 
-_logger = null_logger(__name__)
+logger = null_logger(__name__)
 
 
 class InteHead:
@@ -138,7 +138,7 @@ class InteHead:
             return Simulator(s_code)
         except ValueError:
             # changed from a UserWarning to a logging message
-            _logger.warning("Unknown simulator code %s", s_code)
+            logger.warning("Unknown simulator code %s", s_code)
             return s_code
 
     @property


### PR DESCRIPTION
Resolves #1467 

Increased focus on test coverage, should dismiss logging, TYPE_CHECKING code.

## Checklist

- [x] Tests added (if not, comment why)  No tests for this, not changes in python code
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
