### PR TITLE
MAINT: implement FileWrapper for welldata rms_ascii

### DIFF
--- a/tests/test_io/test_welldata/test_fformat_rms_ascii.py
+++ b/tests/test_io/test_welldata/test_fformat_rms_ascii.py
@@ -62,10 +62,8 @@ PORO CONT lin
 101.0 201.0 1001.0 0.30
 """
     stream = io.BytesIO(rms_content)
-    # Convert to TextIOWrapper for text reading
-    text_stream = io.TextIOWrapper(stream, encoding="utf-8")
 
-    well = WellData.from_rms_ascii(filepath=text_stream)
+    well = WellData.from_rms_ascii(filepath=stream)
 
     assert well.name == "TestWell"
     assert well.n_records == 2


### PR DESCRIPTION
Resolves #1501 

* Using FileWrapper
* Break RMS ascii read into header and data section


## Checklist

- [ ] Tests added (if not, comment why)  - No new tests
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
