### PR TITLE
MAINT: add rms_well ascii format to io._welldata

### DIFF
--- a/src/xtgeo/io/_file.py
+++ b/src/xtgeo/io/_file.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from xtgeo.cube import Cube
     from xtgeo.grid3d import Grid, GridProperties, GridProperty
     from xtgeo.surface import RegularSurface, Surfaces
-    from xtgeo.wells import BlockedWell, BlockedWells, Well, Wells
+    from xtgeo.well import BlockedWell, BlockedWells, Well, Wells
     from xtgeo.xyz import Points, Polygons
 
     XTGeoObject = Union[
@@ -50,7 +50,7 @@ VALID_FILE_ALIASES = ["$fmu-v1", "$md5sum", "$random"]
 
 
 class FileFormat(Enum):
-    RMSWELL = ["rmswell", "rmsw", "w", "bw"]
+    RMSWELL = ["rms_ascii", "rms_asc", "rmsasc", "rmswell", "rmsw", "w", "bw"]
     ROFF_BINARY = ["roff_binary", "roff", "roff_bin", "roff-bin", "roffbin", "roff.*"]
     ROFF_ASCII = ["roff_ascii", "roff_asc", "roff-asc", "roffasc", "asc"]
     EGRID = ["egrid", "eclipserun"]
@@ -123,7 +123,7 @@ class FileWrapper:
         self,
         filelike: FileLike,
         mode: Literal["r", "w", "rb", "wb"] = "rb",
-        obj: XTGeoObject = None,
+        obj: XTGeoObject | None = None,
     ) -> None:
         logger.debug("Init ran for FileWrapper")
 

--- a/src/xtgeo/io/_welldata/_blockedwell_io.py
+++ b/src/xtgeo/io/_welldata/_blockedwell_io.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
 
 from xtgeo.common.log import null_logger
-from xtgeo.io._welldata._well_io import WellData
+from xtgeo.io._welldata._well_io import WellData, WellFileFormat
+
+if TYPE_CHECKING:  # pragma: no cover
+    from xtgeo.common.types import FileLike
 
 logger = null_logger(__name__)
 
@@ -106,3 +110,51 @@ class BlockedWellData(WellData):
                 f"Index {index} out of bounds for well with {self.n_records} records"
             )
         return (self.i_index[index], self.j_index[index], self.k_index[index])
+
+    @classmethod
+    def from_file(
+        cls,
+        filepath: FileLike,
+        fformat: WellFileFormat = WellFileFormat.RMS_ASCII,
+        **kwargs: Any,
+    ) -> BlockedWellData:
+        """Read blocked well data from file with format selection."""
+        if fformat == WellFileFormat.RMS_ASCII:
+            return cls.from_rms_ascii(filepath, **kwargs)
+
+        raise NotImplementedError(f"File format {fformat} not supported yet.")
+
+    def to_file(
+        self,
+        filepath: FileLike,
+        fformat: WellFileFormat = WellFileFormat.RMS_ASCII,
+        **kwargs: Any,
+    ) -> None:
+        """Write blocked well data to file with format selection."""
+        if fformat == WellFileFormat.RMS_ASCII:
+            self.to_rms_ascii(filepath, **kwargs)
+            return
+
+        raise NotImplementedError(f"File format {fformat} not supported yet.")
+
+    @classmethod
+    def from_rms_ascii(cls, filepath: FileLike) -> BlockedWellData:
+        """Read blocked well data from RMS ASCII file."""
+        from xtgeo.io._welldata._fformats._rms_ascii import read_rms_ascii_blockedwell
+
+        return read_rms_ascii_blockedwell(filepath=filepath)
+
+    def to_rms_ascii(
+        self,
+        filepath: FileLike,
+        *,
+        precision: int = 4,
+    ) -> None:
+        """Write blocked well data to RMS ASCII file."""
+        from xtgeo.io._welldata._fformats._rms_ascii import write_rms_ascii_blockedwell
+
+        write_rms_ascii_blockedwell(
+            blocked_well=self,
+            filepath=filepath,
+            precision=precision,
+        )

--- a/src/xtgeo/io/_welldata/_fformats/_rms_ascii.py
+++ b/src/xtgeo/io/_welldata/_fformats/_rms_ascii.py
@@ -1,0 +1,391 @@
+"""RMS ASCII I/O for well data and blocked well data."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, TextIO
+
+import numpy as np
+import pandas as pd
+
+from xtgeo.common.log import null_logger
+from xtgeo.io._welldata._blockedwell_io import BlockedWellData
+from xtgeo.io._welldata._well_io import WellData, WellLog
+
+if TYPE_CHECKING:  # pragma: no cover
+    from xtgeo.common.types import FileLike
+
+logger = null_logger(__name__)
+
+RMS_ASCII_UNDEF: Final[float] = -999.0
+
+
+def read_rms_ascii_well(filepath: FileLike) -> WellData:
+    """Read well data from RMS ASCII file or stream.
+
+    Args:
+        filepath: Path to RMS ASCII file or a file-like stream object
+
+    Returns:
+        WellData object
+
+    """
+    is_stream = isinstance(filepath, (io.StringIO, io.BytesIO, io.TextIOBase))
+
+    path_obj: Path | None = None
+    if not is_stream:
+        assert isinstance(filepath, (str, Path))
+        path_obj = Path(filepath)
+
+        if not path_obj.exists():
+            raise FileNotFoundError(f"File not found: {path_obj}")
+        logger.debug("Reading well data from RMS ASCII: %s", path_obj)
+    else:
+        logger.debug("Reading well data from RMS ASCII stream")
+
+    wlogtype: dict[str, str] = {}
+    wlogrecords: dict[str, dict[int, str] | tuple[Any, ...]] = {}
+    lognames: list[str] = []
+
+    lnum = 1
+
+    fwell: TextIO
+    if is_stream:
+        fwell = filepath  # type: ignore[assignment]
+        should_close = False
+    else:
+        assert path_obj is not None
+        fwell = open(path_obj, "r", encoding="UTF-8")  # noqa: SIM115
+        should_close = True
+
+    try:
+        for line in fwell:
+            if lnum <= 2:
+                pass  # Skip first two lines (version and description)
+            elif lnum == 3:
+                # Well header: name xpos ypos [rkb]
+                # Well name can contain spaces, so parse from right to left
+                # rkb is optional, typically 0.0 or small value (Kelly Bushing height)
+                row = line.strip().split()
+
+                if len(row) < 3:
+                    raise ValueError(f"Invalid well header format: {line}")
+
+                # Try parsing with RKB (last 3 values are xpos, ypos, rkb)
+                try:
+                    rkb = float(row[-1])
+                    ypos = float(row[-2])
+                    xpos = float(row[-3])
+                    # Everything before the last 3 values is the well name
+                    wname: str = " ".join(row[:-3])
+                except (ValueError, IndexError):
+                    # No RKB, parse as name xpos ypos (last 2 values are xpos, ypos)
+                    try:
+                        ypos = float(row[-1])
+                        xpos = float(row[-2])
+                        # Everything before the last 2 values is the well name
+                        wname = " ".join(row[:-2])
+                        rkb = 0.0
+                    except (ValueError, IndexError):
+                        raise ValueError(f"Invalid well header format: {line}")
+
+            elif lnum == 4:
+                nlogs = int(line)
+                nlogread = 0
+                logger.debug("Number of logs: %s", nlogs)
+                if nlogs == 0:
+                    break
+
+            else:
+                row = line.strip().split()
+                lname_raw = str(row[0])
+                ltype = row[1].upper()
+
+                if "_index" in lname_raw.lower():
+                    lname: str = lname_raw.upper()
+                else:
+                    lname = lname_raw
+
+                lognames.append(lname)
+                wlogtype[lname] = ltype
+
+                logger.debug("Reading log name %s of type %s", lname, ltype)
+
+                if ltype == "DISC":
+                    # Discrete log: pairs of code and name
+                    rxv = row[2:]
+                    xdict: dict[int, str] = {
+                        int(rxv[i]): str(rxv[i + 1]) for i in range(0, len(rxv), 2)
+                    }
+                    wlogrecords[lname] = xdict
+                else:
+                    # Continuous log: store tuple of metadata (CONT, UNK, lin, etc.)
+                    wlogrecords[lname] = tuple(row[1:])
+
+                nlogread += 1
+
+                if nlogread >= nlogs:
+                    break
+
+            lnum += 1
+
+        # Read the data section
+        # The stream is already positioned right after the header, so read directly
+        column_names = ["X_UTME", "Y_UTMN", "Z_TVDSS"] + lognames
+
+        dfr = pd.read_csv(  # type: ignore[call-overload]
+            fwell,
+            sep=r"\s+",
+            header=None,
+            names=column_names,
+            dtype=np.float64,
+            na_values=RMS_ASCII_UNDEF,
+        )
+    finally:
+        if should_close:
+            fwell.close()
+
+    # Extract coordinates
+    survey_x = dfr["X_UTME"].to_numpy(dtype=np.float64)
+    survey_y = dfr["Y_UTMN"].to_numpy(dtype=np.float64)
+    survey_z = dfr["Z_TVDSS"].to_numpy(dtype=np.float64)
+
+    logs = []
+    for log_name in lognames:
+        values = dfr[log_name].to_numpy(dtype=np.float64)
+        is_discrete = wlogtype[log_name] == "DISC"
+        # Store metadata for both discrete and continuous logs
+        code_names = wlogrecords.get(log_name)
+
+        log = WellLog(
+            name=log_name, values=values, is_discrete=is_discrete, code_names=code_names
+        )
+        logs.append(log)
+
+    well = WellData(
+        name=wname,
+        xpos=xpos,
+        ypos=ypos,
+        zpos=rkb,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=tuple(logs),
+    )
+
+    logger.debug(
+        "Successfully read well '%s' with %d records and %d logs",
+        wname,
+        well.n_records,
+        len(logs),
+    )
+
+    return well
+
+
+def write_rms_ascii_well(
+    well: WellData,
+    filepath: FileLike,
+    precision: int = 4,
+) -> None:
+    """Write well data to RMS ASCII file or stream.
+
+    Args:
+        well: WellData object to write
+        filepath: Output RMS ASCII file path or a file-like stream object
+        precision: Number of decimal places for floats (default: 4)
+
+    """
+    # Handle file paths vs streams
+    is_stream = isinstance(filepath, (io.StringIO, io.BytesIO, io.TextIOBase))
+
+    if not is_stream:
+        assert isinstance(filepath, (str, Path))
+        path_obj = Path(filepath)
+        logger.debug("Writing well data to RMS ASCII: %s", path_obj)
+        fwell_write: TextIO = open(path_obj, "w", encoding="utf-8")  # noqa: SIM115
+        should_close = True
+    else:
+        logger.debug("Writing well data to RMS ASCII stream")
+        fwell_write = filepath  # type: ignore[assignment]
+        should_close = False
+
+    try:
+        # Line 1: Version
+        print("1.0", file=fwell_write)
+        # Line 2: Description
+        print("Unknown", file=fwell_write)
+        # Line 3: Well header
+        if well.zpos is None or well.zpos == 0.0:
+            print(f"{well.name} {well.xpos} {well.ypos}", file=fwell_write)
+        else:
+            print(f"{well.name} {well.xpos} {well.ypos} {well.zpos}", file=fwell_write)
+        # Line 4: Number of logs (not including X, Y, Z coordinates)
+        print(f"{len(well.logs)}", file=fwell_write)
+
+        # Log definitions (only for actual logs, not coordinates)
+        for log in well.logs:
+            if log.is_discrete:
+                log_type = "DISC"
+                wrec = "lin"
+                if log.code_names and isinstance(log.code_names, dict):
+                    code_parts: list[str] = []
+                    for code, name in sorted(log.code_names.items()):
+                        code_parts.extend([str(code), name])
+                    wrec = " ".join(code_parts)
+            else:
+                # Continuous log: try to restore metadata from code_names tuple
+                if isinstance(log.code_names, tuple) and len(log.code_names) >= 2:
+                    log_type = str(log.code_names[0])
+                    wrec = " ".join(str(x) for x in log.code_names[1:])
+                else:
+                    log_type = "UNK"
+                    wrec = "lin"
+
+            print(f"{log.name} {log_type} {wrec}", file=fwell_write)
+    finally:
+        if should_close:
+            fwell_write.close()
+
+    data = {
+        "X_UTME": well.survey_x,
+        "Y_UTMN": well.survey_y,
+        "Z_TVDSS": well.survey_z,
+    }
+
+    for log in well.logs:
+        data[log.name] = log.values
+
+    tmpdf = pd.DataFrame(data).fillna(value=RMS_ASCII_UNDEF)
+
+    # Convert discrete logs to integers
+    for log in well.logs:
+        if log.is_discrete:
+            tmpdf[[log.name]] = tmpdf[[log.name]].fillna(RMS_ASCII_UNDEF).astype(int)
+
+    cformat = f"%.{precision}f"
+
+    # For streams, append directly; for files, use append mode
+    # (append: preparing for writing multiple wells to one file)
+    if is_stream:
+        tmpdf.to_csv(
+            filepath,
+            sep=" ",
+            header=False,
+            index=False,
+            float_format=cformat,
+            escapechar="\\",
+        )
+    else:
+        tmpdf.to_csv(
+            path_obj,
+            sep=" ",
+            header=False,
+            index=False,
+            float_format=cformat,
+            escapechar="\\",
+            mode="a",
+        )
+
+    logger.debug(
+        "Successfully wrote well '%s' with %d records to %s",
+        well.name,
+        well.n_records,
+        filepath,
+    )
+
+
+def read_rms_ascii_blockedwell(
+    filepath: FileLike,
+) -> BlockedWellData:
+    """Read blocked well data from RMS ASCII file.
+
+    This assumes the file contains I_INDEX, J_INDEX, K_INDEX columns.
+
+    Args:
+        filepath: Path to RMS ASCII file
+
+    Returns:
+        BlockedWellData object
+
+    """
+    well = read_rms_ascii_well(filepath)
+
+    i_index_log = well.get_log("I_INDEX")
+    j_index_log = well.get_log("J_INDEX")
+    k_index_log = well.get_log("K_INDEX")
+
+    if not i_index_log or not j_index_log or not k_index_log:
+        raise ValueError(
+            "File does not contain I_INDEX, J_INDEX, and K_INDEX logs "
+            "required for blocked well"
+        )
+
+    # Remove index logs from the logs tuple
+    remaining_logs = tuple(
+        log for log in well.logs if log.name not in ["I_INDEX", "J_INDEX", "K_INDEX"]
+    )
+
+    blocked_well = BlockedWellData(
+        name=well.name,
+        xpos=well.xpos,
+        ypos=well.ypos,
+        zpos=well.zpos,
+        survey_x=well.survey_x,
+        survey_y=well.survey_y,
+        survey_z=well.survey_z,
+        logs=remaining_logs,
+        i_index=i_index_log.values,
+        j_index=j_index_log.values,
+        k_index=k_index_log.values,
+    )
+
+    logger.debug(
+        "Successfully read blocked well '%s' with %d records and %d blocked cells",
+        blocked_well.name,
+        blocked_well.n_records,
+        blocked_well.n_blocked_cells,
+    )
+
+    return blocked_well
+
+
+def write_rms_ascii_blockedwell(
+    blocked_well: BlockedWellData,
+    filepath: FileLike,
+    precision: int = 4,
+) -> None:
+    """Write blocked well data to RMS ASCII file.
+
+    Args:
+        blocked_well: BlockedWellData object to write
+        filepath: Output RMS ASCII file path
+        precision: Number of decimal places for floats (default: 4)
+
+    """
+    i_log = WellLog(name="I_INDEX", values=blocked_well.i_index, is_discrete=False)
+    j_log = WellLog(name="J_INDEX", values=blocked_well.j_index, is_discrete=False)
+    k_log = WellLog(name="K_INDEX", values=blocked_well.k_index, is_discrete=False)
+
+    temp_logs = blocked_well.logs + (i_log, j_log, k_log)
+
+    temp_well = WellData(
+        name=blocked_well.name,
+        xpos=blocked_well.xpos,
+        ypos=blocked_well.ypos,
+        zpos=blocked_well.zpos,
+        survey_x=blocked_well.survey_x,
+        survey_y=blocked_well.survey_y,
+        survey_z=blocked_well.survey_z,
+        logs=temp_logs,
+    )
+
+    write_rms_ascii_well(temp_well, filepath, precision)
+
+    logger.debug(
+        "Successfully wrote blocked well '%s' with %d blocked cells to %s",
+        blocked_well.name,
+        blocked_well.n_blocked_cells,
+        filepath,
+    )

--- a/tests/test_io/test_welldata/test_fformat_rms_ascii.py
+++ b/tests/test_io/test_welldata/test_fformat_rms_ascii.py
@@ -1,0 +1,772 @@
+"""Tests for RMS ASCII format I/O for WellData and BlockedWellData."""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+from xtgeo.io._welldata._blockedwell_io import BlockedWellData
+from xtgeo.io._welldata._well_io import WellData, WellFileFormat, WellLog
+
+# ============================================================================
+# Legacy stream tests (kept for specific stream-related edge cases)
+# ============================================================================
+
+
+def test_welldata_write_discrete_to_stream():
+    """Test writing WellData with discrete log to StringIO stream."""
+    import io
+
+    from xtgeo.io._welldata._well_io import WellData, WellLog
+
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 1.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE"},
+    )
+
+    well = WellData(
+        name="DiscreteStreamWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 100.0, 100.0]),
+        survey_y=np.array([200.0, 200.0, 200.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(facies_log,),
+    )
+
+    stream = io.StringIO()
+    well.to_rms_ascii(filepath=stream)
+
+    content = stream.getvalue()
+    assert "DiscreteStreamWell" in content
+    assert "FACIES DISC 1 SAND 2 SHALE" in content
+
+
+def test_welldata_read_from_bytesio_stream():
+    """Test reading WellData from BytesIO stream."""
+    import io
+
+    from xtgeo.io._welldata._well_io import WellData
+
+    rms_content = b"""1.0
+Test well from bytes
+TestWell 100.0 200.0 0.0
+1
+PORO CONT lin
+100.0 200.0 1000.0 0.25
+101.0 201.0 1001.0 0.30
+"""
+    stream = io.BytesIO(rms_content)
+    # Convert to TextIOWrapper for text reading
+    text_stream = io.TextIOWrapper(stream, encoding="utf-8")
+
+    well = WellData.from_rms_ascii(filepath=text_stream)
+
+    assert well.name == "TestWell"
+    assert well.n_records == 2
+    assert len(well.logs) == 1
+
+
+def test_welldata_read_zero_logs():
+    """Test reading WellData with zero logs (nlogs == 0)."""
+    import io
+
+    from xtgeo.io._welldata._well_io import WellData
+
+    rms_content = """1.0
+Well with no logs
+NoLogsWell 150.0 250.0 10.0
+0
+150.0 250.0 1500.0
+151.0 251.0 1501.0
+"""
+    stream = io.StringIO(rms_content)
+    well = WellData.from_rms_ascii(filepath=stream)
+
+    assert well.name == "NoLogsWell"
+    assert well.xpos == 150.0
+    assert well.ypos == 250.0
+    assert well.zpos == 10.0
+    assert len(well.logs) == 0
+    assert well.n_records == 2
+
+
+def test_welldata_read_well_name_with_spaces():
+    """Test reading WellData with well name containing spaces."""
+    import io
+
+    from xtgeo.io._welldata._well_io import WellData
+
+    # Test with RKB
+    rms_content_with_rkb = """1.0
+Well with space in name
+31/4-2 A   4444030. 9937883.0 32.0
+1
+GR CONT lin
+4444030.0 9937883.0 1000.0 75.5
+4444031.0 9937884.0 1001.0 80.2
+"""
+    stream = io.StringIO(rms_content_with_rkb)
+    well = WellData.from_rms_ascii(filepath=stream)
+
+    assert well.name == "31/4-2 A"
+    assert well.xpos == 4444030.0
+    assert well.ypos == 9937883.0
+    assert well.zpos == 32.0
+    assert well.n_records == 2
+
+    # Test without RKB
+    rms_content_no_rkb = """1.0
+Well with space in name no RKB
+31/4-2 A   4444030. 9937883.0
+1
+GR CONT lin
+4444030.0 9937883.0 1000.0 75.5
+"""
+    stream = io.StringIO(rms_content_no_rkb)
+    well = WellData.from_rms_ascii(filepath=stream)
+
+    assert well.name == "31/4-2 A"
+    assert well.xpos == 4444030.0
+    assert well.ypos == 9937883.0
+    assert well.zpos == 0.0
+    assert well.n_records == 1
+
+
+# ============================================================================
+# WellData.to_file() and WellData.from_file() with RMS_ASCII format
+# ============================================================================
+
+
+def test_welldata_to_file_from_file_basic(tmp_path):
+    """Test basic WellData write and read using to_file/from_file."""
+    # Create well data
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]))
+    poro_log = WellLog(name="PORO", values=np.array([0.15, 0.20, 0.25]))
+
+    well = WellData(
+        name="WELL-A",
+        xpos=1000.0,
+        ypos=2000.0,
+        zpos=100.0,
+        survey_x=np.array([1000.0, 1001.0, 1002.0]),
+        survey_y=np.array([2000.0, 2001.0, 2002.0]),
+        survey_z=np.array([1500.0, 1600.0, 1700.0]),
+        logs=(gr_log, poro_log),
+    )
+
+    # Write to file
+    filepath = tmp_path / "well_a.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    # Read back
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    # Verify
+    assert well_read.name == "WELL-A"
+    assert well_read.xpos == 1000.0
+    assert well_read.ypos == 2000.0
+    assert well_read.zpos == 100.0
+    assert well_read.n_records == 3
+    assert len(well_read.logs) == 2
+    assert well_read.log_names == ("GR", "PORO")
+    np.testing.assert_array_almost_equal(well_read.survey_x, well.survey_x)
+    np.testing.assert_array_almost_equal(well_read.survey_z, well.survey_z)
+
+
+def test_welldata_to_file_from_file_with_discrete_log(tmp_path):
+    """Test WellData with discrete log using to_file/from_file."""
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 3.0, 1.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE", 3: "LIMESTONE"},
+    )
+
+    well = WellData(
+        name="WELL-B",
+        xpos=5000.0,
+        ypos=6000.0,
+        zpos=50.0,
+        survey_x=np.array([5000.0, 5000.0, 5000.0, 5000.0]),
+        survey_y=np.array([6000.0, 6000.0, 6000.0, 6000.0]),
+        survey_z=np.array([2000.0, 2010.0, 2020.0, 2030.0]),
+        logs=(facies_log,),
+    )
+
+    filepath = tmp_path / "well_b.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    assert well_read.name == "WELL-B"
+    assert well_read.n_records == 4
+    assert len(well_read.logs) == 1
+
+    facies_read = well_read.get_log("FACIES")
+    assert facies_read is not None
+    assert facies_read.is_discrete
+    assert facies_read.code_names == {1: "SAND", 2: "SHALE", 3: "LIMESTONE"}
+    np.testing.assert_array_equal(facies_read.values, facies_log.values)
+
+
+def test_welldata_to_file_from_file_no_rkb(tmp_path):
+    """Test WellData without RKB (zpos=0) using to_file/from_file."""
+    log = WellLog(name="DEPTH", values=np.array([1000.0, 1100.0]))
+
+    well = WellData(
+        name="WELL-NO-RKB",
+        xpos=123.45,
+        ypos=678.90,
+        zpos=0.0,  # No RKB
+        survey_x=np.array([123.45, 123.46]),
+        survey_y=np.array([678.90, 678.91]),
+        survey_z=np.array([1000.0, 1100.0]),
+        logs=(log,),
+    )
+
+    filepath = tmp_path / "well_no_rkb.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    assert well_read.name == "WELL-NO-RKB"
+    assert well_read.zpos == 0.0
+    assert well_read.n_records == 2
+
+
+def test_welldata_to_file_from_file_no_logs(tmp_path):
+    """Test WellData with no logs using to_file/from_file."""
+    well = WellData(
+        name="EMPTY-LOGS",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=10.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1100.0, 1200.0]),
+        logs=(),
+    )
+
+    filepath = tmp_path / "well_no_logs.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    assert well_read.name == "EMPTY-LOGS"
+    assert len(well_read.logs) == 0
+    assert well_read.n_records == 3
+
+
+def test_welldata_to_file_from_file_precision(tmp_path):
+    """Test WellData precision parameter in to_file."""
+    log = WellLog(name="VALUE", values=np.array([1.23456789]))
+
+    well = WellData(
+        name="PRECISION-TEST",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0]),
+        survey_y=np.array([200.0]),
+        survey_z=np.array([1000.0]),
+        logs=(log,),
+    )
+
+    # Write with precision=2
+    filepath = tmp_path / "well_precision.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII, precision=2)
+
+    content = filepath.read_text()
+    # Should have 2 decimal places (1.23)
+    assert "1.23" in content
+    # Should not have more precision
+    assert "1.2345" not in content
+
+
+def test_welldata_to_file_from_file_with_nan_values(tmp_path):
+    """Test WellData with NaN values using to_file/from_file."""
+    log = WellLog(name="INCOMPLETE", values=np.array([10.0, np.nan, 30.0]))
+
+    well = WellData(
+        name="NAN-TEST",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1100.0, 1200.0]),
+        logs=(log,),
+    )
+
+    filepath = tmp_path / "well_nan.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    log_read = well_read.get_log("INCOMPLETE")
+    assert log_read is not None
+    # Check values with NaN handling
+    assert np.array_equal(log_read.values, log.values, equal_nan=True)
+
+
+def test_welldata_to_file_from_file_multiple_logs(tmp_path):
+    """Test WellData with multiple logs of different types."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+    poro_log = WellLog(name="PORO", values=np.array([0.15, 0.20]))
+    perm_log = WellLog(name="PERM", values=np.array([100.0, 200.0]))
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE"},
+    )
+
+    well = WellData(
+        name="MULTI-LOG",
+        xpos=1000.0,
+        ypos=2000.0,
+        zpos=25.0,
+        survey_x=np.array([1000.0, 1001.0]),
+        survey_y=np.array([2000.0, 2001.0]),
+        survey_z=np.array([1500.0, 1600.0]),
+        logs=(gr_log, poro_log, perm_log, facies_log),
+    )
+
+    filepath = tmp_path / "well_multi_log.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    assert well_read.n_records == 2
+    assert len(well_read.logs) == 4
+    assert well_read.log_names == ("GR", "PORO", "PERM", "FACIES")
+
+    # Check discrete log
+    facies_read = well_read.get_log("FACIES")
+    assert facies_read.is_discrete
+    assert facies_read.code_names == {1: "SAND", 2: "SHALE"}
+
+
+def test_welldata_metadata_roundtrip(tmp_path):
+    """Test that continuous log metadata (unit, scale) is preserved in roundtrip."""
+    # Create a log with specific metadata tuple (TYPE, UNIT, SCALE, ...)
+    # Note: The first element 'CONT' is usually implied by is_discrete=False,
+    # but the parser stores the whole tuple from the file.
+    # When creating manually, we simulate what the parser produces.
+    meta_tuple = ("CONT", "mMD", "log")
+
+    perm_log = WellLog(
+        name="PERM",
+        values=np.array([100.0, 200.0]),
+        is_discrete=False,
+        code_names=meta_tuple,
+    )
+
+    well = WellData(
+        name="META-TEST",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 100.0]),
+        survey_y=np.array([200.0, 200.0]),
+        survey_z=np.array([1000.0, 1001.0]),
+        logs=(perm_log,),
+    )
+
+    filepath = tmp_path / "well_meta.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    # Verify the file content has the metadata
+    content = filepath.read_text()
+    assert "PERM CONT mMD log" in content
+
+    # Read back and verify
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+    perm_read = well_read.get_log("PERM")
+
+    # The parser reads the whole line after name, so it should match
+    assert perm_read.code_names == meta_tuple
+
+
+def test_welldata_discrete_sorted_output(tmp_path):
+    """Test that discrete log codes are written in sorted order."""
+    # Create code_names with unsorted keys
+    codes = {2: "SHALE", 1: "SAND", 3: "LIME"}
+
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 3.0]),
+        is_discrete=True,
+        code_names=codes,
+    )
+
+    well = WellData(
+        name="SORT-TEST",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 100.0, 100.0]),
+        survey_y=np.array([200.0, 200.0, 200.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(facies_log,),
+    )
+
+    filepath = tmp_path / "well_sort.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    content = filepath.read_text()
+    # Check for the specific sorted string sequence
+    expected_header = "FACIES DISC 1 SAND 2 SHALE 3 LIME"
+    assert expected_header in content
+
+
+def test_welldata_to_file_from_file_stream(tmp_path):
+    """Test WellData using to_file/from_file with stream objects."""
+    log = WellLog(name="TEST", values=np.array([1.0, 2.0]))
+
+    well = WellData(
+        name="STREAM-TEST",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1100.0]),
+        logs=(log,),
+    )
+
+    # Write to stream
+    stream_out = io.StringIO()
+    well.to_file(filepath=stream_out, fformat=WellFileFormat.RMS_ASCII)
+
+    # Read from stream
+    stream_in = io.StringIO(stream_out.getvalue())
+    well_read = WellData.from_file(filepath=stream_in, fformat=WellFileFormat.RMS_ASCII)
+
+    assert well_read.name == "STREAM-TEST"
+    assert well_read.n_records == 2
+    assert len(well_read.logs) == 1
+
+
+# ============================================================================
+# BlockedWellData.to_file() and BlockedWellData.from_file() with RMS_ASCII
+# ============================================================================
+
+
+def test_blockedwell_to_file_from_file_basic(tmp_path):
+    """Test basic BlockedWellData write and read using to_file/from_file."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]))
+
+    blocked_well = BlockedWellData(
+        name="BLOCKED-A",
+        xpos=1000.0,
+        ypos=2000.0,
+        zpos=100.0,
+        survey_x=np.array([1000.0, 1001.0, 1002.0]),
+        survey_y=np.array([2000.0, 2001.0, 2002.0]),
+        survey_z=np.array([1500.0, 1600.0, 1700.0]),
+        i_index=np.array([10.0, 11.0, 12.0]),
+        j_index=np.array([20.0, 21.0, 22.0]),
+        k_index=np.array([1.0, 2.0, 3.0]),
+        logs=(gr_log,),
+    )
+
+    filepath = tmp_path / "blocked_a.txt"
+    blocked_well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    blocked_read = BlockedWellData.from_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII
+    )
+
+    assert blocked_read.name == "BLOCKED-A"
+    assert blocked_read.xpos == 1000.0
+    assert blocked_read.ypos == 2000.0
+    assert blocked_read.zpos == 100.0
+    assert blocked_read.n_records == 3
+    assert len(blocked_read.logs) == 1
+    assert blocked_read.n_blocked_cells == 3
+    np.testing.assert_array_equal(blocked_read.i_index, blocked_well.i_index)
+    np.testing.assert_array_equal(blocked_read.j_index, blocked_well.j_index)
+    np.testing.assert_array_equal(blocked_read.k_index, blocked_well.k_index)
+
+
+def test_blockedwell_to_file_from_file_with_nan_indices(tmp_path):
+    """Test BlockedWellData with NaN indices using to_file/from_file."""
+    blocked_well = BlockedWellData(
+        name="BLOCKED-NAN",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0, 103.0]),
+        survey_y=np.array([200.0, 201.0, 202.0, 203.0]),
+        survey_z=np.array([1000.0, 1100.0, 1200.0, 1300.0]),
+        i_index=np.array([10.0, np.nan, 11.0, 12.0]),
+        j_index=np.array([20.0, np.nan, 21.0, 22.0]),
+        k_index=np.array([1.0, np.nan, 2.0, 3.0]),
+        logs=(),
+    )
+
+    filepath = tmp_path / "blocked_nan.txt"
+    blocked_well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    blocked_read = BlockedWellData.from_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII
+    )
+
+    assert blocked_read.n_blocked_cells == 3  # One point has NaN indices
+    # Check indices with NaN handling
+    assert np.array_equal(blocked_read.i_index, blocked_well.i_index, equal_nan=True)
+    assert np.array_equal(blocked_read.j_index, blocked_well.j_index, equal_nan=True)
+    assert np.array_equal(blocked_read.k_index, blocked_well.k_index, equal_nan=True)
+
+
+def test_blockedwell_to_file_from_file_multiple_logs(tmp_path):
+    """Test BlockedWellData with multiple logs using to_file/from_file."""
+    poro_log = WellLog(name="PORO", values=np.array([0.15, 0.20]))
+    perm_log = WellLog(name="PERM", values=np.array([100.0, 200.0]))
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE"},
+    )
+
+    blocked_well = BlockedWellData(
+        name="BLOCKED-MULTI",
+        xpos=5000.0,
+        ypos=6000.0,
+        zpos=50.0,
+        survey_x=np.array([5000.0, 5001.0]),
+        survey_y=np.array([6000.0, 6001.0]),
+        survey_z=np.array([2000.0, 2100.0]),
+        i_index=np.array([15.0, 16.0]),
+        j_index=np.array([25.0, 26.0]),
+        k_index=np.array([5.0, 6.0]),
+        logs=(poro_log, perm_log, facies_log),
+    )
+
+    filepath = tmp_path / "blocked_multi.txt"
+    blocked_well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    blocked_read = BlockedWellData.from_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII
+    )
+
+    assert blocked_read.n_records == 2
+    assert len(blocked_read.logs) == 3
+    assert blocked_read.log_names == ("PORO", "PERM", "FACIES")
+
+    facies_read = blocked_read.get_log("FACIES")
+    assert facies_read.is_discrete
+    assert facies_read.code_names == {1: "SAND", 2: "SHALE"}
+
+
+def test_blockedwell_to_file_from_file_no_logs(tmp_path):
+    """Test BlockedWellData with no logs using to_file/from_file."""
+    blocked_well = BlockedWellData(
+        name="BLOCKED-NOLOG",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=10.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1100.0]),
+        i_index=np.array([10.0, 11.0]),
+        j_index=np.array([20.0, 21.0]),
+        k_index=np.array([1.0, 2.0]),
+        logs=(),
+    )
+
+    filepath = tmp_path / "blocked_nolog.txt"
+    blocked_well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    blocked_read = BlockedWellData.from_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII
+    )
+
+    assert blocked_read.name == "BLOCKED-NOLOG"
+    assert len(blocked_read.logs) == 0
+    assert blocked_read.n_records == 2
+    assert blocked_read.n_blocked_cells == 2
+
+
+def test_blockedwell_to_file_from_file_precision(tmp_path):
+    """Test BlockedWellData precision parameter in to_file."""
+    log = WellLog(name="VALUE", values=np.array([1.23456789]))
+
+    blocked_well = BlockedWellData(
+        name="BLOCKED-PRECISION",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0]),
+        survey_y=np.array([200.0]),
+        survey_z=np.array([1000.0]),
+        i_index=np.array([10.0]),
+        j_index=np.array([20.0]),
+        k_index=np.array([1.0]),
+        logs=(log,),
+    )
+
+    filepath = tmp_path / "blocked_precision.txt"
+    blocked_well.to_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII, precision=3
+    )
+
+    content = filepath.read_text()
+    # Should have 3 decimal places
+    assert "1.235" in content or "1.234" in content
+
+
+def test_blockedwell_to_file_from_file_stream(tmp_path):
+    """Test BlockedWellData using to_file/from_file with stream objects."""
+    blocked_well = BlockedWellData(
+        name="BLOCKED-STREAM",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1100.0]),
+        i_index=np.array([10.0, 11.0]),
+        j_index=np.array([20.0, 21.0]),
+        k_index=np.array([1.0, 2.0]),
+        logs=(),
+    )
+
+    # Write to stream
+    stream_out = io.StringIO()
+    blocked_well.to_file(filepath=stream_out, fformat=WellFileFormat.RMS_ASCII)
+
+    # Read from stream
+    stream_in = io.StringIO(stream_out.getvalue())
+    blocked_read = BlockedWellData.from_file(
+        filepath=stream_in, fformat=WellFileFormat.RMS_ASCII
+    )
+
+    assert blocked_read.name == "BLOCKED-STREAM"
+    assert blocked_read.n_records == 2
+    np.testing.assert_array_equal(blocked_read.i_index, blocked_well.i_index)
+
+
+def test_blockedwell_to_file_from_file_roundtrip_complex(tmp_path):
+    """Test complex BlockedWellData roundtrip with all features."""
+    # Create complex blocked well with mixed logs
+    gr_log = WellLog(name="GR", values=np.array([45.5, 67.8, 89.2, 101.3]))
+    poro_log = WellLog(name="PORO", values=np.array([0.18, 0.22, np.nan, 0.16]))
+    sw_log = WellLog(name="SW", values=np.array([0.45, 0.38, 0.52, 0.41]))
+    zone_log = WellLog(
+        name="ZONE",
+        values=np.array([1.0, 1.0, 2.0, 3.0]),
+        is_discrete=True,
+        code_names={1: "UPPER", 2: "MIDDLE", 3: "LOWER"},
+    )
+
+    blocked_well = BlockedWellData(
+        name="31/4-A-15 H",
+        xpos=456789.12,
+        ypos=6543210.98,
+        zpos=25.5,
+        survey_x=np.array([456789.12, 456789.5, 456790.0, 456790.5]),
+        survey_y=np.array([6543210.98, 6543211.2, 6543211.5, 6543211.8]),
+        survey_z=np.array([1850.5, 1855.0, 1859.5, 1864.0]),
+        i_index=np.array([125.0, 125.0, 126.0, np.nan]),
+        j_index=np.array([234.0, 234.0, 235.0, np.nan]),
+        k_index=np.array([15.0, 16.0, 17.0, np.nan]),
+        logs=(gr_log, poro_log, sw_log, zone_log),
+    )
+
+    filepath = tmp_path / "complex_blocked.txt"
+    blocked_well.to_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII, precision=4
+    )
+
+    blocked_read = BlockedWellData.from_file(
+        filepath=filepath, fformat=WellFileFormat.RMS_ASCII
+    )
+
+    # Verify all attributes
+    assert blocked_read.name == "31/4-A-15 H"
+    assert blocked_read.xpos == pytest.approx(456789.12, abs=1e-2)
+    assert blocked_read.ypos == pytest.approx(6543210.98, abs=1e-2)
+    assert blocked_read.zpos == pytest.approx(25.5, abs=1e-2)
+    assert blocked_read.n_records == 4
+    assert blocked_read.n_blocked_cells == 3  # One has NaN indices
+    assert len(blocked_read.logs) == 4
+
+    # Verify indices with NaN handling
+    assert np.array_equal(blocked_read.i_index, blocked_well.i_index, equal_nan=True)
+    assert np.array_equal(blocked_read.j_index, blocked_well.j_index, equal_nan=True)
+    assert np.array_equal(blocked_read.k_index, blocked_well.k_index, equal_nan=True)
+
+    # Verify logs
+    poro_read = blocked_read.get_log("PORO")
+    # Use allclose for float comparison with NaN handling
+    assert np.allclose(poro_read.values, poro_log.values, equal_nan=True, rtol=1e-5)
+
+    zone_read = blocked_read.get_log("ZONE")
+    assert zone_read.is_discrete
+    assert zone_read.code_names == {1: "UPPER", 2: "MIDDLE", 3: "LOWER"}
+
+
+def test_blockedwell_from_file_missing_indices(tmp_path):
+    """BlockedWellData.from_file shall raise ValueError when indices are missing."""
+    # Create a regular WellData file (no I_INDEX, J_INDEX, K_INDEX)
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+
+    well = WellData(
+        name="REGULAR-WELL",
+        xpos=1000.0,
+        ypos=2000.0,
+        zpos=100.0,
+        survey_x=np.array([1000.0, 1001.0]),
+        survey_y=np.array([2000.0, 2001.0]),
+        survey_z=np.array([1500.0, 1600.0]),
+        logs=(gr_log,),
+    )
+
+    # Write WellData to file
+    filepath = tmp_path / "regular_well.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    # Try to read as BlockedWellData - should raise ValueError
+    with pytest.raises(
+        ValueError,
+        match="File does not contain I_INDEX, J_INDEX, and K_INDEX logs",
+    ):
+        BlockedWellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+
+def test_blockedwell_from_file_partial_indices(tmp_path):
+    """BlockedWellData.from_file -> ValueError when only some indices present."""
+    # Create a file with only I_INDEX and J_INDEX (missing K_INDEX)
+    i_log = WellLog(name="I_INDEX", values=np.array([10.0, 11.0]))
+    j_log = WellLog(name="J_INDEX", values=np.array([20.0, 21.0]))
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+
+    well = WellData(
+        name="PARTIAL-INDICES",
+        xpos=1000.0,
+        ypos=2000.0,
+        zpos=100.0,
+        survey_x=np.array([1000.0, 1001.0]),
+        survey_y=np.array([2000.0, 2001.0]),
+        survey_z=np.array([1500.0, 1600.0]),
+        logs=(i_log, j_log, gr_log),
+    )
+
+    filepath = tmp_path / "partial_indices.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    # Try to read as BlockedWellData - should raise ValueError
+    with pytest.raises(
+        ValueError,
+        match="File does not contain I_INDEX, J_INDEX, and K_INDEX logs",
+    ):
+        BlockedWellData.from_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)


### PR DESCRIPTION
Part 3 of PR's addressing parts of #1436 and general move to xtgeo.io  #1480 

Closing https://github.com/equinor/xtgeo/issues/1481

Here i/o from `WellData` and `BlockedWellData` to/from several file formats are provided from the new `xtgeo.io._welldata` modules. It does currently not affect any current public API. That will come in  later PR.

Included here is RMS ASCII well format. Subsequent PR's will add additional formats.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
