### PR TITLE
ENH: create FileWrapper method for retrieving text stream (#1492)

### DIFF
--- a/src/xtgeo/io/_file.py
+++ b/src/xtgeo/io/_file.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import pathlib
@@ -12,7 +13,9 @@ import uuid
 from enum import Enum
 from os.path import join
 from tempfile import mkstemp
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Generator, Literal, TextIO, Union
+
+from typing_extensions import Self
 
 import xtgeo._cxtgeo
 from xtgeo.common.exceptions import InvalidFileFormatError
@@ -646,3 +649,28 @@ class FileWrapper:
                 return FileFormat.TSURF
 
         return FileFormat.UNKNOWN
+
+    @contextlib.contextmanager
+    def get_text_stream(self: Self) -> Generator[TextIO, None, None]:
+        """
+        Context manager to handle both file paths and file-like objects for reading.
+        Yields:
+            A text stream (TextIO) for reading.
+        Raises:
+            FileNotFoundError: If the file does not exist.
+        """
+
+        if not self.check_file():
+            raise FileNotFoundError(f"\nFile {self.name}:\nThe file does not exist.")
+
+        if isinstance(self.file, pathlib.Path):
+            with open(self.file, "r") as stream:
+                yield stream
+        elif isinstance(self.file, io.BytesIO):
+            with io.TextIOWrapper(self.file) as text_wrapper:
+                text_wrapper.seek(0)
+                yield text_wrapper
+        else:
+            # StringIO is already a text stream
+            self.file.seek(0)
+            yield self.file

--- a/tests/test_io/test_tsurf/test_tsurf_reader.py
+++ b/tests/test_io/test_tsurf/test_tsurf_reader.py
@@ -1,4 +1,4 @@
-from io import BytesIO, StringIO
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -115,55 +115,6 @@ def test_file_string_input(tmp_path: str, complete_tsurf_file) -> None:
     assert result_path is not None
 
 
-def test_file_path_input(tmp_path: Path, complete_tsurf_file) -> None:
-    """Test reading from Path input."""
-    # Test with Path
-    filepath = tmp_path / "test.ts"
-    with open(filepath, "w") as f:
-        f.write(complete_tsurf_file)
-
-    result_path = read_tsurf(filepath)
-    assert result_path is not None
-
-
-def test_file_stringio_input(complete_tsurf_file) -> None:
-    """Test reading from StringIO input."""
-    result_stringio = read_tsurf(tsurf_stream(complete_tsurf_file))
-    assert result_stringio is not None
-
-
-def test_file_bytesio_input(complete_tsurf_file) -> None:
-    """Test reading from BytesIO input."""
-    result_bytesio = read_tsurf(BytesIO(complete_tsurf_file.encode("utf-8")))
-    assert result_bytesio is not None
-
-
-def test_file_non_regular_file_input(tmp_path: Path) -> None:
-    """Test reading from a non-regular file (e.g., folder)."""
-
-    non_regular_file = tmp_path / "some_folder"
-    non_regular_file.mkdir()
-
-    with pytest.raises(FileNotFoundError, match="does not exist"):
-        read_tsurf(non_regular_file)
-
-
-def test_file_other_than_filelike_input() -> None:
-    """Test reading from an unsupported input type."""
-    with pytest.raises(
-        RuntimeError, match="Cannot instantiate <class 'xtgeo.io._file.FileWrapper'>"
-    ):
-        read_tsurf(12345)  # Invalid input type
-
-
-def test_file_empty():
-    """Test that empty file raises error."""
-    with pytest.raises(
-        ValueError, match="does not match format detected from file contents"
-    ):
-        read_tsurf(StringIO(""))
-
-
 def test_file_unusual_suffix(minimal_tsurf_file, tmp_path: Path) -> None:
     """
     Test with unusual file suffix.
@@ -174,13 +125,6 @@ def test_file_unusual_suffix(minimal_tsurf_file, tmp_path: Path) -> None:
         f.write(minimal_tsurf_file)
     result_unusual_suffix = read_tsurf(filepath)
     assert result_unusual_suffix is not None
-
-
-def test_file_non_existent(tmp_path: Path) -> None:
-    """Test with non-existent file."""
-    filepath = tmp_path / "non_existent.ts"
-    with pytest.raises(FileNotFoundError, match="does not exist"):
-        read_tsurf(filepath)
 
 
 def test_comments_and_empty_lines(tmp_path: Path) -> None:


### PR DESCRIPTION
Resolves https://github.com/equinor/xtgeo/issues/1492

Implemented FileWrapper method for creating text stream, including tests.
Removed similar tests from TSurf reader.
Applied FileWrapper method in XYZ io and the TSurf reader.


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
