### PR TITLE
BUG: Fix SEGY cube export producing non-UTF8 byte in binary header

### DIFF
--- a/src/xtgeo/cube/_cube_export.py
+++ b/src/xtgeo/cube/_cube_export.py
@@ -88,16 +88,9 @@ def export_segy(cube: Cube, sfile: str) -> None:
         f.bin[segyio.BinField.SortingCode] = 4  # trace sorting from C: needed?
         # TODO: Make this read from cube._measurement (or something)
         f.bin[segyio.BinField.MeasurementSystem] = 1
-
-    with open(sfile, "r+b") as stream:
-        stream.seek(3200)
-        header = bytearray(stream.read(400))
-        if len(header) == 400:
-            # SEG-Y rev1 unassigned ranges in binary header.
-            header[60:300] = b"\x00" * 240
-            header[306:400] = b"\x00" * 94
-            stream.seek(3200)
-            stream.write(header)
+        text_header = bytearray(f.text[0])
+        text_header[-1] = 0x20  # ASCII space
+        f.text[0] = bytes(text_header)
 
 
 def export_rmsreg(self, sfile):

--- a/tests/test_cube/test_cube.py
+++ b/tests/test_cube/test_cube.py
@@ -242,20 +242,18 @@ def test_segy_export_to_bytesio_raises():
         cube.to_file(stream, fformat="segy")
 
 
-def test_segy_export_sanitizes_unassigned_binary_header_bytes(
+def test_segy_export_sanitizes_text_header_last_byte(
     tmp_path: pathlib.Path,
 ) -> None:
-    """Binary header unassigned bytes are deterministic after export."""
+    """Text header last byte is a safe EBCDIC space after export."""
     cube = xtgeo.Cube(ncol=3, nrow=2, nlay=5, xinc=10, yinc=10, zinc=1)
     cube.values = list(range(30))
-    outfile = tmp_path / "cube_header_sanitized.segy"
+    outfile = tmp_path / "cube_text_header_sanitized.segy"
 
     cube.to_file(outfile, fformat="segy")
     raw = outfile.read_bytes()
-    binary_header = raw[3200:3600]
-
-    assert binary_header[60:300] == b"\x00" * 240
-    assert binary_header[306:400] == b"\x00" * 94
+    assert raw[3199] == 0x40  # EBCDIC space
+    assert raw[3199] != 0x80
 
     with segyio.open(outfile, "r") as seg:
         assert seg.bin[segyio.BinField.Interval] == 1000

--- a/uv.lock
+++ b/uv.lock
@@ -2581,7 +2581,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "numpy" },
-    { name = "pandas", specifier = ">=1.1,<3.0.0" },
+    { name = "pandas", specifier = ">=1.1" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "psutil", marker = "extra == 'dev'" },
     { name = "pyarrow" },


### PR DESCRIPTION
Resolves #1542 

The nightly uploads to Sumo from `f_atlas02` and `f_scout_ci` stopped producing `cubes` after the recent change in export_cube.
```
"FAILED SEGY upload as OpenVDS 'utf-8' codec can't decode byte 0x80 in position 3267: invalid start byte <class 'UnicodeDecodeError'>\"
```
from here we know that the upload failed because that one byte in SEGY binary header position 3267 was 0x80. Previously before the export cube changes in xtgeo, that position 3267 was unused and explicitly written to ASCII '0' (0x30), ref [here](https://github.com/equinor/xtgeo/blob/621c7ff005c1550d01905f0b81df58c18932ce28/src/lib/src/cube_export_segy.c#L183C5-L183C33). After the change, there's no 0 assignment for the unused byte, so a byte like 0x80 could appear. Proposed fix is to zeroed out again the unused binary header.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
