### PR TITLE
MAINT: implement hdf5 in io for welldata

### DIFF
--- a/src/xtgeo/io/_welldata/_blockedwell_io.py
+++ b/src/xtgeo/io/_welldata/_blockedwell_io.py
@@ -125,6 +125,9 @@ class BlockedWellData(WellData):
         if fformat == WellFileFormat.CSV:
             return cls.from_csv(filepath, **kwargs)
 
+        if fformat == WellFileFormat.HDF5:
+            return cls.from_hdf5(filepath, **kwargs)
+
         raise NotImplementedError(f"File format {fformat} not supported yet.")
 
     def to_file(
@@ -140,6 +143,10 @@ class BlockedWellData(WellData):
 
         if fformat == WellFileFormat.CSV:
             self.to_csv(filepath, **kwargs)
+            return
+
+        if fformat == WellFileFormat.HDF5:
+            self.to_hdf5(filepath, **kwargs)
             return
 
         raise NotImplementedError(f"File format {fformat} not supported yet.")
@@ -185,4 +192,31 @@ class BlockedWellData(WellData):
             blocked_well=self,
             filepath=filepath,
             **kwargs,
+        )
+
+    @classmethod
+    def from_hdf5(cls, filepath: FileLike, **kwargs: Any) -> BlockedWellData:
+        """Read blocked well data from HDF5 file."""
+        from xtgeo.io._welldata._fformats._hdf5_xtgeo import read_hdf5_blockedwell
+
+        return read_hdf5_blockedwell(filepath=filepath)
+
+    def to_hdf5(
+        self,
+        filepath: FileLike,
+        *,
+        compression: str = "lzf",
+    ) -> None:
+        """Write blocked well data to HDF5 file.
+
+        Args:
+            filepath: Output HDF5 file path
+            compression: Compression method ("lzf", "blosc", or None)
+        """
+        from xtgeo.io._welldata._fformats._hdf5_xtgeo import write_hdf5_blockedwell
+
+        write_hdf5_blockedwell(
+            blocked_well=self,
+            filepath=filepath,
+            compression=compression,
         )

--- a/src/xtgeo/io/_welldata/_fformats/_hdf5_xtgeo.py
+++ b/src/xtgeo/io/_welldata/_fformats/_hdf5_xtgeo.py
@@ -1,0 +1,573 @@
+"""HDF5 i/o using a xtgeo variant.
+
+The HDF5 format is a binary file format that can store large and complex datasets
+efficiently. It is commonly used in scientific computing and data analysis. The xtgeo
+variant of HDF5 is a specific implementation that may include additional metadata or
+structure tailored for geological data.
+
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Final
+
+import h5py
+import hdf5plugin
+import numpy as np
+
+from xtgeo.common._xyz_enum import _AttrType
+from xtgeo.common.log import null_logger
+from xtgeo.io._file import FileWrapper
+from xtgeo.io._welldata._blockedwell_io import BlockedWellData
+from xtgeo.io._welldata._well_io import WellData, WellLog
+
+if TYPE_CHECKING:  # pragma: no cover
+    from xtgeo.common.types import FileLike
+
+logger = null_logger(__name__)
+
+HDF5_FORMAT_IDCODE: Final[int] = 1401
+HDF5_PROVIDER: Final[str] = "xtgeo"
+
+
+def _export_wlogs_to_hdf5(well: WellData) -> dict[str, tuple[str, Any]]:
+    """
+    Convert WellData logs to the wlogs format used in HDF5 metadata.
+
+    This creates a dictionary where each log name maps to a tuple of
+    (log_type, code_names_or_metadata).
+
+    Args:
+        well: WellData object
+
+    Returns:
+        Dictionary with log names as keys and (type, records) tuples as values
+
+    """
+    wlogs: dict[str, tuple[str, Any]] = {}
+
+    for log in well.logs:
+        if log.is_discrete:
+            log_type = _AttrType.DISC.value
+            # For discrete logs, code_names is a dict mapping codes to names
+            wlogs[log.name] = (log_type, log.code_names)
+        else:
+            # For continuous logs, check if we have metadata in code_names
+            if isinstance(log.code_names, tuple) and len(log.code_names) > 0:
+                log_type = str(log.code_names[0])
+                # Store the full tuple as metadata
+                wlogs[log.name] = (log_type, log.code_names)
+            else:
+                log_type = _AttrType.CONT.value
+                wlogs[log.name] = (log_type, None)
+
+    return wlogs
+
+
+def _import_wlogs_from_hdf5(
+    wlogs: dict[str, tuple[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """
+    Convert HDF5 wlogs format to separate wlogtypes and wlogrecords dictionaries.
+
+    This is the inverse of _export_wlogs_to_hdf5.
+
+    Args:
+        wlogs: Dictionary from HDF5 with (type, records) tuples
+
+    Returns:
+        Dictionary with "wlogtypes" and "wlogrecords" keys
+
+    """
+    wlogtypes: dict[str, str] = {}
+    wlogrecords: dict[str, Any] = {}
+
+    for key in wlogs:
+        typ, rec = wlogs[key]
+
+        if typ in {_AttrType.DISC.value, _AttrType.CONT.value}:
+            wlogtypes[key] = deepcopy(typ)
+        else:
+            # If it's not DISC or CONT, assume it's a CONT log with type metadata
+            wlogtypes[key] = _AttrType.CONT.value
+
+        if rec is None:
+            wlogrecords[key] = None
+        elif isinstance(rec, dict):
+            # For DISC logs, convert string keys back to integers
+            # (JSON serialization converts int keys to strings)
+            if typ == _AttrType.DISC.value:
+                wlogrecords[key] = {int(k): v for k, v in rec.items()}
+            else:
+                wlogrecords[key] = deepcopy(rec)
+        elif isinstance(rec, (list, tuple)):
+            # For CONT logs, records are metadata tuples
+            wlogrecords[key] = tuple(rec)
+        else:
+            wlogrecords[key] = None
+
+    return {"wlogtypes": wlogtypes, "wlogrecords": wlogrecords}
+
+
+def write_hdf5_well(
+    well: WellData,
+    filepath: FileLike,
+    compression: str = "lzf",
+) -> None:
+    """Write well data to HDF5 file using xtgeo format.
+
+    Args:
+        well: WellData object to write
+        filepath: Output HDF5 file path or file-like object
+        compression: Compression method ("lzf", "blosc", or None)
+            - "lzf": Fast compression (default)
+            - "blosc": High compression ratio
+            - None: No compression
+
+    """
+    wrapper = FileWrapper(filepath, mode="w")
+
+    logger.debug("Writing well data to HDF5: %s", wrapper.name)
+
+    # Prepare compression settings
+    compression_filter: str | hdf5plugin.Blosc | None = None
+    if compression and compression == "blosc":
+        compression_filter = hdf5plugin.Blosc(
+            cname="blosclz", clevel=9, shuffle=hdf5plugin.Blosc.SHUFFLE
+        )
+    elif compression and compression == "lzf":
+        compression_filter = "lzf"
+
+    # Build metadata structure compatible with original format
+    wlogs = _export_wlogs_to_hdf5(well)
+
+    metadata = {
+        "_class_": "Well",
+        "_required_": {
+            "rkb": well.zpos if well.zpos is not None else 0.0,
+            "xpos": well.xpos,
+            "ypos": well.ypos,
+            "name": well.name,
+            "wlogs": wlogs,
+            "mdlogname": None,  # Not used in new structure
+            "zonelogname": None,  # Not used in new structure
+        },
+    }
+
+    jmeta = json.dumps(metadata).encode()
+
+    with h5py.File(wrapper.name, "w") as fh5:
+        logger.debug("Creating HDF5 Well group in %s", wrapper.name)
+        grp = fh5.create_group("Well")
+
+        # Create a pseudo-dataframe structure: store index and columns
+        # Index is just 0, 1, 2, ... n_records-1
+        index = np.arange(well.n_records, dtype=np.int64)
+        grp.create_dataset(
+            "index",
+            data=index,
+            compression=compression_filter,
+            chunks=True,
+        )
+
+        # Store survey coordinates as columns
+        grp.create_dataset(
+            "column/X_UTME",
+            data=well.survey_x,
+            compression=compression_filter,
+            chunks=True,
+        )
+        grp.create_dataset(
+            "column/Y_UTMN",
+            data=well.survey_y,
+            compression=compression_filter,
+            chunks=True,
+        )
+        grp.create_dataset(
+            "column/Z_TVDSS",
+            data=well.survey_z,
+            compression=compression_filter,
+            chunks=True,
+        )
+
+        # Store each log as a column
+        for log in well.logs:
+            grp.create_dataset(
+                f"column/{log.name}",
+                data=log.values,
+                compression=compression_filter,
+                chunks=True,
+            )
+
+        # Store column names as an attribute
+        all_columns = ["X_UTME", "Y_UTMN", "Z_TVDSS"] + list(well.log_names)
+        grp.attrs["columns"] = np.array(all_columns, dtype="S")
+        grp.attrs["metadata"] = jmeta
+        grp.attrs["provider"] = HDF5_PROVIDER
+        grp.attrs["format_idcode"] = HDF5_FORMAT_IDCODE
+
+    logger.debug(
+        "Successfully wrote well '%s' with %d records to %s",
+        well.name,
+        well.n_records,
+        wrapper.name,
+    )
+
+
+def read_hdf5_well(filepath: FileLike) -> WellData:
+    """Read well data from HDF5 file using xtgeo format.
+
+    Args:
+        filepath: Path to HDF5 file or file-like object
+
+    Returns:
+        WellData object
+
+    Raises:
+        ValueError: If file format is invalid or required data is missing
+
+    """
+    wrapper = FileWrapper(filepath, mode="r")
+
+    logger.debug("Reading well data from HDF5: %s", wrapper.name)
+
+    with h5py.File(wrapper.file, "r") as fh5:
+        if "Well" not in fh5:
+            raise ValueError("Invalid HDF5 well file: missing 'Well' group")
+
+        grp = fh5["Well"]
+
+        # Read metadata
+        if "metadata" not in grp.attrs:
+            raise ValueError("Invalid HDF5 well file: missing metadata")
+
+        jmeta = grp.attrs["metadata"]
+        if isinstance(jmeta, bytes):
+            jmeta = jmeta.decode()
+
+        meta = json.loads(jmeta, object_pairs_hook=dict)
+        req = meta.get("_required_", {})
+
+        # Extract basic well information
+        wname = req.get("name", "unknown")
+        xpos = req.get("xpos", 0.0)
+        ypos = req.get("ypos", 0.0)
+        rkb = req.get("rkb", 0.0)
+
+        # Read column names
+        columns_bytes = grp.attrs.get("columns", [])
+        columns = [
+            col.decode() if isinstance(col, bytes) else col for col in columns_bytes
+        ]
+
+        # Read survey data
+        survey_x = grp["column/X_UTME"][:].astype(np.float64)
+        survey_y = grp["column/Y_UTMN"][:].astype(np.float64)
+        survey_z = grp["column/Z_TVDSS"][:].astype(np.float64)
+
+        # Read log metadata from wlogs
+        wlogs_raw = req.get("wlogs", {})
+        wlogs_parsed = _import_wlogs_from_hdf5(wlogs_raw)
+        wlogtypes = wlogs_parsed["wlogtypes"]
+        wlogrecords = wlogs_parsed["wlogrecords"]
+
+        # Identify and read log data (exclude coordinate columns)
+        log_names = [
+            col for col in columns if col not in ["X_UTME", "Y_UTMN", "Z_TVDSS"]
+        ]
+
+        logs = []
+        for log_name in log_names:
+            values = grp[f"column/{log_name}"][:].astype(np.float64)
+
+            # Determine if discrete and get code_names
+            is_discrete = (
+                wlogtypes.get(log_name, _AttrType.CONT.value) == _AttrType.DISC.value
+            )
+            code_names = wlogrecords.get(log_name)
+
+            log = WellLog(
+                name=log_name,
+                values=values,
+                is_discrete=is_discrete,
+                code_names=code_names,
+            )
+            logs.append(log)
+
+    well = WellData(
+        name=wname,
+        xpos=xpos,
+        ypos=ypos,
+        zpos=rkb,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=tuple(logs),
+    )
+
+    logger.debug(
+        "Successfully read well '%s' with %d records and %d logs",
+        wname,
+        well.n_records,
+        len(logs),
+    )
+
+    return well
+
+
+def write_hdf5_blockedwell(
+    blocked_well: BlockedWellData,
+    filepath: FileLike,
+    compression: str = "lzf",
+) -> None:
+    """Write blocked well data to HDF5 file.
+
+    Args:
+        blocked_well: BlockedWellData object to write
+        filepath: Output HDF5 file path
+        compression: Compression method ("lzf", "blosc", or None)
+
+    """
+    wrapper = FileWrapper(filepath, mode="w")
+
+    logger.debug("Writing blocked well data to HDF5: %s", wrapper.name)
+
+    # Prepare compression settings
+    compression_filter: str | hdf5plugin.Blosc | None = None
+    if compression and compression == "blosc":
+        compression_filter = hdf5plugin.Blosc(
+            cname="blosclz", clevel=9, shuffle=hdf5plugin.Blosc.SHUFFLE
+        )
+    elif compression and compression == "lzf":
+        compression_filter = "lzf"
+
+    # Build metadata structure
+    wlogs = _export_wlogs_to_hdf5(blocked_well)
+
+    metadata = {
+        "_class_": "BlockedWell",
+        "_required_": {
+            "rkb": blocked_well.zpos if blocked_well.zpos is not None else 0.0,
+            "xpos": blocked_well.xpos,
+            "ypos": blocked_well.ypos,
+            "name": blocked_well.name,
+            "wlogs": wlogs,
+            "mdlogname": None,
+            "zonelogname": None,
+        },
+    }
+
+    jmeta = json.dumps(metadata).encode()
+
+    with h5py.File(wrapper.name, "w") as fh5:
+        logger.debug("Creating HDF5 Well group in %s", wrapper.name)
+        grp = fh5.create_group("Well")
+
+        # Store index
+        index = np.arange(blocked_well.n_records, dtype=np.int64)
+        grp.create_dataset(
+            "index",
+            data=index,
+            compression=compression_filter,
+            chunks=True,
+        )
+
+        # Store survey coordinates
+        grp.create_dataset(
+            "column/X_UTME",
+            data=blocked_well.survey_x,
+            compression=compression_filter,
+            chunks=True,
+        )
+        grp.create_dataset(
+            "column/Y_UTMN",
+            data=blocked_well.survey_y,
+            compression=compression_filter,
+            chunks=True,
+        )
+        grp.create_dataset(
+            "column/Z_TVDSS",
+            data=blocked_well.survey_z,
+            compression=compression_filter,
+            chunks=True,
+        )
+
+        # Store grid indices as columns
+        grp.create_dataset(
+            "column/I_INDEX",
+            data=blocked_well.i_index,
+            compression=compression_filter,
+            chunks=True,
+        )
+        grp.create_dataset(
+            "column/J_INDEX",
+            data=blocked_well.j_index,
+            compression=compression_filter,
+            chunks=True,
+        )
+        grp.create_dataset(
+            "column/K_INDEX",
+            data=blocked_well.k_index,
+            compression=compression_filter,
+            chunks=True,
+        )
+
+        # Store each log
+        for log in blocked_well.logs:
+            grp.create_dataset(
+                f"column/{log.name}",
+                data=log.values,
+                compression=compression_filter,
+                chunks=True,
+            )
+
+        # Store column names
+        all_columns = [
+            "X_UTME",
+            "Y_UTMN",
+            "Z_TVDSS",
+            "I_INDEX",
+            "J_INDEX",
+            "K_INDEX",
+        ] + list(blocked_well.log_names)
+        grp.attrs["columns"] = np.array(all_columns, dtype="S")
+        grp.attrs["metadata"] = jmeta
+        grp.attrs["provider"] = HDF5_PROVIDER
+        grp.attrs["format_idcode"] = HDF5_FORMAT_IDCODE
+
+    logger.debug(
+        "Successfully wrote blocked well '%s' with %d blocked cells to %s",
+        blocked_well.name,
+        blocked_well.n_blocked_cells,
+        wrapper.name,
+    )
+
+
+def read_hdf5_blockedwell(filepath: FileLike) -> BlockedWellData:
+    """Read blocked well data from HDF5 file.
+
+    Args:
+        filepath: Path to HDF5 file
+
+    Returns:
+        BlockedWellData object
+
+    Raises:
+        ValueError: If file format is invalid or required data is missing
+
+    """
+    wrapper = FileWrapper(filepath, mode="r")
+
+    logger.debug("Reading blocked well data from HDF5: %s", wrapper.name)
+
+    with h5py.File(wrapper.file, "r") as fh5:
+        if "Well" not in fh5:
+            raise ValueError("Invalid HDF5 well file: missing 'Well' group")
+
+        grp = fh5["Well"]
+
+        # Read metadata
+        if "metadata" not in grp.attrs:
+            raise ValueError("Invalid HDF5 well file: missing metadata")
+
+        jmeta = grp.attrs["metadata"]
+        if isinstance(jmeta, bytes):
+            jmeta = jmeta.decode()
+
+        meta = json.loads(jmeta, object_pairs_hook=dict)
+        req = meta.get("_required_", {})
+
+        # Extract basic well information
+        wname = req.get("name", "unknown")
+        xpos = req.get("xpos", 0.0)
+        ypos = req.get("ypos", 0.0)
+        rkb = req.get("rkb", 0.0)
+
+        # Read column names
+        columns_bytes = grp.attrs.get("columns", [])
+        columns = [
+            col.decode() if isinstance(col, bytes) else col for col in columns_bytes
+        ]
+
+        # Read survey data
+        survey_x = grp["column/X_UTME"][:].astype(np.float64)
+        survey_y = grp["column/Y_UTMN"][:].astype(np.float64)
+        survey_z = grp["column/Z_TVDSS"][:].astype(np.float64)
+
+        # Read grid indices - check if they exist
+        if (
+            "column/I_INDEX" not in grp
+            or "column/J_INDEX" not in grp
+            or "column/K_INDEX" not in grp
+        ):
+            raise ValueError(
+                "File does not contain I_INDEX, J_INDEX, and K_INDEX columns "
+                "required for blocked well"
+            )
+
+        i_index = grp["column/I_INDEX"][:].astype(np.float64)
+        j_index = grp["column/J_INDEX"][:].astype(np.float64)
+        k_index = grp["column/K_INDEX"][:].astype(np.float64)
+
+        # Read log metadata
+        wlogs_raw = req.get("wlogs", {})
+        wlogs_parsed = _import_wlogs_from_hdf5(wlogs_raw)
+        wlogtypes = wlogs_parsed["wlogtypes"]
+        wlogrecords = wlogs_parsed["wlogrecords"]
+
+        # Identify log names (exclude coordinates and indices)
+        log_names = [
+            col
+            for col in columns
+            if col
+            not in [
+                "X_UTME",
+                "Y_UTMN",
+                "Z_TVDSS",
+                "I_INDEX",
+                "J_INDEX",
+                "K_INDEX",
+            ]
+        ]
+
+        logs = []
+        for log_name in log_names:
+            values = grp[f"column/{log_name}"][:].astype(np.float64)
+
+            is_discrete = (
+                wlogtypes.get(log_name, _AttrType.CONT.value) == _AttrType.DISC.value
+            )
+            code_names = wlogrecords.get(log_name)
+
+            log = WellLog(
+                name=log_name,
+                values=values,
+                is_discrete=is_discrete,
+                code_names=code_names,
+            )
+            logs.append(log)
+
+    blocked_well = BlockedWellData(
+        name=wname,
+        xpos=xpos,
+        ypos=ypos,
+        zpos=rkb,
+        survey_x=survey_x,
+        survey_y=survey_y,
+        survey_z=survey_z,
+        logs=tuple(logs),
+        i_index=i_index,
+        j_index=j_index,
+        k_index=k_index,
+    )
+
+    logger.debug(
+        "Successfully read blocked well '%s' with %d records and %d blocked cells",
+        blocked_well.name,
+        blocked_well.n_records,
+        blocked_well.n_blocked_cells,
+    )
+
+    return blocked_well

--- a/src/xtgeo/io/_welldata/_well_io.py
+++ b/src/xtgeo/io/_welldata/_well_io.py
@@ -28,7 +28,7 @@ class WellFileFormat(Enum):
     Attributes:
         RMS_ASCII: RMS ASCII well format
         CSV: CSV format
-        HDF5: HDF5 format (not yet implemented)
+        HDF5: HDF5 format using xtgeo variant
 
     """
 
@@ -239,6 +239,9 @@ class WellData:
         if fformat == WellFileFormat.CSV:
             return cls.from_csv(filepath, **kwargs)
 
+        if fformat == WellFileFormat.HDF5:
+            return cls.from_hdf5(filepath, **kwargs)
+
         raise NotImplementedError(f"File format {fformat} is not supported")
 
     def to_file(
@@ -260,6 +263,10 @@ class WellData:
 
         if fformat == WellFileFormat.CSV:
             self.to_csv(filepath, **kwargs)
+            return
+
+        if fformat == WellFileFormat.HDF5:
+            self.to_hdf5(filepath, **kwargs)
             return
 
         raise NotImplementedError(f"File format {fformat} is not supported.")
@@ -298,3 +305,26 @@ class WellData:
         from xtgeo.io._welldata._fformats._csv_table import write_csv_well
 
         write_csv_well(well=self, filepath=filepath, **kwargs)
+
+    @classmethod
+    def from_hdf5(cls, filepath: FileLike, **kwargs: Any) -> WellData:
+        """Read well data from HDF5 file."""
+        from xtgeo.io._welldata._fformats._hdf5_xtgeo import read_hdf5_well
+
+        return read_hdf5_well(filepath=filepath)
+
+    def to_hdf5(
+        self,
+        filepath: FileLike,
+        *,
+        compression: str = "lzf",
+    ) -> None:
+        """Write well data to HDF5 file.
+
+        Args:
+            filepath: Output HDF5 file path
+            compression: Compression method ("lzf", "blosc", or None)
+        """
+        from xtgeo.io._welldata._fformats._hdf5_xtgeo import write_hdf5_well
+
+        write_hdf5_well(well=self, filepath=filepath, compression=compression)

--- a/tests/test_io/test_welldata/test_fformat_hdf5.py
+++ b/tests/test_io/test_welldata/test_fformat_hdf5.py
@@ -1,0 +1,677 @@
+"""Tests for HDF5 format I/O for WellData and BlockedWellData."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from xtgeo.io._welldata._blockedwell_io import BlockedWellData
+from xtgeo.io._welldata._well_io import WellData, WellFileFormat, WellLog
+
+
+def test_welldata_hdf5_basic_write_read(tmp_path):
+    """Test basic WellData write and read using HDF5 format."""
+    # Create well data
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]))
+    poro_log = WellLog(name="PORO", values=np.array([0.15, 0.20, 0.25]))
+
+    well = WellData(
+        name="TestWell_HDF5",
+        xpos=460000.0,
+        ypos=5930000.0,
+        zpos=25.0,
+        survey_x=np.array([460000.0, 460010.0, 460020.0]),
+        survey_y=np.array([5930000.0, 5930010.0, 5930020.0]),
+        survey_z=np.array([1000.0, 1010.0, 1020.0]),
+        logs=(gr_log, poro_log),
+    )
+
+    # Write to HDF5
+    filepath = tmp_path / "test_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    # Read back
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    # Verify
+    assert well_read.name == well.name
+    assert well_read.xpos == well.xpos
+    assert well_read.ypos == well.ypos
+    assert well_read.zpos == well.zpos
+    assert well_read.n_records == well.n_records
+    np.testing.assert_array_almost_equal(well_read.survey_x, well.survey_x)
+    np.testing.assert_array_almost_equal(well_read.survey_y, well.survey_y)
+    np.testing.assert_array_almost_equal(well_read.survey_z, well.survey_z)
+    assert well_read.log_names == well.log_names
+
+    # Check logs
+    for log_name in well.log_names:
+        log_orig = well.get_log(log_name)
+        log_read = well_read.get_log(log_name)
+        assert log_read is not None
+        assert log_orig is not None
+        np.testing.assert_array_almost_equal(log_read.values, log_orig.values)
+
+
+def test_welldata_hdf5_with_discrete_log(tmp_path):
+    """Test WellData HDF5 I/O with discrete log."""
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 1.0, 3.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE", 3: "LIMESTONE"},
+    )
+
+    well = WellData(
+        name="DiscreteWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0, 103.0]),
+        survey_y=np.array([200.0, 201.0, 202.0, 203.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0, 1003.0]),
+        logs=(facies_log,),
+    )
+
+    filepath = tmp_path / "discrete_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.name == well.name
+    facies_read = well_read.get_log("FACIES")
+    assert facies_read is not None
+    assert facies_read.is_discrete
+    assert facies_read.code_names == facies_log.code_names
+    np.testing.assert_array_almost_equal(facies_read.values, facies_log.values)
+
+
+def test_welldata_hdf5_compression_blosc(tmp_path):
+    """Test HDF5 I/O with blosc compression."""
+    gr_log = WellLog(name="GR", values=np.random.rand(100))
+
+    well = WellData(
+        name="CompressedWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=10.0,
+        survey_x=np.linspace(100, 200, 100),
+        survey_y=np.linspace(200, 300, 100),
+        survey_z=np.linspace(1000, 1100, 100),
+        logs=(gr_log,),
+    )
+
+    filepath = tmp_path / "compressed_well.hdf5"
+    well.to_hdf5(filepath=filepath, compression="blosc")
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.name == well.name
+    assert well_read.n_records == 100
+    gr_read = well_read.get_log("GR")
+    assert gr_read is not None
+    np.testing.assert_array_almost_equal(gr_read.values, gr_log.values)
+
+
+def test_welldata_hdf5_compression_lzf(tmp_path):
+    """Test HDF5 I/O with lzf compression (default)."""
+    poro_log = WellLog(name="PORO", values=np.random.rand(50))
+
+    well = WellData(
+        name="LZFWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.linspace(100, 150, 50),
+        survey_y=np.linspace(200, 250, 50),
+        survey_z=np.linspace(1000, 1050, 50),
+        logs=(poro_log,),
+    )
+
+    filepath = tmp_path / "lzf_well.hdf5"
+    well.to_hdf5(filepath=filepath, compression="lzf")
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.name == well.name
+    assert well_read.n_records == 50
+
+
+def test_welldata_hdf5_no_compression(tmp_path):
+    """Test HDF5 I/O without compression."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+
+    well = WellData(
+        name="NoCompressionWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1001.0]),
+        logs=(gr_log,),
+    )
+
+    filepath = tmp_path / "no_compression_well.hdf5"
+    well.to_hdf5(filepath=filepath, compression=None)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.name == well.name
+    assert well_read.n_records == 2
+
+
+def test_welldata_hdf5_with_nan_values(tmp_path):
+    """Test HDF5 I/O with NaN values in continuous log."""
+    poro_log = WellLog(name="PORO", values=np.array([0.15, np.nan, 0.25, np.nan, 0.35]))
+
+    well = WellData(
+        name="NaNWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0, 103.0, 104.0]),
+        survey_y=np.array([200.0, 201.0, 202.0, 203.0, 204.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0, 1003.0, 1004.0]),
+        logs=(poro_log,),
+    )
+
+    filepath = tmp_path / "nan_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    poro_read = well_read.get_log("PORO")
+    assert poro_read is not None
+    assert np.isnan(poro_read.values[1])
+    assert np.isnan(poro_read.values[3])
+    assert poro_read.values[0] == 0.15
+
+
+def test_welldata_hdf5_multiple_logs(tmp_path):
+    """Test HDF5 I/O with multiple logs of different types."""
+    n = 10
+    gr_log = WellLog(name="GR", values=np.random.rand(n) * 100)
+    poro_log = WellLog(name="PORO", values=np.random.rand(n) * 0.4)
+    perm_log = WellLog(name="PERM", values=np.random.rand(n) * 1000)
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.random.randint(1, 4, n).astype(float),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE", 3: "LIMESTONE"},
+    )
+
+    well = WellData(
+        name="MultiLogWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=15.0,
+        survey_x=np.linspace(100, 200, n),
+        survey_y=np.linspace(200, 300, n),
+        survey_z=np.linspace(1000, 1100, n),
+        logs=(gr_log, poro_log, perm_log, facies_log),
+    )
+
+    filepath = tmp_path / "multi_log_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.n_records == n
+    assert len(well_read.logs) == 4
+    assert set(well_read.log_names) == {"GR", "PORO", "PERM", "FACIES"}
+
+
+def test_welldata_hdf5_using_to_file_from_file(tmp_path):
+    """Test HDF5 I/O using to_file/from_file with HDF5 format enum."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]))
+
+    well = WellData(
+        name="EnumFormatWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(gr_log,),
+    )
+
+    filepath = tmp_path / "enum_format_well.hdf5"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.HDF5)
+
+    well_read = WellData.from_file(filepath=filepath, fformat=WellFileFormat.HDF5)
+
+    assert well_read.name == well.name
+    assert well_read.n_records == 3
+
+
+# ============================================================================
+# BlockedWellData HDF5 tests
+# ============================================================================
+
+
+def test_blockedwell_hdf5_basic_write_read(tmp_path):
+    """Test basic BlockedWellData write and read using HDF5 format."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]))
+    poro_log = WellLog(name="PORO", values=np.array([0.15, 0.20, 0.25]))
+
+    blocked_well = BlockedWellData(
+        name="BlockedWell_HDF5",
+        xpos=460000.0,
+        ypos=5930000.0,
+        zpos=25.0,
+        survey_x=np.array([460000.0, 460010.0, 460020.0]),
+        survey_y=np.array([5930000.0, 5930010.0, 5930020.0]),
+        survey_z=np.array([1000.0, 1010.0, 1020.0]),
+        logs=(gr_log, poro_log),
+        i_index=np.array([10.0, 11.0, 12.0]),
+        j_index=np.array([20.0, 21.0, 22.0]),
+        k_index=np.array([5.0, 6.0, 7.0]),
+    )
+
+    filepath = tmp_path / "blocked_well.hdf5"
+    blocked_well.to_hdf5(filepath=filepath)
+
+    blocked_well_read = BlockedWellData.from_hdf5(filepath=filepath)
+
+    assert blocked_well_read.name == blocked_well.name
+    assert blocked_well_read.n_records == 3
+    assert blocked_well_read.n_blocked_cells == 3
+    np.testing.assert_array_almost_equal(
+        blocked_well_read.i_index, blocked_well.i_index
+    )
+    np.testing.assert_array_almost_equal(
+        blocked_well_read.j_index, blocked_well.j_index
+    )
+    np.testing.assert_array_almost_equal(
+        blocked_well_read.k_index, blocked_well.k_index
+    )
+
+
+def test_blockedwell_hdf5_with_discrete_log(tmp_path):
+    """Test BlockedWellData HDF5 I/O with discrete log."""
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 1.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE"},
+    )
+
+    blocked_well = BlockedWellData(
+        name="BlockedDiscreteWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(facies_log,),
+        i_index=np.array([5.0, 6.0, 7.0]),
+        j_index=np.array([10.0, 11.0, 12.0]),
+        k_index=np.array([1.0, 1.0, 2.0]),
+    )
+
+    filepath = tmp_path / "blocked_discrete_well.hdf5"
+    blocked_well.to_hdf5(filepath=filepath)
+
+    blocked_well_read = BlockedWellData.from_hdf5(filepath=filepath)
+
+    facies_read = blocked_well_read.get_log("FACIES")
+    assert facies_read is not None
+    assert facies_read.is_discrete
+    assert facies_read.code_names == {1: "SAND", 2: "SHALE"}
+
+
+def test_blockedwell_hdf5_using_to_file_from_file(tmp_path):
+    """Test BlockedWellData HDF5 I/O using to_file/from_file."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+
+    blocked_well = BlockedWellData(
+        name="BlockedEnumWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1001.0]),
+        logs=(gr_log,),
+        i_index=np.array([5.0, 6.0]),
+        j_index=np.array([10.0, 11.0]),
+        k_index=np.array([1.0, 1.0]),
+    )
+
+    filepath = tmp_path / "blocked_enum_well.hdf5"
+    blocked_well.to_file(filepath=filepath, fformat=WellFileFormat.HDF5)
+
+    blocked_well_read = BlockedWellData.from_file(
+        filepath=filepath, fformat=WellFileFormat.HDF5
+    )
+
+    assert blocked_well_read.name == blocked_well.name
+    assert blocked_well_read.n_records == 2
+    assert blocked_well_read.n_blocked_cells == 2
+
+
+def test_welldata_hdf5_no_logs(tmp_path):
+    """Test HDF5 I/O with well containing no logs."""
+    well = WellData(
+        name="NoLogsWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(),
+    )
+
+    filepath = tmp_path / "no_logs_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.name == well.name
+    assert well_read.n_records == 3
+    assert len(well_read.logs) == 0
+
+
+def test_welldata_hdf5_no_rkb(tmp_path):
+    """Test HDF5 I/O with well without RKB (zpos=0.0)."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+
+    well = WellData(
+        name="NoRKBWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1001.0]),
+        logs=(gr_log,),
+    )
+
+    filepath = tmp_path / "no_rkb_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    assert well_read.name == well.name
+    assert well_read.zpos == 0.0
+
+
+def test_welldata_hdf5_continuous_log_with_metadata(tmp_path):
+    """Test HDF5 I/O with continuous log containing metadata tuple."""
+    # Create a log with metadata in code_names
+    poro_log = WellLog(
+        name="PORO",
+        values=np.array([0.15, 0.20, 0.25]),
+        is_discrete=False,
+        code_names=("UNK", "lin"),
+    )
+
+    well = WellData(
+        name="MetadataWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(poro_log,),
+    )
+
+    filepath = tmp_path / "metadata_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    poro_read = well_read.get_log("PORO")
+    assert poro_read is not None
+    assert not poro_read.is_discrete
+    assert poro_read.code_names == ("UNK", "lin")
+
+
+def test_welldata_hdf5_verify_discrete_flag(tmp_path):
+    """Test that is_discrete flag is correctly preserved."""
+    # Create a mix of continuous and discrete logs
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]), is_discrete=False)
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 1.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE"},
+    )
+
+    well = WellData(
+        name="MixedWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(gr_log, facies_log),
+    )
+
+    filepath = tmp_path / "mixed_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    gr_read = well_read.get_log("GR")
+    facies_read = well_read.get_log("FACIES")
+
+    assert gr_read is not None
+    assert not gr_read.is_discrete
+    assert gr_read.code_names is None
+
+    assert facies_read is not None
+    assert facies_read.is_discrete
+    assert facies_read.code_names == {1: "SAND", 2: "SHALE"}
+
+
+def test_blockedwell_hdf5_no_logs(tmp_path):
+    """Test BlockedWellData HDF5 I/O with no logs."""
+    blocked_well = BlockedWellData(
+        name="BlockedNoLogs",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1001.0]),
+        logs=(),
+        i_index=np.array([5.0, 6.0]),
+        j_index=np.array([10.0, 11.0]),
+        k_index=np.array([1.0, 1.0]),
+    )
+
+    filepath = tmp_path / "blocked_no_logs.hdf5"
+    blocked_well.to_hdf5(filepath=filepath)
+
+    blocked_well_read = BlockedWellData.from_hdf5(filepath=filepath)
+
+    assert blocked_well_read.name == blocked_well.name
+    assert blocked_well_read.n_records == 2
+    assert len(blocked_well_read.logs) == 0
+    np.testing.assert_array_almost_equal(
+        blocked_well_read.i_index, blocked_well.i_index
+    )
+
+
+def test_blockedwell_hdf5_with_nan_indices(tmp_path):
+    """Test BlockedWellData HDF5 I/O with NaN indices."""
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0, 100.0]))
+
+    blocked_well = BlockedWellData(
+        name="BlockedNaNIndices",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0, 102.0]),
+        survey_y=np.array([200.0, 201.0, 202.0]),
+        survey_z=np.array([1000.0, 1001.0, 1002.0]),
+        logs=(gr_log,),
+        i_index=np.array([5.0, np.nan, 7.0]),
+        j_index=np.array([10.0, np.nan, 12.0]),
+        k_index=np.array([1.0, np.nan, 2.0]),
+    )
+
+    filepath = tmp_path / "blocked_nan_indices.hdf5"
+    blocked_well.to_hdf5(filepath=filepath)
+
+    blocked_well_read = BlockedWellData.from_hdf5(filepath=filepath)
+
+    assert blocked_well_read.n_records == 3
+    assert blocked_well_read.n_blocked_cells == 2  # Only 2 valid cells
+    assert np.isnan(blocked_well_read.i_index[1])
+    assert np.isnan(blocked_well_read.j_index[1])
+    assert np.isnan(blocked_well_read.k_index[1])
+
+
+def test_blockedwell_hdf5_compression_blosc(tmp_path):
+    """Test BlockedWellData HDF5 I/O with blosc compression."""
+    gr_log = WellLog(name="GR", values=np.random.rand(50))
+
+    blocked_well = BlockedWellData(
+        name="BlockedCompressed",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.linspace(100, 150, 50),
+        survey_y=np.linspace(200, 250, 50),
+        survey_z=np.linspace(1000, 1050, 50),
+        logs=(gr_log,),
+        i_index=np.random.randint(1, 20, 50).astype(float),
+        j_index=np.random.randint(1, 30, 50).astype(float),
+        k_index=np.random.randint(1, 10, 50).astype(float),
+    )
+
+    filepath = tmp_path / "blocked_compressed.hdf5"
+    blocked_well.to_hdf5(filepath=filepath, compression="blosc")
+
+    blocked_well_read = BlockedWellData.from_hdf5(filepath=filepath)
+
+    assert blocked_well_read.name == blocked_well.name
+    assert blocked_well_read.n_records == 50
+    np.testing.assert_array_almost_equal(
+        blocked_well_read.i_index, blocked_well.i_index
+    )
+
+
+def test_welldata_hdf5_metadata_roundtrip(tmp_path):
+    """Test that all well metadata is preserved through HDF5 roundtrip."""
+    facies_log = WellLog(
+        name="FACIES",
+        values=np.array([1.0, 2.0, 3.0, 1.0, 2.0]),
+        is_discrete=True,
+        code_names={1: "SAND", 2: "SHALE", 3: "LIMESTONE"},
+    )
+    poro_log = WellLog(
+        name="PORO",
+        values=np.array([0.15, 0.20, 0.25, 0.18, 0.22]),
+        is_discrete=False,
+    )
+
+    well = WellData(
+        name="ComplexWell_123",
+        xpos=460123.45,
+        ypos=5932456.78,
+        zpos=32.5,
+        survey_x=np.array([460123.45, 460124.0, 460125.0, 460126.0, 460127.0]),
+        survey_y=np.array([5932456.78, 5932457.0, 5932458.0, 5932459.0, 5932460.0]),
+        survey_z=np.array([1000.0, 1010.5, 1020.25, 1030.75, 1040.0]),
+        logs=(facies_log, poro_log),
+    )
+
+    filepath = tmp_path / "roundtrip_well.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    well_read = WellData.from_hdf5(filepath=filepath)
+
+    # Verify all attributes
+    assert well_read.name == well.name
+    assert well_read.xpos == well.xpos
+    assert well_read.ypos == well.ypos
+    assert well_read.zpos == well.zpos
+    assert well_read.n_records == well.n_records
+    assert well_read.log_names == well.log_names
+
+    # Verify survey arrays
+    np.testing.assert_array_almost_equal(well_read.survey_x, well.survey_x)
+    np.testing.assert_array_almost_equal(well_read.survey_y, well.survey_y)
+    np.testing.assert_array_almost_equal(well_read.survey_z, well.survey_z)
+
+    # Verify logs in detail
+    for log_name in well.log_names:
+        log_orig = well.get_log(log_name)
+        log_read = well_read.get_log(log_name)
+        assert log_read is not None
+        assert log_orig is not None
+        assert log_read.is_discrete == log_orig.is_discrete
+        assert log_read.code_names == log_orig.code_names
+        np.testing.assert_array_almost_equal(log_read.values, log_orig.values)
+
+
+# ============================================================================
+# Error handling tests
+# ============================================================================
+
+
+def test_welldata_hdf5_invalid_file_no_well_group(tmp_path):
+    """Test reading HDF5 file without 'Well' group raises error."""
+    import h5py
+    import pytest
+
+    filepath = tmp_path / "invalid_no_group.hdf5"
+
+    # Create HDF5 file without the 'Well' group
+    with h5py.File(filepath, "w") as fh5:
+        fh5.create_group("SomeOtherGroup")
+
+    with pytest.raises(ValueError, match="missing 'Well' group"):
+        WellData.from_hdf5(filepath=filepath)
+
+
+def test_welldata_hdf5_invalid_file_no_metadata(tmp_path):
+    """Test reading HDF5 file without metadata raises error."""
+    import h5py
+    import pytest
+
+    filepath = tmp_path / "invalid_no_metadata.hdf5"
+
+    # Create HDF5 file with Well group but no metadata
+    with h5py.File(filepath, "w") as fh5:
+        grp = fh5.create_group("Well")
+        grp.attrs["columns"] = np.array(["X_UTME", "Y_UTMN", "Z_TVDSS"], dtype="S")
+
+    with pytest.raises(ValueError, match="missing metadata"):
+        WellData.from_hdf5(filepath=filepath)
+
+
+def test_blockedwell_hdf5_missing_indices(tmp_path):
+    """Test reading BlockedWellData from file missing grid indices."""
+    import pytest
+
+    # First create a regular well file
+    gr_log = WellLog(name="GR", values=np.array([50.0, 75.0]))
+
+    well = WellData(
+        name="RegularWell",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0, 101.0]),
+        survey_y=np.array([200.0, 201.0]),
+        survey_z=np.array([1000.0, 1001.0]),
+        logs=(gr_log,),
+    )
+
+    filepath = tmp_path / "regular_well_not_blocked.hdf5"
+    well.to_hdf5(filepath=filepath)
+
+    # Try to read it as BlockedWellData - should fail
+    with pytest.raises(
+        ValueError, match="does not contain I_INDEX, J_INDEX, and K_INDEX"
+    ):
+        BlockedWellData.from_hdf5(filepath=filepath)


### PR DESCRIPTION
Resolves #1534

Part of #1480

Add HDF5 support for welldata in xtgeo/io/_welldata with extended tests

The current public i/o for Well and BlockedWell in xtgeo still uses the existing "old" functions, but a coming PR will do the switch.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
