### PR TITLE
BUG: Fix removal of undef values in logs

### DIFF
--- a/tests/test_well/test_well_xyzdata_class.py
+++ b/tests/test_well/test_well_xyzdata_class.py
@@ -43,6 +43,7 @@ def test_well_xyzdata_ensure_attr(generate_data: pd.DataFrame):
     assert instance.get_attr_type("FACIES") == "CONT"
     assert instance.get_attr_record("FACIES") == ("", "")
 
+    # Change FACIES attribute type from CONT to DISC
     instance.set_attr_type("FACIES", "DISC")
     assert instance.get_attr_record("FACIES") == {1: "1", 3: "3", 4: "4"}
 


### PR DESCRIPTION
Resolves #1516

Ensure undef values are removed also when changing log attribute type

See closed PR for discussion: https://github.com/equinor/xtgeo/pull/1517

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
