### PR TITLE
CI: Fix uv python version (#1524)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,17 +24,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-
-      - name: Set up Python
-        run: uv python install 3.12
+        with:
+          python-version: ${{ matrix.python }}
 
       - name: Install cibuildwheel
         run: |
-         uv venv
-         uv pip install -U pip cibuildwheel twine
+          uv venv
+          uv pip install -U pip cibuildwheel twine
 
       - name: Build wheels
         run: uv run cibuildwheel --output-dir wheelhouse


### PR DESCRIPTION
Add CI fix for publish workflow to make the publish of the new version 4.17.1 work.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
