### PR TITLE
BUG: Fix bottom pillar Z-coord from `create_box_grid` method

### DIFF
--- a/src/lib/src/grid3d/grid.cpp
+++ b/src/lib/src/grid3d/grid.cpp
@@ -767,7 +767,7 @@ create_grid_from_cube(const cube::Cube &cube,
             coordsv_[ibc++] = apply_zori;
             coordsv_[ibc++] = p.x();
             coordsv_[ibc++] = p.y();
-            coordsv_[ibc++] = apply_zori + cube.zinc * (cube.nlay + 1);
+            coordsv_[ibc++] = apply_zori + cube.zinc * cube.nlay;
         }
     }
 

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -1450,7 +1450,7 @@ def test_more_translate_coords(testdata_path):
         (4, 0.5),
     ],
 )
-def test_create_box_grid_give_correct_pillar_zcoord(nz, dz):
+def test_create_box_grid_gives_correct_pillar_zcoord(nz, dz):
     """Test that create_box_grid with coordsv creates expected coordinates."""
     grd = xtgeo.create_box_grid(
         dimension=(2, 2, nz),

--- a/tests/test_grid3d/test_grid.py
+++ b/tests/test_grid3d/test_grid.py
@@ -1440,3 +1440,39 @@ def test_more_translate_coords(testdata_path):
     np.testing.assert_allclose(
         g11_xyz[2].values, original_xyz[2].values, rtol=1e-5, atol=1e-6
     )
+
+
+@pytest.mark.parametrize(
+    "nz, dz",
+    [
+        (2, 1),
+        (3, 2),
+        (4, 0.5),
+    ],
+)
+def test_create_box_grid_give_correct_pillar_zcoord(nz, dz):
+    """Test that create_box_grid with coordsv creates expected coordinates."""
+    grd = xtgeo.create_box_grid(
+        dimension=(2, 2, nz),
+        increment=(1, 1, dz),
+    )
+
+    # Check that the minimum pillar z-coordinate corresponds to the origin (z = 0)
+    min_pillar_z = np.min(grd._coordsv[:, :, 2])
+    assert min_pillar_z == pytest.approx(0.0)
+
+    # Check that the maximum pillar z-coordinate matches the total height nz * dz
+    max_pillar_z = np.max(grd._coordsv[:, :, 5])
+    assert max_pillar_z == pytest.approx(nz * dz)
+
+    # Check that the z-coordinates at intermediate layers (cell centers) are correct
+    _, _, z = grd.get_xyz()
+    expected_layer_centers = np.linspace(dz / 2.0, nz * dz - dz / 2.0, nz)
+    for k in range(nz):
+        # All cells in layer k should have the same z equal to the expected center
+        np.testing.assert_allclose(
+            z.values[:, :, k],
+            expected_layer_centers[k],
+            rtol=1e-6,
+            atol=1e-6,
+        )


### PR DESCRIPTION
Resolves #1589 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
