### PR TITLE
ENH: Add RLE support for ZCORN

### DIFF
--- a/src/xtgeo/grid3d/_grdecl_grid.py
+++ b/src/xtgeo/grid3d/_grdecl_grid.py
@@ -342,7 +342,7 @@ class GrdeclGrid(EclGrid):
                 if values is None:
                     continue
                 filestream.write(f"{kw}\n")
-                if rle and (kw == "ACTNUM"):
+                if rle and (kw in ["ACTNUM", "ZCORN"]):
                     counts, unique_values = run_length_encoding(values)
                     for i, (count, unique_value) in enumerate(
                         zip(counts, unique_values)


### PR DESCRIPTION
Resolves #1486 

Add support for ZCORN keyword to Run-Length Encoding compression. This is particularly useful for horizontal grid

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
