### PR TITLE
BUG: revert casting of wrapped_file.name to string (#1544)

### DIFF
--- a/src/xtgeo/xyz/_xyz_io.py
+++ b/src/xtgeo/xyz/_xyz_io.py
@@ -405,20 +405,17 @@ def to_file(
         # NB! reuse export_rms_attr function, but no attributes
         # are possible
         ncount = export_rms_attr(
-            xyz, str(wrapped_file.name), attributes=False, pfilter=pfilter
+            xyz, wrapped_file.name, attributes=False, pfilter=pfilter
         )
 
     elif fformat in FileFormat.RMS_ATTR.value:
         ncount = export_rms_attr(
-            xyz,
-            str(wrapped_file.name),
-            attributes=attributes,
-            pfilter=pfilter,
+            xyz, wrapped_file.name, attributes=attributes, pfilter=pfilter
         )
     elif fformat in FileFormat.CSV.value:
         ncount = export_table(
             xyz,
-            str(wrapped_file.name),
+            wrapped_file.name,
             attributes=attributes,
             pfilter=pfilter,
             file_format="csv",
@@ -426,14 +423,14 @@ def to_file(
     elif fformat in FileFormat.PARQUET.value:
         ncount = export_table(
             xyz,
-            str(wrapped_file.name),
+            wrapped_file.name,
             attributes=attributes,
             pfilter=pfilter,
             file_format="parquet",
         )
     elif fformat == "rms_wellpicks":
         ncount = export_rms_wpicks(
-            xyz, str(wrapped_file.name), hcolumn, wcolumn, mdcolumn=mdcolumn
+            xyz, wrapped_file.name, hcolumn, wcolumn, mdcolumn=mdcolumn
         )
     else:
         extensions = FileFormat.extensions_string(


### PR DESCRIPTION
Resolves #1544 

Reverts casting of wrapped_file.name to str in the io module, which should avoid that when points/polygons are written to memory streams they are dumped to disk with names like <_io.BytesIO object at 0x7fbe57bc5c60>

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
