### PR TITLE
TYP: type annotate src/xtgeo/xyz/_xyz_roxapi.py

### DIFF
--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -53,7 +53,7 @@ class XYZ(ABC):
         self._xname = xname
         self._yname = yname
         self._zname = zname
-        self._attrs: list[str] = []
+        self._attrs: dict[str, str] = {}
 
     @property
     def xyztype(self) -> _XYZType:

--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -70,7 +70,7 @@ def _import_table(pfile, xyztype, file_format="csv"):
     ncol = len(columns)
 
     if ncol == 3:
-        if xyztype == _XYZType.POLYGONS.value:
+        if xyztype == _XYZType.POLYGONS:
             # If the file is a polygon file, add a POLY_ID column
             dataframe["POLY_ID"] = 0
             return {
@@ -88,7 +88,7 @@ def _import_table(pfile, xyztype, file_format="csv"):
             "zname": columns[2],
             "values": dataframe,
         }
-    if xyztype == _XYZType.POLYGONS.value and ncol == 4:
+    if xyztype == _XYZType.POLYGONS and ncol == 4:
         return {
             "xname": columns[0],
             "yname": columns[1],
@@ -96,7 +96,7 @@ def _import_table(pfile, xyztype, file_format="csv"):
             "pname": columns[3],
             "values": dataframe,
         }
-    if xyztype == _XYZType.POLYGONS.value and ncol > 4:
+    if xyztype == _XYZType.POLYGONS and ncol > 4:
         # need to infer the attrs from column 5...
         attr_names = columns[4:]
         attrs = {}
@@ -119,7 +119,7 @@ def _import_table(pfile, xyztype, file_format="csv"):
             "attributes": attrs,
             "values": dataframe,
         }
-    if xyztype == _XYZType.POINTS.value and ncol > 3:
+    if xyztype == _XYZType.POINTS and ncol > 3:
         # need to infer the attrs from column 5...
         attr_names = columns[3:]
         attrs = {}
@@ -146,19 +146,19 @@ def _import_table(pfile, xyztype, file_format="csv"):
 
 
 def import_csv_polygons(pfile):
-    return _import_table(pfile, _XYZType.POLYGONS.value, file_format="csv")
+    return _import_table(pfile, _XYZType.POLYGONS, file_format="csv")
 
 
 def import_csv_points(pfile):
-    return _import_table(pfile, _XYZType.POINTS.value, file_format="csv")
+    return _import_table(pfile, _XYZType.POINTS, file_format="csv")
 
 
 def import_parquet_polygons(pfile):
-    return _import_table(pfile, _XYZType.POLYGONS.value, file_format="parquet")
+    return _import_table(pfile, _XYZType.POLYGONS, file_format="parquet")
 
 
 def import_parquet_points(pfile):
-    return _import_table(pfile, _XYZType.POINTS.value, file_format="parquet")
+    return _import_table(pfile, _XYZType.POINTS, file_format="parquet")
 
 
 def import_zmap(pfile, zname=_AttrName.ZNAME.value):
@@ -446,7 +446,7 @@ def export_rms_attr(self, pfile, attributes=True, pfilter=None):
                     f"Valid keys are {df.columns}"
                 )
 
-    if self._xyztype == _XYZType.POLYGONS.value:  # a bit weird: TODO fixup
+    if self._xyztype == _XYZType.POLYGONS:  # a bit weird: TODO fixup
         if not attributes and self._pname in df.columns:
             # need to convert the dataframe
             df = _convert_idbased_xyz(self, df)
@@ -514,7 +514,7 @@ def export_table(self, pfile, file_format="csv", attributes=False, pfilter=None)
         df = df.fillna(value=999.0)
 
     # Apply filter if any (Points only)
-    if self._xyztype == _XYZType.POINTS.value and pfilter:
+    if self._xyztype == _XYZType.POINTS and pfilter:
         for key, val in pfilter.items():
             if key in df.columns:
                 df = df.loc[df[key].isin(val)]
@@ -525,9 +525,9 @@ def export_table(self, pfile, file_format="csv", attributes=False, pfilter=None)
                 )
 
     # Select columns based on type and attributes
-    if self._xyztype == _XYZType.POLYGONS.value and not attributes:
+    if self._xyztype == _XYZType.POLYGONS and not attributes:
         df = df.iloc[:, 0:4]
-    elif self._xyztype == _XYZType.POINTS.value and not attributes:
+    elif self._xyztype == _XYZType.POINTS and not attributes:
         df = df.iloc[:, 0:3]
     elif attributes:
         if isinstance(attributes, bool):
@@ -559,7 +559,7 @@ def export_table(self, pfile, file_format="csv", attributes=False, pfilter=None)
                 f"Attributes must be a bool or a list, not {type(attributes)}"
             )
 
-        if self._xyztype == _XYZType.POLYGONS.value:
+        if self._xyztype == _XYZType.POLYGONS:
             # Ensure POLY_ID is included
             if self._pname not in df.columns:
                 df[self._pname] = 0
@@ -707,11 +707,11 @@ def _from_list_like(plist, zname, attrs, xyztype) -> pd.DataFrame:
         if totnum == 3 + lenattrs:
             dfr = pd.DataFrame(plist[:, :3], columns=["X_UTME", "Y_UTMN", zname])
             dfr = dfr.astype(float)
-            if xyztype == _XYZType.POLYGONS.value:
+            if xyztype == _XYZType.POLYGONS:
                 # pname column is missing but assign 0 as ID
                 dfr["POLY_ID"] = 0
 
-        elif totnum == 4 + lenattrs and xyztype == _XYZType.POLYGONS.value:
+        elif totnum == 4 + lenattrs and xyztype == _XYZType.POLYGONS:
             dfr = pd.DataFrame(
                 plist[:, :4],
                 columns=["X_UTME", "Y_UTMN", zname, "POLY_ID"],
@@ -723,7 +723,7 @@ def _from_list_like(plist, zname, attrs, xyztype) -> pd.DataFrame:
             )
         dfr.dropna()
         dfr = dfr.astype(np.float64)
-        if xyztype == _XYZType.POLYGONS.value:
+        if xyztype == _XYZType.POLYGONS:
             dfr[_AttrName.PNAME.value] = dfr[_AttrName.PNAME.value].astype(np.int32)
 
         if lenattrs > 0:

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -97,7 +97,7 @@ def _roxar_importer(
     attributes: bool | list[str] = False,
 ):
     return _xyz_roxapi.load_xyz_from_rms(
-        project, name, category, stype, realisation, attributes, _XYZType.POINTS.value
+        project, name, category, stype, realisation, attributes, _XYZType.POINTS
     )
 
 
@@ -451,7 +451,7 @@ class Points(XYZ):
         filesrc: str = None,
     ):
         """Initialisation of Points()."""
-        self._xyztype = _XYZType.POINTS.value
+        self._xyztype = _XYZType.POINTS
 
         super().__init__(self._xyztype, xname, yname, zname)
 

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -80,7 +80,7 @@ def _roxar_importer(
     attributes: bool | list[str] = False,
 ):  # pragma: no cover
     kwargs = _xyz_roxapi.load_xyz_from_rms(
-        project, name, category, stype, realisation, attributes, _XYZType.POLYGONS.value
+        project, name, category, stype, realisation, attributes, _XYZType.POLYGONS
     )
 
     kwargs["name"] = name if name else "poly"
@@ -299,7 +299,7 @@ class Polygons(XYZ):
         fformat: str = "guess",
         filesrc: str = None,
     ):
-        self._xyztype: str = _XYZType.POLYGONS.value
+        self._xyztype: _XYZType = _XYZType.POLYGONS
 
         super().__init__(self._xyztype, xname, yname, zname)
         self._pname = pname

--- a/tests/test_xyz/test_points.py
+++ b/tests/test_xyz/test_points.py
@@ -96,7 +96,7 @@ def test_points_read_write_csv(testdata_path, tmp_path):
 def test_points_io_with_attrs(points_with_attrs, tmp_path):
     """Test roundtrip of polygons with attributes from file and back.
 
-    Note that some formats does not store attributes.
+    Note that some formats do not store attributes.
     """
 
     plist, attrs = points_with_attrs

--- a/tests/test_xyz/test_xyz_roxapi_mock.py
+++ b/tests/test_xyz/test_xyz_roxapi_mock.py
@@ -145,7 +145,7 @@ def test_roxar_polygon_importer():
             stype,
             realisation,
             attributes,
-            _XYZType.POLYGONS.value,
+            _XYZType.POLYGONS,
         )
 
         # Check the result
@@ -194,7 +194,7 @@ def test_roxar_polygon_importer_attrs():
             stype,
             realisation,
             attributes,
-            _XYZType.POLYGONS.value,
+            _XYZType.POLYGONS,
         )
 
         # Check the result


### PR DESCRIPTION
Part of #1429 

Type annotate src/xtgeo/xyz/_xyz_roxapi.py

Additional related code changes:
- enum `_XYZType`: compare enums directly, not their values (e.g. use `_XYZType.POLYGONS`, not `_XYZType.POLYGONS.value`)
- enum `_XYZType`: compare enums directly, not their string equivalencies
- `import roxar` (and related imports): required some modifications to allow typing


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
