### PR TITLE
MAINT: establish WellData/WellLog frozen classes dedicated to i/o

### DIFF
--- a/src/xtgeo/io/__init__.py
+++ b/src/xtgeo/io/__init__.py
@@ -1,1 +1,1 @@
-"""XTGeo io module"""
+"""XTGeo io package"""

--- a/src/xtgeo/io/_welldata/__init__.py
+++ b/src/xtgeo/io/_welldata/__init__.py
@@ -1,0 +1,1 @@
+"""Well data I/O - read/write functions for various file formats."""

--- a/src/xtgeo/io/_welldata/_well_io.py
+++ b/src/xtgeo/io/_welldata/_well_io.py
@@ -1,0 +1,190 @@
+"""I/O of well data"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+from xtgeo.common.log import null_logger
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+logger = null_logger(__name__)
+
+
+@dataclass(frozen=True)
+class WellLog:
+    """Immutable container for a single well log.
+
+    A well log represents a continuous or discrete measurement along a wellbore.
+
+    Attributes:
+        name: The name of the log (e.g., "GR", "PHIT", "FACIES")
+        values: NumPy array containing the log values. Undefined/missing values
+            should be represented as np.nan for continuous logs or a specific
+            undefined integer value for discrete logs.
+        is_discrete: If True, this is a discrete/categorical log; if False,
+            it's a continuous log.
+        code_names: For discrete logs: mapping from codes (integers) to names
+            Example: {0: "SHALE", 1: "SAND", 2: "LIMESTONE"}
+            For continuous logs: optional metadata tuple (e.g., ("CONT", "UNK", "lin"))
+
+    """
+
+    name: str
+    values: npt.NDArray[np.float64]
+    is_discrete: bool = False
+    code_names: dict[int, str] | tuple | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the well log data."""
+        if (
+            self.is_discrete
+            and self.code_names is not None
+            and isinstance(self.code_names, dict)
+            and not all(isinstance(k, (int, np.integer)) for k in self.code_names)
+        ):
+            raise ValueError("code_names keys must be integers for discrete logs")
+
+
+@dataclass(frozen=True)
+class WellData:
+    """Immutable internal data container for well data read/write.
+
+    This dataclass stores all the essential information about a well, including
+    its position, trajectory (survey), and associated well logs. The design is
+    immutable to ensure data integrity during coming I/O operations.
+
+    Attributes:
+        name: Well name (e.g., "31/2-E-4 AH")
+        xpos: X-coordinate of the well header position
+        ypos: Y-coordinate of the well header position
+        zpos: Z-coordinate of the well header position (typically RKB, if present)
+        survey_x: NumPy array of X-coordinates along the wellbore trajectory
+            (float64)
+        survey_y: NumPy array of Y-coordinates along the wellbore trajectory
+            (float64)
+        survey_z: NumPy array of Z-coordinates (typically TVD/TVDSS) along
+            trajectory (float64)
+        logs: Tuple of WellLog objects containing well log data. Use tuple for
+            immutability. Empty tuple if no logs. Log values are stored as float64
+            by default (TODO: consider change to float32 for less memory use.)
+
+    Notes:
+        - All NumPy arrays should have the same length (number of survey points)
+        - Undefined values in continuous logs should be np.nan
+        - Logs are stored as a tuple to maintain immutability
+    """
+
+    name: str
+    xpos: float
+    ypos: float
+    zpos: float
+    survey_x: npt.NDArray[np.float64]
+    survey_y: npt.NDArray[np.float64]
+    survey_z: npt.NDArray[np.float64]
+    logs: tuple[WellLog, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate well data consistency."""
+
+        n_survey = len(self.survey_x)
+        if len(self.survey_y) != n_survey or len(self.survey_z) != n_survey:
+            raise ValueError(
+                f"Survey arrays must have the same length. Got X:{len(self.survey_x)}, "
+                f"Y:{len(self.survey_y)}, Z:{len(self.survey_z)}"
+            )
+
+        for log in self.logs:
+            if len(log.values) != n_survey:
+                raise ValueError(
+                    f"Log '{log.name}' has {len(log.values)} values, but survey "
+                    f"has {n_survey} points"
+                )
+
+    @property
+    def n_records(self) -> int:
+        """Return the number of survey records/points."""
+        return len(self.survey_x)
+
+    @property
+    def log_names(self) -> tuple[str, ...]:
+        """Return tuple of all log names."""
+        return tuple(log.name for log in self.logs)
+
+    def get_log(self, name: str) -> WellLog | None:
+        """Get a well log by name.
+
+        Args:
+            name: Name of the log to retrieve
+
+        Returns:
+            WellLog object if found, None otherwise
+        """
+        for log in self.logs:
+            if log.name == name:
+                return log
+        return None
+
+    def get_continuous_logs(self) -> tuple[WellLog, ...]:
+        """Return tuple of all continuous logs."""
+        return tuple(log for log in self.logs if not log.is_discrete)
+
+    def get_discrete_logs(self) -> tuple[WellLog, ...]:
+        """Return tuple of all discrete logs."""
+        return tuple(log for log in self.logs if log.is_discrete)
+
+    def to_dataframe(
+        self,
+        lognames: list[str] | None = None,
+        xname: str = "X_UTME",
+        yname: str = "Y_UTMN",
+        zname: str = "Z_TVDSS",
+    ) -> "pd.DataFrame":
+        """Return survey and selected logs as a pandas DataFrame.
+
+        Args:
+            lognames: List of log names to include. If None, all logs are included.
+            xname: Column name for X coordinates (default: "X_UTME")
+            yname: Column name for Y coordinates (default: "Y_UTMN")
+            zname: Column name for Z coordinates (default: "Z_TVDSS")
+
+        Returns:
+            pandas.DataFrame with survey coordinates and selected logs
+
+        Raises:
+            ValueError: If a requested log name is not found
+
+        Example:
+            >>> df = well.to_dataframe(lognames=["GR", "PHIT"])
+            >>> df = well.to_dataframe()  # All logs
+        """
+        import pandas as pd
+
+        data = {
+            xname: self.survey_x,
+            yname: self.survey_y,
+            zname: self.survey_z,
+        }
+
+        if lognames is None:
+            # Include all logs
+            for log in self.logs:
+                data[log.name] = log.values
+        else:
+            # Include only specified logs
+            for logname in lognames:
+                found_log = self.get_log(logname)
+                if found_log is None:
+                    available = ", ".join(self.log_names)
+                    raise ValueError(
+                        f"Log '{logname}' not found. Available logs: {available}"
+                    )
+                data[logname] = found_log.values
+
+        return pd.DataFrame(data)

--- a/tests/test_io/test_welldata/test_welldata.py
+++ b/tests/test_io/test_welldata/test_welldata.py
@@ -1,0 +1,244 @@
+"""Tests for WellData and WellLog dataclasses (i/o in separate tests)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xtgeo.io._welldata._well_io import WellData, WellLog
+
+
+def test_welllog_continuous_creation():
+    """Test creating a continuous well log."""
+    values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    log = WellLog(name="GR", values=values, is_discrete=False)
+
+    assert log.name == "GR"
+    assert len(log.values) == 5
+    assert not log.is_discrete
+    assert log.code_names is None
+    np.testing.assert_array_equal(log.values, values)
+
+
+def test_welllog_discrete_creation():
+    """Test creating a discrete well log with code names."""
+    values = np.array([1.0, 2.0, 1.0, 3.0, 2.0])
+    code_names = {1: "SHALE", 2: "SAND", 3: "LIMESTONE"}
+    log = WellLog(name="FACIES", values=values, is_discrete=True, code_names=code_names)
+
+    assert log.name == "FACIES"
+    assert log.is_discrete
+    assert log.code_names == code_names
+    np.testing.assert_array_equal(log.values, values)
+
+
+def test_welllog_with_nan_values():
+    """Test well log with undefined (NaN) values."""
+    values = np.array([1.0, np.nan, 3.0, np.nan, 5.0])
+    log = WellLog(name="PHIT", values=values)
+
+    assert log.name == "PHIT"
+    assert np.isnan(log.values[1])
+    assert np.isnan(log.values[3])
+    assert log.values[0] == 1.0
+
+
+def test_welllog_code_names_validation():
+    """Test that code_names validation works."""
+    values = np.array([1.0, 2.0, 3.0])
+
+    # This should raise an error - code names with string keys
+    with pytest.raises(ValueError, match="code_names keys must be integers"):
+        WellLog(
+            name="FACIES",
+            values=values,
+            is_discrete=True,
+            code_names={"1": "SHALE", "2": "SAND"},  # String keys - should fail
+        )
+
+
+def test_welllog_immutability():
+    """Test that WellLog is immutable."""
+    log = WellLog(name="GR", values=np.array([1.0, 2.0, 3.0]))
+
+    with pytest.raises(Exception):  # FrozenInstanceError or similar
+        log.name = "NEW_NAME"
+
+
+def test_welldata_creation():
+    """Test creating WellData with survey and logs."""
+    n = 5
+    survey_x = np.linspace(0, 100, n)
+    survey_y = np.linspace(0, 200, n)
+    survey_z = np.linspace(-50, -150, n)
+
+    gr_log = WellLog(name="GR", values=np.random.rand(n))
+    phit_log = WellLog(name="PHIT", values=np.random.rand(n))
+
+    well = WellData(
+        name="TestWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=25.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log, phit_log),
+    )
+
+    assert well.name == "TestWell"
+    assert well.xpos == 100.0
+    assert well.ypos == 200.0
+    assert well.zpos == 25.0
+    assert well.n_records == n
+    assert len(well.logs) == 2
+    assert well.log_names == ("GR", "PHIT")
+
+
+def test_welldata_validation_survey_length_mismatch():
+    """Test that WellData validates survey array lengths."""
+    with pytest.raises(ValueError, match="Survey arrays must have the same length"):
+        WellData(
+            name="TestWell",
+            xpos=0.0,
+            ypos=0.0,
+            zpos=0.0,
+            survey_x=np.array([1.0, 2.0, 3.0]),
+            survey_y=np.array([1.0, 2.0]),  # Wrong length
+            survey_z=np.array([1.0, 2.0, 3.0]),
+        )
+
+
+def test_welldata_validation_log_length_mismatch():
+    """Test that WellData validates log lengths match survey."""
+    n = 5
+    survey_x = np.linspace(0, 100, n)
+    survey_y = np.linspace(0, 200, n)
+    survey_z = np.linspace(-50, -150, n)
+
+    # Create log with wrong length
+    wrong_log = WellLog(name="GR", values=np.array([1.0, 2.0, 3.0]))
+
+    with pytest.raises(ValueError, match="Log 'GR' has 3 values, but survey has 5"):
+        WellData(
+            name="TestWell",
+            xpos=0.0,
+            ypos=0.0,
+            zpos=0.0,
+            survey_x=survey_x,
+            survey_y=survey_y,
+            survey_z=survey_z,
+            logs=(wrong_log,),
+        )
+
+
+def test_welldata_get_log():
+    """Test getting a log by name."""
+    n = 5
+    survey_x = np.linspace(0, 100, n)
+    survey_y = np.linspace(0, 200, n)
+    survey_z = np.linspace(-50, -150, n)
+
+    gr_log = WellLog(name="GR", values=np.random.rand(n))
+    phit_log = WellLog(name="PHIT", values=np.random.rand(n))
+
+    well = WellData(
+        name="TestWell",
+        xpos=0.0,
+        ypos=0.0,
+        zpos=0.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log, phit_log),
+    )
+
+    # Get existing log
+    retrieved_log = well.get_log("GR")
+    assert retrieved_log is not None
+    assert retrieved_log.name == "GR"
+
+    # Get non-existing log
+    missing_log = well.get_log("NONEXISTENT")
+    assert missing_log is None
+
+
+def test_welldata_get_continuous_and_discrete_logs():
+    """Test filtering logs by type."""
+    n = 5
+    survey_x = np.linspace(0, 100, n)
+    survey_y = np.linspace(0, 200, n)
+    survey_z = np.linspace(-50, -150, n)
+
+    gr_log = WellLog(name="GR", values=np.random.rand(n), is_discrete=False)
+    phit_log = WellLog(name="PHIT", values=np.random.rand(n), is_discrete=False)
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 1.0, 3.0, 2.0]),
+        is_discrete=True,
+        code_names={1: "SHALE", 2: "SAND", 3: "LIMESTONE"},
+    )
+
+    well = WellData(
+        name="TestWell",
+        xpos=0.0,
+        ypos=0.0,
+        zpos=0.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log, phit_log, facies_log),
+    )
+
+    continuous = well.get_continuous_logs()
+    assert len(continuous) == 2
+    assert all(log.name in ["GR", "PHIT"] for log in continuous)
+
+    discrete = well.get_discrete_logs()
+    assert len(discrete) == 1
+    assert discrete[0].name == "FACIES"
+
+
+def test_welldata_empty_logs():
+    """Test WellData with no logs."""
+    n = 5
+    survey_x = np.linspace(0, 100, n)
+    survey_y = np.linspace(0, 200, n)
+    survey_z = np.linspace(-50, -150, n)
+
+    well = WellData(
+        name="TestWell",
+        xpos=0.0,
+        ypos=0.0,
+        zpos=0.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(),  # Empty tuple
+    )
+
+    assert well.n_records == n
+    assert len(well.logs) == 0
+    assert well.log_names == ()
+    assert well.get_continuous_logs() == ()
+    assert well.get_discrete_logs() == ()
+
+
+def test_welldata_immutability():
+    """Test that WellData is immutable."""
+    well = WellData(
+        name="TestWell",
+        xpos=0.0,
+        ypos=0.0,
+        zpos=0.0,
+        survey_x=np.array([1.0, 2.0, 3.0]),
+        survey_y=np.array([1.0, 2.0, 3.0]),
+        survey_z=np.array([1.0, 2.0, 3.0]),
+    )
+
+    # Try to modify - should fail
+    with pytest.raises(Exception):  # FrozenInstanceError or similar
+        well.name = "NewName"
+
+    with pytest.raises(Exception):
+        well.xpos = 999.0

--- a/tests/test_io/test_welldata/test_welldata_dataframe.py
+++ b/tests/test_io/test_welldata/test_welldata_dataframe.py
@@ -1,0 +1,269 @@
+"""Tests for WellData.to_dataframe() method."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from xtgeo.io._welldata._well_io import WellData, WellLog
+
+
+def test_welldata_to_dataframe_all_logs():
+    """Test converting WellData to DataFrame with all logs."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    gr_log = WellLog(name="GR", values=np.array([50.0, 60.0, 70.0]), is_discrete=False)
+    phit_log = WellLog(
+        name="PHIT", values=np.array([0.25, 0.30, 0.28]), is_discrete=False
+    )
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log, phit_log),
+    )
+
+    df = well.to_dataframe()
+
+    # Check DataFrame shape
+    assert len(df) == 3
+    assert len(df.columns) == 5  # X, Y, Z + 2 logs
+
+    # Check column names
+    assert "X_UTME" in df.columns
+    assert "Y_UTMN" in df.columns
+    assert "Z_TVDSS" in df.columns
+    assert "GR" in df.columns
+    assert "PHIT" in df.columns
+
+    # Check values
+    np.testing.assert_array_equal(df["X_UTME"].values, survey_x)
+    np.testing.assert_array_equal(df["Y_UTMN"].values, survey_y)
+    np.testing.assert_array_equal(df["Z_TVDSS"].values, survey_z)
+    np.testing.assert_array_equal(df["GR"].values, gr_log.values)
+    np.testing.assert_array_equal(df["PHIT"].values, phit_log.values)
+
+
+def test_welldata_to_dataframe_subset_logs():
+    """Test converting WellData to DataFrame with subset of logs."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    gr_log = WellLog(name="GR", values=np.array([50.0, 60.0, 70.0]), is_discrete=False)
+    phit_log = WellLog(
+        name="PHIT", values=np.array([0.25, 0.30, 0.28]), is_discrete=False
+    )
+    perm_log = WellLog(
+        name="PERM", values=np.array([150.0, 200.0, 175.0]), is_discrete=False
+    )
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log, phit_log, perm_log),
+    )
+
+    # Request only specific logs
+    df = well.to_dataframe(lognames=["GR", "PERM"])
+
+    # Check DataFrame shape
+    assert len(df) == 3
+    assert len(df.columns) == 5  # X, Y, Z + 2 selected logs
+
+    # Check column names
+    assert "X_UTME" in df.columns
+    assert "Y_UTMN" in df.columns
+    assert "Z_TVDSS" in df.columns
+    assert "GR" in df.columns
+    assert "PERM" in df.columns
+    assert "PHIT" not in df.columns  # Should not be included
+
+    # Check values
+    np.testing.assert_array_equal(df["GR"].values, gr_log.values)
+    np.testing.assert_array_equal(df["PERM"].values, perm_log.values)
+
+
+def test_welldata_to_dataframe_custom_column_names():
+    """Test converting WellData to DataFrame with custom column names."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    gr_log = WellLog(name="GR", values=np.array([50.0, 60.0, 70.0]), is_discrete=False)
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log,),
+    )
+
+    df = well.to_dataframe(xname="EASTING", yname="NORTHING", zname="DEPTH")
+
+    # Check custom column names
+    assert "EASTING" in df.columns
+    assert "NORTHING" in df.columns
+    assert "DEPTH" in df.columns
+    assert "X_UTME" not in df.columns
+    assert "Y_UTMN" not in df.columns
+    assert "Z_TVDSS" not in df.columns
+
+    # Check values
+    np.testing.assert_array_equal(df["EASTING"].values, survey_x)
+    np.testing.assert_array_equal(df["NORTHING"].values, survey_y)
+    np.testing.assert_array_equal(df["DEPTH"].values, survey_z)
+
+
+def test_welldata_to_dataframe_no_logs():
+    """Test converting WellData to DataFrame with no logs."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(),
+    )
+
+    df = well.to_dataframe()
+
+    # Check DataFrame shape - only survey columns
+    assert len(df) == 3
+    assert len(df.columns) == 3  # Only X, Y, Z
+
+    # Check column names
+    assert "X_UTME" in df.columns
+    assert "Y_UTMN" in df.columns
+    assert "Z_TVDSS" in df.columns
+
+
+def test_welldata_to_dataframe_invalid_logname():
+    """Test that requesting non-existent log raises ValueError."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    gr_log = WellLog(name="GR", values=np.array([50.0, 60.0, 70.0]), is_discrete=False)
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log,),
+    )
+
+    with pytest.raises(ValueError, match="Log 'NONEXISTENT' not found"):
+        well.to_dataframe(lognames=["GR", "NONEXISTENT"])
+
+
+def test_welldata_to_dataframe_with_nan_values():
+    """Test converting WellData to DataFrame with NaN values in logs."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    gr_log = WellLog(
+        name="GR", values=np.array([50.0, np.nan, 70.0]), is_discrete=False
+    )
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log,),
+    )
+
+    df = well.to_dataframe()
+
+    # Check NaN values are preserved
+    assert df["GR"].iloc[0] == pytest.approx(50.0)
+    assert pd.isna(df["GR"].iloc[1])
+    assert df["GR"].iloc[2] == pytest.approx(70.0)
+
+
+def test_welldata_to_dataframe_discrete_logs():
+    """Test converting WellData to DataFrame with discrete logs."""
+    survey_x = np.array([100.0, 101.0, 102.0, 103.0])
+    survey_y = np.array([200.0, 201.0, 202.0, 203.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0, 1003.0])
+
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([0.0, 1.0, 1.0, 2.0]),
+        is_discrete=True,
+        code_names={0: "Shale", 1: "Sand", 2: "Limestone"},
+    )
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(facies_log,),
+    )
+
+    df = well.to_dataframe()
+
+    # Check discrete log values
+    assert len(df) == 4
+    np.testing.assert_array_equal(df["FACIES"].values, [0.0, 1.0, 1.0, 2.0])
+
+
+def test_welldata_to_dataframe_empty_lognames_list():
+    """Test converting WellData to DataFrame with empty lognames list."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    gr_log = WellLog(name="GR", values=np.array([50.0, 60.0, 70.0]), is_discrete=False)
+
+    well = WellData(
+        name="TEST_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(gr_log,),
+    )
+
+    # Empty list should result in only survey columns
+    df = well.to_dataframe(lognames=[])
+
+    assert len(df) == 3
+    assert len(df.columns) == 3  # Only X, Y, Z
+    assert "GR" not in df.columns


### PR DESCRIPTION

Resolves #1469 

Part one of a bigger refactor. Establish internal immutable `WellLog` and `WellData` classes dedicated to i/o as a layer above Well, Wells, BlockedWell and BlockedWells.

This PR does not affect the public interface.


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
