### PR TITLE
ENH: add dict as return type from TSurf data class (#1558)

### DIFF
--- a/tests/test_io/test_tsurf/test_tsurf_reader.py
+++ b/tests/test_io/test_tsurf/test_tsurf_reader.py
@@ -1102,3 +1102,48 @@ def test_tsurf_data_roundtrip_bytes_io(complete_tsurf_file: str) -> None:
     assert result.coord_sys == result_written.coord_sys
     assert np.array_equal(result.vertices, result_written.vertices)
     assert np.array_equal(result.triangles, result_written.triangles)
+
+
+def test_get_as_dict_with_coord_sys(complete_tsurf_file: str) -> None:
+    """Test get_as_dict returns correct keys and values with coordinate system."""
+    data = TSurfData.from_file(tsurf_stream(complete_tsurf_file))
+    result = data.asdict()
+
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"header", "coord_sys", "vertices", "triangles"}
+
+    assert result["header"] == {"name": "test_surface"}
+    assert np.array_equal(result["vertices"], data.vertices)
+    assert np.array_equal(result["triangles"], data.triangles)
+
+    coord_sys = result["coord_sys"]
+    assert coord_sys is not None
+    assert coord_sys["name"] == "Default"
+    assert coord_sys["axis_name"] == ["X", "Y", "Z"]
+    assert coord_sys["axis_unit"] == ["m", "m", "m"]
+    assert coord_sys["zpositive"] == "Depth"
+
+
+def test_get_as_dict_without_coord_sys(minimal_tsurf_file: str) -> None:
+    """Test get_as_dict does not contain coord_sys data when section is absent."""
+    data = TSurfData.from_file(tsurf_stream(minimal_tsurf_file))
+    result = data.asdict()
+
+    assert result["header"] == {"name": "test_surface"}
+    assert "coord_sys" not in result
+    assert np.array_equal(result["vertices"], data.vertices)
+    assert np.array_equal(result["triangles"], data.triangles)
+
+
+def test_num_vertices(complete_tsurf_file: str) -> None:
+    """Test num_vertices returns the correct vertex count."""
+    data = TSurfData.from_file(tsurf_stream(complete_tsurf_file))
+    assert data.num_vertices == 3
+    assert data.num_vertices == data.vertices.shape[0]
+
+
+def test_num_triangles(complete_tsurf_file: str) -> None:
+    """Test num_triangles returns the correct triangle count."""
+    data = TSurfData.from_file(tsurf_stream(complete_tsurf_file))
+    assert data.num_triangles == 1
+    assert data.num_triangles == data.triangles.shape[0]


### PR DESCRIPTION
Resolves #1558 

Add method in TSurfData to return its data as a dictionary with fixed keys.
This is needed to populate a TriangleSurface instance via a generic interface taking dictionaries as input.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
