### PR TITLE
FIX: fix typo in typing of hash function

### DIFF
--- a/src/xtgeo/common/sys.py
+++ b/src/xtgeo/common/sys.py
@@ -64,7 +64,7 @@ def check_folder(
 
 
 def generic_hash(
-    gid: str, hashmethod: Literal["md5", "sha256", "blake2d"] | Callable = "md5"
+    gid: str, hashmethod: Literal["md5", "sha256", "blake2b"] | Callable = "md5"
 ) -> str:
     """Return a unique hash ID for current instance.
 


### PR DESCRIPTION
Resolves #1577 

Fixed typo in typing of hash function

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
