### PR TITLE
MAINT: add csv format support in io/welldata

### DIFF
--- a/src/xtgeo/io/_welldata/_blockedwell_io.py
+++ b/src/xtgeo/io/_welldata/_blockedwell_io.py
@@ -122,6 +122,9 @@ class BlockedWellData(WellData):
         if fformat == WellFileFormat.RMS_ASCII:
             return cls.from_rms_ascii(filepath, **kwargs)
 
+        if fformat == WellFileFormat.CSV:
+            return cls.from_csv(filepath, **kwargs)
+
         raise NotImplementedError(f"File format {fformat} not supported yet.")
 
     def to_file(
@@ -133,6 +136,10 @@ class BlockedWellData(WellData):
         """Write blocked well data to file with format selection."""
         if fformat == WellFileFormat.RMS_ASCII:
             self.to_rms_ascii(filepath, **kwargs)
+            return
+
+        if fformat == WellFileFormat.CSV:
+            self.to_csv(filepath, **kwargs)
             return
 
         raise NotImplementedError(f"File format {fformat} not supported yet.")
@@ -157,4 +164,25 @@ class BlockedWellData(WellData):
             blocked_well=self,
             filepath=filepath,
             precision=precision,
+        )
+
+    @classmethod
+    def from_csv(cls, filepath: FileLike, **kwargs: Any) -> BlockedWellData:
+        """Read blocked well data from CSV file."""
+        from xtgeo.io._welldata._fformats._csv_table import read_csv_blockedwell
+
+        return read_csv_blockedwell(filepath=filepath, **kwargs)
+
+    def to_csv(
+        self,
+        filepath: FileLike,
+        **kwargs: Any,
+    ) -> None:
+        """Write blocked well data to CSV file."""
+        from xtgeo.io._welldata._fformats._csv_table import write_csv_blockedwell
+
+        write_csv_blockedwell(
+            blocked_well=self,
+            filepath=filepath,
+            **kwargs,
         )

--- a/src/xtgeo/io/_welldata/_fformats/_csv_table.py
+++ b/src/xtgeo/io/_welldata/_fformats/_csv_table.py
@@ -1,0 +1,422 @@
+"""CSV I/O for well data and blocked well data."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from xtgeo.common.log import null_logger
+from xtgeo.io._file import FileWrapper
+from xtgeo.io._welldata._blockedwell_io import BlockedWellData
+from xtgeo.io._welldata._well_io import WellData, WellLog
+
+if TYPE_CHECKING:  # pragma: no cover
+    from xtgeo.common.types import FileLike
+
+logger = null_logger(__name__)
+
+
+def _read_and_filter_csv(
+    wrapper: FileWrapper,
+    wellname: str | None,
+    wellname_col: str,
+    required_cols: list[str],
+) -> tuple[pd.DataFrame, str]:
+    """Helper function to read CSV and filter by wellname.
+
+    Args:
+        wrapper: FileWrapper for the CSV file
+        wellname: Name of the well to extract. If None, uses the first well found.
+        wellname_col: Column name for well name
+        required_cols: List of required column names
+
+    Returns:
+        Tuple of (filtered DataFrame, actual wellname used)
+
+    Raises:
+        ValueError: If required columns are missing or wellname not found
+    """
+    with wrapper.get_text_stream_read() as fwell:
+        df = pd.read_csv(fwell)
+
+    has_wellname_col = wellname_col in df.columns  # Check if wellname_col exists
+
+    # Validate required columns (excluding wellname_col if not present)
+    required_cols_to_check = [
+        col for col in required_cols if col != wellname_col or has_wellname_col
+    ]
+    missing_cols = [col for col in required_cols_to_check if col not in df.columns]
+    if missing_cols:
+        raise ValueError(
+            f"Missing required columns in CSV file: {', '.join(missing_cols)}"
+        )
+
+    # If wellname column doesn't exist, treat as single-well file
+    if not has_wellname_col:
+        if wellname is not None:
+            logger.warning(
+                f"Column '{wellname_col}' not found in CSV. "
+                f"Treating as single-well file and using provided wellname '{wellname}'"
+            )
+            actual_wellname = wellname
+        else:
+            actual_wellname = str(wrapper.name) if wrapper.name else "UNKNOWN"
+            logger.debug(
+                f"Column '{wellname_col}' not found. Using filename as wellname: "
+                f"'{actual_wellname}'"
+            )
+        return df, actual_wellname
+
+    if wellname is None:
+        available_wells = df[wellname_col].unique().tolist()
+        if len(available_wells) == 0:
+            raise ValueError(f"No wells found in CSV file (column '{wellname_col}')")
+        wellname = available_wells[0]
+        logger.debug(
+            f"No wellname specified, using first well: '{wellname}' "
+            f"(available: {available_wells})"
+        )
+
+    # Filter by wellname
+    well_data = df[df[wellname_col] == wellname]
+
+    if well_data.empty:
+        available_wells = df[wellname_col].unique().tolist()
+        raise ValueError(
+            f"Well '{wellname}' not found in CSV file. "
+            f"Available wells: {', '.join(map(str, available_wells))}"
+        )
+
+    return well_data, wellname
+
+
+def _extract_logs(
+    well_data: pd.DataFrame,
+    excluded_cols: list[str],
+) -> tuple[WellLog, ...]:
+    """Helper function to extract well logs from DataFrame.
+
+    Args:
+        well_data: DataFrame containing well data
+        excluded_cols: List of column names to exclude (coordinates, indices, etc.)
+
+    Returns:
+        Tuple of WellLog objects
+    """
+    log_cols = [col for col in well_data.columns if col not in excluded_cols]
+
+    logs = []
+    for log_name in log_cols:
+        values = well_data[log_name].to_numpy(dtype=np.float64)
+
+        # Try to determine if this is a discrete or continuous log
+        # If all non-NaN values are integers, treat as discrete
+        is_discrete = False
+        if not np.all(np.isnan(values)):
+            non_nan_values = values[~np.isnan(values)]
+            if np.allclose(non_nan_values, np.round(non_nan_values)):
+                is_discrete = True
+
+        log = WellLog(name=log_name, values=values, is_discrete=is_discrete)
+        logs.append(log)
+
+    return tuple(logs)
+
+
+def read_csv_well(
+    filepath: FileLike,
+    wellname: str | None = None,
+    xname: str = "X_UTME",
+    yname: str = "Y_UTMN",
+    zname: str = "Z_TVDSS",
+    wellname_col: str = "WELLNAME",
+) -> WellData:
+    """Read well data from CSV file or stream.
+
+    The CSV file can contain data for multiple wells. This function extracts data
+    for a specific well by filtering on the wellname column. If the wellname column
+    doesn't exist, treats it as a single-well file.
+
+    Args:
+        filepath: Path to CSV file or a file-like stream object
+        wellname: Name of the well to extract from the CSV file. If None, uses the
+            first well found in the file (or filename if no wellname column exists).
+        xname: Column name for X coordinates (default: "X_UTME")
+        yname: Column name for Y coordinates (default: "Y_UTMN")
+        zname: Column name for Z coordinates (default: "Z_TVDSS")
+        wellname_col: Column name for well name (default: "WELLNAME")
+
+    Returns:
+        WellData object
+
+    Raises:
+        ValueError: If required columns are missing or wellname not found
+
+    Example:
+        >>> from xtgeo.io._welldata._fformats._csv_table import read_csv_well
+        >>> well = read_csv_well("well.csv", wellname="WELL-1")
+        >>> print(f"Well: {well.name}, Records: {well.n_records}")
+    """
+    wrapper = FileWrapper(filepath, mode="r")
+
+    logger.debug("Reading well data from CSV: %s", wrapper.name)
+
+    # Read and filter CSV data
+    required_cols = [xname, yname, zname, wellname_col]
+    df, actual_wellname = _read_and_filter_csv(
+        wrapper, wellname, wellname_col, required_cols
+    )
+
+    survey_x = df[xname].to_numpy(dtype=np.float64)
+    survey_y = df[yname].to_numpy(dtype=np.float64)
+    survey_z = df[zname].to_numpy(dtype=np.float64)
+
+    xpos = float(survey_x[0])
+    ypos = float(survey_y[0])
+    zpos = float(survey_z[0])
+
+    excluded_cols = [xname, yname, zname, wellname_col]
+    logs = _extract_logs(df, excluded_cols)
+
+    well = WellData(
+        name=actual_wellname,
+        xpos=xpos,
+        ypos=ypos,
+        zpos=zpos,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=logs,
+    )
+
+    logger.debug(
+        "Successfully read well '%s' with %d records and %d logs",
+        actual_wellname,
+        well.n_records,
+        len(logs),
+    )
+
+    return well
+
+
+def write_csv_well(
+    well: WellData,
+    filepath: FileLike,
+    xname: str = "X_UTME",
+    yname: str = "Y_UTMN",
+    zname: str = "Z_TVDSS",
+    wellname_col: str = "WELLNAME",
+    include_header: bool = True,
+) -> None:
+    """Write well data to CSV file or stream.
+
+    Args:
+        well: WellData object to write
+        filepath: Output CSV file path or a file-like stream object
+        xname: Column name for X coordinates (default: "X_UTME")
+        yname: Column name for Y coordinates (default: "Y_UTMN")
+        zname: Column name for Z coordinates (default: "Z_TVDSS")
+        wellname_col: Column name for well name (default: "WELLNAME")
+        include_header: Whether to include column headers (default: True)
+
+    Example:
+        >>> from xtgeo.io._welldata._fformats._csv_table import write_csv_well
+        >>> write_csv_well(well, "output.csv")
+    """
+    wrapper = FileWrapper(filepath, mode="w")
+
+    logger.debug("Writing well data to CSV: %s", wrapper.name)
+
+    data = {
+        xname: well.survey_x,
+        yname: well.survey_y,
+        zname: well.survey_z,
+        wellname_col: [well.name] * well.n_records,
+    }
+
+    for log in well.logs:
+        data[log.name] = log.values
+
+    df = pd.DataFrame(data)
+
+    with wrapper.get_text_stream_write() as fwell_write:
+        df.to_csv(fwell_write, index=False, header=include_header)
+
+    logger.debug(
+        "Successfully wrote well '%s' with %d records to %s",
+        well.name,
+        well.n_records,
+        wrapper.name,
+    )
+
+
+def read_csv_blockedwell(
+    filepath: FileLike,
+    wellname: str | None = None,
+    xname: str = "X_UTME",
+    yname: str = "Y_UTMN",
+    zname: str = "Z_TVDSS",
+    i_indexname: str = "I_INDEX",
+    j_indexname: str = "J_INDEX",
+    k_indexname: str = "K_INDEX",
+    wellname_col: str = "WELLNAME",
+) -> BlockedWellData:
+    """Read blocked well data from CSV file.
+
+    The CSV file can contain data for multiple wells. This function extracts data
+    for a specific well by filtering on the wellname column. If the wellname column
+    doesn't exist, treats it as a single-well file.
+
+    Args:
+        filepath: Path to CSV file
+        wellname: Name of the well to extract from the CSV file. If None, uses the
+            first well found in the file (or filename if no wellname column exists).
+        xname: Column name for X coordinates (default: "X_UTME")
+        yname: Column name for Y coordinates (default: "Y_UTMN")
+        zname: Column name for Z coordinates (default: "Z_TVDSS")
+        i_indexname: Column name for I-indices (default: "I_INDEX")
+        j_indexname: Column name for J-indices (default: "J_INDEX")
+        k_indexname: Column name for K-indices (default: "K_INDEX")
+        wellname_col: Column name for well name (default: "WELLNAME")
+
+    Returns:
+        BlockedWellData object
+
+    Raises:
+        ValueError: If required columns are missing or wellname not found
+
+    Example:
+        >>> from xtgeo.io._welldata._fformats._csv_table import read_csv_blockedwell
+        >>> blocked_well = read_csv_blockedwell("blocked_well.csv", wellname="WELL-1")
+        >>> print(f"Well: {blocked_well.name}, Records: {blocked_well.n_records}")
+    """
+    wrapper = FileWrapper(filepath, mode="r")
+
+    logger.debug("Reading blocked well data from CSV: %s", wrapper.name)
+
+    # Read and filter CSV data
+    required_cols = [
+        xname,
+        yname,
+        zname,
+        i_indexname,
+        j_indexname,
+        k_indexname,
+        wellname_col,
+    ]
+    df, actual_wellname = _read_and_filter_csv(
+        wrapper, wellname, wellname_col, required_cols
+    )
+
+    # Extract survey data
+    survey_x = df[xname].to_numpy(dtype=np.float64)
+    survey_y = df[yname].to_numpy(dtype=np.float64)
+    survey_z = df[zname].to_numpy(dtype=np.float64)
+
+    # Extract grid indices
+    i_index = df[i_indexname].to_numpy(dtype=np.float64)
+    j_index = df[j_indexname].to_numpy(dtype=np.float64)
+    k_index = df[k_indexname].to_numpy(dtype=np.float64)
+
+    # Well header position from first record
+    xpos = float(survey_x[0])
+    ypos = float(survey_y[0])
+    zpos = float(survey_z[0])
+
+    # Extract logs (all columns except coordinates, indices, and wellname)
+    excluded_cols = [
+        xname,
+        yname,
+        zname,
+        i_indexname,
+        j_indexname,
+        k_indexname,
+        wellname_col,
+    ]
+    logs = _extract_logs(df, excluded_cols)
+
+    blocked_well = BlockedWellData(
+        name=actual_wellname,
+        xpos=xpos,
+        ypos=ypos,
+        zpos=zpos,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=logs,
+        i_index=i_index,
+        j_index=j_index,
+        k_index=k_index,
+    )
+
+    logger.debug(
+        "Successfully read blocked well '%s' with %d records and %d logs",
+        actual_wellname,
+        blocked_well.n_records,
+        len(logs),
+    )
+
+    return blocked_well
+
+
+def write_csv_blockedwell(
+    blocked_well: BlockedWellData,
+    filepath: FileLike,
+    xname: str = "X_UTME",
+    yname: str = "Y_UTMN",
+    zname: str = "Z_TVDSS",
+    i_indexname: str = "I_INDEX",
+    j_indexname: str = "J_INDEX",
+    k_indexname: str = "K_INDEX",
+    wellname_col: str = "WELLNAME",
+    include_header: bool = True,
+) -> None:
+    """Write blocked well data to CSV file.
+
+    Args:
+        blocked_well: BlockedWellData object to write
+        filepath: Output CSV file path
+        xname: Column name for X coordinates (default: "X_UTME")
+        yname: Column name for Y coordinates (default: "Y_UTMN")
+        zname: Column name for Z coordinates (default: "Z_TVDSS")
+        i_indexname: Column name for I-indices (default: "I_INDEX")
+        j_indexname: Column name for J-indices (default: "J_INDEX")
+        k_indexname: Column name for K-indices (default: "K_INDEX")
+        wellname_col: Column name for well name (default: "WELLNAME")
+        include_header: Whether to include column headers (default: True)
+
+    Example:
+        >>> from xtgeo.io._welldata._fformats._csv_table import write_csv_blockedwell
+        >>> write_csv_blockedwell(blocked_well, "output.csv")
+    """
+    wrapper = FileWrapper(filepath, mode="w")
+
+    logger.debug("Writing blocked well data to CSV: %s", wrapper.name)
+
+    # Create DataFrame with coordinates, indices, and wellname
+    data = {
+        xname: blocked_well.survey_x,
+        yname: blocked_well.survey_y,
+        zname: blocked_well.survey_z,
+        i_indexname: blocked_well.i_index,
+        j_indexname: blocked_well.j_index,
+        k_indexname: blocked_well.k_index,
+        wellname_col: [blocked_well.name] * blocked_well.n_records,
+    }
+
+    for log in blocked_well.logs:
+        data[log.name] = log.values
+
+    df = pd.DataFrame(data)
+
+    with wrapper.get_text_stream_write() as fwell_write:
+        df.to_csv(fwell_write, index=False, header=include_header)
+
+    logger.debug(
+        "Successfully wrote blocked well '%s' with %d records to %s",
+        blocked_well.name,
+        blocked_well.n_records,
+        wrapper.name,
+    )

--- a/tests/test_io/test_welldata/test_fformat_csv.py
+++ b/tests/test_io/test_welldata/test_fformat_csv.py
@@ -1,0 +1,613 @@
+"""Tests for CSV format I/O for WellData and BlockedWellData."""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+from xtgeo.io._welldata._blockedwell_io import BlockedWellData
+from xtgeo.io._welldata._well_io import WellData, WellFileFormat, WellLog
+
+
+@pytest.fixture
+def sample_csv_well_file(tmp_path):
+    """Create a sample CSV file for testing WellData I/O."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,PHIT,PERM
+464789.0625,6553551.625,1620.5,0.326,125.5
+464789.0625,6553551.625,1621.5,0.316,98.2
+464789.0625,6553551.625,1622.5,0.318,105.7
+464789.0625,6553551.625,1623.5,0.315,92.3
+464789.0625,6553551.625,1624.5,0.307,85.1
+"""
+    csv_file = tmp_path / "test_well.csv"
+    csv_file.write_text(csv_content)
+    return csv_file
+
+
+@pytest.fixture
+def sample_csv_blockedwell_file(tmp_path):
+    """Create a sample CSV file for testing BlockedWellData I/O."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,I_INDEX,J_INDEX,K_INDEX,PHIT,PERM
+464789.0625,6553551.625,1620.5,109,115,0,0.326,125.5
+464789.0625,6553551.625,1621.5,109,115,1,0.316,98.2
+464789.0625,6553551.625,1622.5,109,115,2,0.318,105.7
+464789.0625,6553551.625,1623.5,109,115,3,0.315,92.3
+464789.0625,6553551.625,1624.5,109,115,4,0.307,85.1
+"""
+    csv_file = tmp_path / "test_blockedwell.csv"
+    csv_file.write_text(csv_content)
+    return csv_file
+
+
+def test_welldata_from_file_csv_format(sample_csv_well_file):
+    """Test reading WellData using from_file method with fformat='csv'."""
+    well = WellData.from_file(
+        filepath=sample_csv_well_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    assert well.n_records == 5
+
+    assert well.xpos == pytest.approx(464789.0625)
+    assert well.ypos == pytest.approx(6553551.625)
+    assert well.zpos == pytest.approx(1620.5)
+
+    assert len(well.survey_x) == 5
+    assert len(well.survey_y) == 5
+    assert len(well.survey_z) == 5
+
+    assert np.all(well.survey_x == 464789.0625)
+    assert np.all(well.survey_y == 6553551.625)
+
+    expected_z = np.array([1620.5, 1621.5, 1622.5, 1623.5, 1624.5])
+    np.testing.assert_array_almost_equal(well.survey_z, expected_z)
+
+    assert len(well.logs) == 2
+    assert "PHIT" in well.log_names
+    assert "PERM" in well.log_names
+
+    phit = well.get_log("PHIT")
+    assert phit is not None
+    assert phit.name == "PHIT"
+    assert not phit.is_discrete
+    assert len(phit.values) == 5
+    expected_phit = np.array([0.326, 0.316, 0.318, 0.315, 0.307])
+    np.testing.assert_array_almost_equal(phit.values, expected_phit)
+
+    perm = well.get_log("PERM")
+    assert perm is not None
+    assert perm.name == "PERM"
+    assert not perm.is_discrete
+    assert len(perm.values) == 5
+    expected_perm = np.array([125.5, 98.2, 105.7, 92.3, 85.1])
+    np.testing.assert_array_almost_equal(perm.values, expected_perm)
+
+
+def test_blockedwell_from_file_csv_format(sample_csv_blockedwell_file):
+    """Test reading BlockedWellData using from_file method with fformat='csv'."""
+    well = BlockedWellData.from_file(
+        filepath=sample_csv_blockedwell_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    assert well.n_records == 5
+    assert well.n_blocked_cells == 5
+
+    assert well.xpos == pytest.approx(464789.0625)
+    assert well.ypos == pytest.approx(6553551.625)
+    assert well.zpos == pytest.approx(1620.5)
+
+    assert len(well.survey_x) == 5
+    assert len(well.survey_y) == 5
+    assert len(well.survey_z) == 5
+
+    assert len(well.i_index) == 5
+    assert len(well.j_index) == 5
+    assert len(well.k_index) == 5
+
+    assert np.all(well.i_index == 109)
+    assert np.all(well.j_index == 115)
+
+    expected_k = np.array([0, 1, 2, 3, 4], dtype=np.float64)
+    np.testing.assert_array_equal(well.k_index, expected_k)
+
+    assert len(well.logs) == 2
+    assert "PHIT" in well.log_names
+    assert "PERM" in well.log_names
+
+    phit = well.get_log("PHIT")
+    assert phit is not None
+    expected_phit = np.array([0.326, 0.316, 0.318, 0.315, 0.307])
+    np.testing.assert_array_almost_equal(phit.values, expected_phit)
+
+
+def test_welldata_roundtrip_csv(sample_csv_well_file, tmp_path):
+    """Test that reading and writing WellData preserves data."""
+    well1 = WellData.from_file(
+        filepath=sample_csv_well_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    output_file = tmp_path / "roundtrip.csv"
+    well1.to_file(filepath=output_file, fformat=WellFileFormat.CSV)
+
+    well2 = WellData.from_file(
+        filepath=output_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    assert well1.n_records == well2.n_records
+    np.testing.assert_array_almost_equal(well1.survey_x, well2.survey_x)
+    np.testing.assert_array_almost_equal(well1.survey_y, well2.survey_y)
+    np.testing.assert_array_almost_equal(well1.survey_z, well2.survey_z)
+
+    assert len(well1.logs) == len(well2.logs)
+    for log1, log2 in zip(well1.logs, well2.logs):
+        assert log1.name == log2.name
+        np.testing.assert_array_almost_equal(log1.values, log2.values)
+
+
+def test_blockedwell_roundtrip_csv(sample_csv_blockedwell_file, tmp_path):
+    """Test that reading and writing BlockedWellData preserves data."""
+    well1 = BlockedWellData.from_file(
+        filepath=sample_csv_blockedwell_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    output_file = tmp_path / "roundtrip_blocked.csv"
+    well1.to_file(filepath=output_file, fformat=WellFileFormat.CSV)
+
+    well2 = BlockedWellData.from_file(
+        filepath=output_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    assert well1.n_records == well2.n_records
+    assert well1.n_blocked_cells == well2.n_blocked_cells
+
+    np.testing.assert_array_almost_equal(well1.survey_x, well2.survey_x)
+    np.testing.assert_array_almost_equal(well1.survey_y, well2.survey_y)
+    np.testing.assert_array_almost_equal(well1.survey_z, well2.survey_z)
+
+    np.testing.assert_array_almost_equal(well1.i_index, well2.i_index)
+    np.testing.assert_array_almost_equal(well1.j_index, well2.j_index)
+    np.testing.assert_array_almost_equal(well1.k_index, well2.k_index)
+
+    assert len(well1.logs) == len(well2.logs)
+    for log1, log2 in zip(well1.logs, well2.logs):
+        assert log1.name == log2.name
+        np.testing.assert_array_almost_equal(log1.values, log2.values)
+
+
+def test_welldata_from_csv_custom_columns(tmp_path):
+    """Test reading WellData with custom column names."""
+    csv_content = """EASTING,NORTHING,DEPTH,POR,K
+100.0,200.0,1000.0,0.25,150.0
+100.0,200.0,1001.0,0.30,200.0
+100.0,200.0,1002.0,0.28,175.0
+"""
+    csv_file = tmp_path / "custom_columns.csv"
+    csv_file.write_text(csv_content)
+
+    well = WellData.from_csv(
+        filepath=csv_file,
+        xname="EASTING",
+        yname="NORTHING",
+        zname="DEPTH",
+    )
+
+    assert well.n_records == 3
+    assert well.xpos == 100.0
+    assert well.ypos == 200.0
+    assert well.zpos == 1000.0
+
+    assert len(well.logs) == 2
+    assert "POR" in well.log_names
+    assert "K" in well.log_names
+
+
+def test_blockedwell_from_csv_custom_columns(tmp_path):
+    """Test reading BlockedWellData with custom column names."""
+    csv_content = """EASTING,NORTHING,DEPTH,I,J,K,POR
+100.0,200.0,1000.0,10,20,1,0.25
+100.0,200.0,1001.0,10,20,2,0.30
+100.0,200.0,1002.0,10,20,3,0.28
+"""
+    csv_file = tmp_path / "custom_blocked.csv"
+    csv_file.write_text(csv_content)
+
+    well = BlockedWellData.from_csv(
+        filepath=csv_file,
+        xname="EASTING",
+        yname="NORTHING",
+        zname="DEPTH",
+        i_indexname="I",
+        j_indexname="J",
+        k_indexname="K",
+    )
+
+    assert well.n_records == 3
+    assert well.n_blocked_cells == 3
+
+    assert np.all(well.i_index == 10)
+    assert np.all(well.j_index == 20)
+    expected_k = np.array([1, 2, 3], dtype=np.float64)
+    np.testing.assert_array_equal(well.k_index, expected_k)
+
+
+def test_welldata_to_file_csv_format(tmp_path):
+    """Test writing WellData with to_file method."""
+    well = WellData(
+        name="TestWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=np.array([100.0, 100.0, 100.0]),
+        survey_y=np.array([200.0, 200.0, 200.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(),
+    )
+
+    output_file = tmp_path / "output.csv"
+    well.to_file(filepath=output_file, fformat=WellFileFormat.CSV)
+
+    assert output_file.exists()
+
+    well2 = WellData.from_file(
+        filepath=output_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    assert well2.n_records == 3
+    np.testing.assert_array_almost_equal(well2.survey_z, well.survey_z)
+
+
+def test_blockedwell_to_file_csv_format(tmp_path):
+    """Test writing BlockedWellData with to_file method."""
+    well = BlockedWellData(
+        name="TestWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=np.array([100.0, 100.0, 100.0]),
+        survey_y=np.array([200.0, 200.0, 200.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        i_index=np.array([10.0, 10.0, 11.0]),
+        j_index=np.array([20.0, 20.0, 21.0]),
+        k_index=np.array([1.0, 2.0, 3.0]),
+        logs=(),
+    )
+
+    output_file = tmp_path / "output_blocked.csv"
+    well.to_file(filepath=output_file, fformat=WellFileFormat.CSV)
+
+    assert output_file.exists()
+
+    well2 = BlockedWellData.from_file(
+        filepath=output_file,
+        fformat=WellFileFormat.CSV,
+    )
+
+    assert well2.n_records == 3
+    np.testing.assert_array_almost_equal(well2.i_index, well.i_index)
+    np.testing.assert_array_almost_equal(well2.k_index, well.k_index)
+
+
+def test_welldata_csv_from_stringio():
+    """Test reading CSV WellData from StringIO stream."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,PHIT,PERM
+100.0,200.0,1000.0,0.25,150.0
+101.0,201.0,1001.0,0.30,200.0
+102.0,202.0,1002.0,0.28,175.0
+"""
+    stream = io.StringIO(csv_content)
+    well = WellData.from_csv(filepath=stream)
+
+    assert well.n_records == 3
+    assert well.xpos == pytest.approx(100.0)
+
+    phit = well.get_log("PHIT")
+    np.testing.assert_array_almost_equal(phit.values, [0.25, 0.30, 0.28])
+
+
+def test_welldata_csv_to_stringio():
+    """Test writing CSV WellData to StringIO stream."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    poro_log = WellLog(
+        name="Poro", values=np.array([0.25, 0.30, 0.28]), is_discrete=False
+    )
+
+    well = WellData(
+        name="STREAM_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(poro_log,),
+    )
+
+    stream = io.StringIO()
+    well.to_csv(filepath=stream)
+
+    stream.seek(0)
+    well2 = WellData.from_csv(filepath=stream)
+
+    assert well2.n_records == 3
+    np.testing.assert_array_almost_equal(well2.survey_x, survey_x)
+
+
+def test_blockedwell_csv_from_stringio():
+    """Test reading CSV BlockedWellData from StringIO stream."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,I_INDEX,J_INDEX,K_INDEX,PHIT
+100.0,200.0,1000.0,10,20,1,0.25
+101.0,201.0,1001.0,10,20,2,0.30
+102.0,202.0,1002.0,10,20,3,0.28
+"""
+    stream = io.StringIO(csv_content)
+    well = BlockedWellData.from_csv(filepath=stream)
+
+    assert well.n_records == 3
+    np.testing.assert_array_equal(well.i_index, [10.0, 10.0, 10.0])
+    np.testing.assert_array_equal(well.k_index, [1.0, 2.0, 3.0])
+
+
+def test_blockedwell_csv_to_stringio():
+    """Test writing CSV BlockedWellData to StringIO stream."""
+    survey_x = np.array([100.0, 101.0, 102.0])
+    survey_y = np.array([200.0, 201.0, 202.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+    i_index = np.array([10.0, 10.0, 10.0])
+    j_index = np.array([20.0, 20.0, 20.0])
+    k_index = np.array([1.0, 2.0, 3.0])
+
+    poro_log = WellLog(
+        name="Poro", values=np.array([0.25, 0.30, 0.28]), is_discrete=False
+    )
+
+    well = BlockedWellData(
+        name="BW_STREAM",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        i_index=i_index,
+        j_index=j_index,
+        k_index=k_index,
+        logs=(poro_log,),
+    )
+
+    stream = io.StringIO()
+    well.to_csv(filepath=stream)
+
+    stream.seek(0)
+    well2 = BlockedWellData.from_csv(filepath=stream)
+
+    assert well2.n_records == 3
+    np.testing.assert_array_equal(well2.i_index, i_index)
+    np.testing.assert_array_equal(well2.k_index, k_index)
+
+
+def test_welldata_csv_missing_required_columns(tmp_path):
+    """Test that reading CSV with missing required columns raises ValueError."""
+    csv_content = """X_UTME,PHIT
+100.0,0.25
+101.0,0.26
+"""
+    csv_file = tmp_path / "missing_cols.csv"
+    csv_file.write_text(csv_content)
+
+    with pytest.raises(ValueError, match="Missing required columns"):
+        WellData.from_csv(csv_file)
+
+
+def test_blockedwell_csv_missing_required_columns(tmp_path):
+    """Test that reading blocked well CSV with missing columns raises ValueError."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,PHIT
+100.0,200.0,1000.0,0.25
+101.0,201.0,1001.0,0.26
+"""
+    csv_file = tmp_path / "missing_blocked_cols.csv"
+    csv_file.write_text(csv_content)
+
+    with pytest.raises(ValueError, match="Missing required columns"):
+        BlockedWellData.from_csv(csv_file)
+
+
+def test_welldata_with_discrete_log(tmp_path):
+    """Test that integer-valued logs are detected as discrete."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,FACIES,PHIT
+100.0,200.0,1000.0,1,0.25
+100.0,200.0,1001.0,2,0.30
+100.0,200.0,1002.0,1,0.28
+"""
+    csv_file = tmp_path / "with_facies.csv"
+    csv_file.write_text(csv_content)
+
+    well = WellData.from_csv(csv_file)
+
+    facies = well.get_log("FACIES")
+    assert facies is not None
+    assert facies.is_discrete
+
+    phit = well.get_log("PHIT")
+    assert phit is not None
+    assert not phit.is_discrete
+
+
+def test_welldata_csv_write_with_logs(tmp_path):
+    """Test writing WellData with multiple logs."""
+    survey_x = np.array([100.0, 100.0, 100.0])
+    survey_y = np.array([200.0, 200.0, 200.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+
+    phit_log = WellLog(
+        name="PHIT", values=np.array([0.25, 0.30, 0.28]), is_discrete=False
+    )
+    perm_log = WellLog(
+        name="PERM", values=np.array([100.0, 150.0, 125.0]), is_discrete=False
+    )
+
+    well = WellData(
+        name="MULTI_LOG_WELL",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=(phit_log, perm_log),
+    )
+
+    output_file = tmp_path / "multi_log.csv"
+    well.to_csv(filepath=output_file)
+
+    well2 = WellData.from_csv(output_file)
+    assert len(well2.logs) == 2
+    assert "PHIT" in well2.log_names
+    assert "PERM" in well2.log_names
+
+    phit2 = well2.get_log("PHIT")
+    np.testing.assert_array_almost_equal(phit2.values, phit_log.values)
+
+
+def test_blockedwell_csv_write_with_logs(tmp_path):
+    """Test writing BlockedWellData with multiple logs."""
+    survey_x = np.array([100.0, 100.0, 100.0])
+    survey_y = np.array([200.0, 200.0, 200.0])
+    survey_z = np.array([1000.0, 1001.0, 1002.0])
+    i_index = np.array([10.0, 10.0, 10.0])
+    j_index = np.array([20.0, 20.0, 20.0])
+    k_index = np.array([1.0, 2.0, 3.0])
+
+    phit_log = WellLog(
+        name="PHIT", values=np.array([0.25, 0.30, 0.28]), is_discrete=False
+    )
+
+    well = BlockedWellData(
+        name="BLOCKED_MULTI_LOG",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=1000.0,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        i_index=i_index,
+        j_index=j_index,
+        k_index=k_index,
+        logs=(phit_log,),
+    )
+
+    output_file = tmp_path / "blocked_multi_log.csv"
+    well.to_csv(filepath=output_file)
+
+    well2 = BlockedWellData.from_csv(output_file)
+    assert len(well2.logs) == 1
+    assert "PHIT" in well2.log_names
+    np.testing.assert_array_equal(well2.i_index, i_index)
+
+
+def test_welldata_multiwell_csv_filter_by_wellname(tmp_path):
+    """Test reading specific well from multi-well CSV file."""
+    csv_content = """WELLNAME,X_UTME,Y_UTMN,Z_TVDSS,PHIT
+WELL-1,100.0,200.0,1000.0,0.25
+WELL-1,100.0,200.0,1001.0,0.26
+WELL-2,150.0,250.0,1500.0,0.30
+WELL-2,150.0,250.0,1501.0,0.32
+WELL-3,200.0,300.0,2000.0,0.28
+"""
+    csv_file = tmp_path / "multiwell.csv"
+    csv_file.write_text(csv_content)
+
+    well1 = WellData.from_csv(csv_file, wellname="WELL-1")
+    assert well1.name == "WELL-1"
+    assert well1.n_records == 2
+    assert well1.xpos == pytest.approx(100.0)
+    np.testing.assert_array_almost_equal(well1.survey_z, [1000.0, 1001.0])
+
+    well2 = WellData.from_csv(csv_file, wellname="WELL-2")
+    assert well2.name == "WELL-2"
+    assert well2.n_records == 2
+    assert well2.xpos == pytest.approx(150.0)
+    np.testing.assert_array_almost_equal(well2.survey_z, [1500.0, 1501.0])
+
+    well3 = WellData.from_csv(csv_file, wellname="WELL-3")
+    assert well3.name == "WELL-3"
+    assert well3.n_records == 1
+    assert well3.xpos == pytest.approx(200.0)
+
+
+def test_welldata_multiwell_csv_auto_select_first(tmp_path):
+    """Test that first well is selected when wellname is None."""
+    csv_content = """WELLNAME,X_UTME,Y_UTMN,Z_TVDSS,PHIT
+WELL-2,150.0,250.0,1500.0,0.30
+WELL-2,150.0,250.0,1501.0,0.32
+WELL-1,100.0,200.0,1000.0,0.25
+WELL-1,100.0,200.0,1001.0,0.26
+"""
+    csv_file = tmp_path / "multiwell_order.csv"
+    csv_file.write_text(csv_content)
+
+    well = WellData.from_csv(csv_file, wellname=None)
+    assert well.name == "WELL-2"
+    assert well.n_records == 2
+
+
+def test_welldata_multiwell_csv_nonexistent_well(tmp_path):
+    """Test error when requesting non-existent well."""
+    csv_content = """WELLNAME,X_UTME,Y_UTMN,Z_TVDSS,PHIT
+WELL-1,100.0,200.0,1000.0,0.25
+WELL-2,150.0,250.0,1500.0,0.30
+"""
+    csv_file = tmp_path / "multiwell.csv"
+    csv_file.write_text(csv_content)
+
+    with pytest.raises(ValueError, match="Well 'WELL-999' not found"):
+        WellData.from_csv(csv_file, wellname="WELL-999")
+
+
+def test_blockedwell_multiwell_csv_filter(tmp_path):
+    """Test reading specific blocked well from multi-well CSV file."""
+    csv_content = """WELLNAME,X_UTME,Y_UTMN,Z_TVDSS,I_INDEX,J_INDEX,K_INDEX,PHIT
+WELL-A,100.0,200.0,1000.0,10,20,1,0.25
+WELL-A,100.0,200.0,1001.0,10,20,2,0.26
+WELL-B,150.0,250.0,1500.0,15,25,1,0.30
+WELL-B,150.0,250.0,1501.0,15,25,2,0.32
+"""
+    csv_file = tmp_path / "multiwell_blocked.csv"
+    csv_file.write_text(csv_content)
+
+    well_a = BlockedWellData.from_csv(csv_file, wellname="WELL-A")
+    assert well_a.name == "WELL-A"
+    assert well_a.n_records == 2
+    np.testing.assert_array_equal(well_a.i_index, [10.0, 10.0])
+    np.testing.assert_array_equal(well_a.k_index, [1.0, 2.0])
+
+    well_b = BlockedWellData.from_csv(csv_file, wellname="WELL-B")
+    assert well_b.name == "WELL-B"
+    assert well_b.n_records == 2
+    np.testing.assert_array_equal(well_b.i_index, [15.0, 15.0])
+    np.testing.assert_array_equal(well_b.k_index, [1.0, 2.0])
+
+
+def test_welldata_singlewell_csv_no_wellname_column(tmp_path):
+    """Test reading single-well CSV without WELLNAME column (backward compatibility)."""
+    csv_content = """X_UTME,Y_UTMN,Z_TVDSS,PHIT
+100.0,200.0,1000.0,0.25
+100.0,200.0,1001.0,0.26
+100.0,200.0,1002.0,0.28
+"""
+    csv_file = tmp_path / "singlewell_no_name.csv"
+    csv_file.write_text(csv_content)
+
+    well = WellData.from_csv(csv_file)
+    assert well.n_records == 3
+    assert "singlewell_no_name" in well.name or well.name == "UNKNOWN"


### PR DESCRIPTION
Resolves #1506 

Add CSV read/write to xtgeo/io for welldata. Note currently that CSV's with multiple wells records can be read, but
writing such stacked files is not (yet) implemented (may possibly require a fix in FileWrapper allowing append mode)

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
