### PR TITLE
BUG: ensure RegularSurface fill() values as type MaskedArray

### DIFF
--- a/src/xtgeo/surface/_regsurf_gridding.py
+++ b/src/xtgeo/surface/_regsurf_gridding.py
@@ -2000,7 +2000,7 @@ def surf_fill(
             ind = scipy.ndimage.distance_transform_edt(
                 invalid, return_distances=False, return_indices=True
             )
-            self._values = self._values[tuple(ind)]
+            self._ensure_correct_values(self._values[tuple(ind)])
 
         elif method in ("linear", "cubic", "radial_basis"):
             # Get valid data points
@@ -2051,7 +2051,7 @@ def surf_fill(
                 znew = rbf(np.column_stack([xiv.ravel(), yiv.ravel()])).reshape(
                     xiv.shape
                 )
-            self._values = znew
+            self._ensure_correct_values(znew)
 
         else:
             raise ValueError(

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -1121,6 +1121,20 @@ def test_fill(testdata_path):
     assert srf.values.mean() == pytest.approx(1342.10498, abs=0.001)
 
 
+def test_fill_methods():
+    """Fill the undefined values for the surface, various methods"""
+
+    values = np.arange(120)
+    srf = xtgeo.RegularSurface(ncol=12, nrow=10, xinc=10, yinc=10, values=values)
+    srf.values = np.ma.masked_where(srf.values > 110, srf.values)
+
+    for method in ["linear", "cubic", "radial_basis"]:
+        surface = srf.copy()
+        surface.fill(method=method)
+        assert isinstance(surface._values, np.ma.MaskedArray)
+        assert surface.values.mean() == pytest.approx(59, abs=1)
+
+
 def test_smoothing(testdata_path):
     """Smooth the surface using median/gaussian filter"""
 


### PR DESCRIPTION
Resolves #1495 

Fix a bug intruduced in PR #1426 for the RegularSurface `fill()` method 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
