### PR TITLE
BUG: fix when segy file has non-standard iline/xline byte position

### DIFF
--- a/src/xtgeo/cube/_cube_import.py
+++ b/src/xtgeo/cube/_cube_import.py
@@ -33,12 +33,11 @@ import json
 from collections import defaultdict
 from copy import deepcopy
 from struct import unpack
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from warnings import warn
 
 import numpy as np
 import segyio
-from segyio import TraceField as TF
 
 import xtgeo.common.sys as xsys
 from xtgeo import _cxtgeo
@@ -55,19 +54,36 @@ xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
 
-def import_segy(sfile: FileWrapper) -> dict:
+def import_segy(
+    sfile: FileWrapper,
+    iline: Literal[189, 193] = 189,
+    xline: Literal[189, 193] = 193,
+) -> dict:
     """Import SEGY via the SegyIO library.
 
     Args:
         sfile: File object for SEGY file
+        iline: Byte position of the inline number field in trace headers.
+            Must be 189 or 193.  The only accepted combinations are the
+            SEGY-standard ``(iline=189, xline=193)`` and the swapped variant
+            ``(iline=193, xline=189)`` for files with non-standard byte
+            locations.
+        xline: Byte position of the crossline number field in trace headers.
+            Must be 189 or 193 and different from *iline*.
     """
+    if (iline, xline) not in ((189, 193), (193, 189)):
+        raise ValueError(
+            f"Invalid iline/xline byte positions ({iline}, {xline}). "
+            "Only (189, 193) and (193, 189) are accepted."
+        )
     sfile = sfile.file
 
     attributes = {}
 
     try:
         # cube with all traces present
-        with segyio.open(sfile, "r") as segyfile:
+        with segyio.open(sfile, "r", iline=iline, xline=xline) as segyfile:
+            _warn_if_crossline_sorted_default_bytes(segyfile, iline, xline)
             attributes = _import_segy_all_traces(segyfile)
     except ValueError as verr:
         if any(word in str(verr) for word in ["Invalid dimensions", "inconsistent"]):
@@ -80,7 +96,9 @@ def import_segy(sfile: FileWrapper) -> dict:
             )
 
             with segyio.open(sfile, "r", ignore_geometry=True) as segyfile:
-                attributes = _import_segy_incomplete_traces(segyfile)
+                attributes = _import_segy_incomplete_traces(
+                    segyfile, iline=iline, xline=xline
+                )
         else:
             raise
     except Exception as anyerror:  # catch the rest
@@ -91,6 +109,42 @@ def import_segy(sfile: FileWrapper) -> dict:
 
     attributes["segyfile"] = sfile
     return attributes
+
+
+def _warn_if_crossline_sorted_default_bytes(
+    segyfile: segyio.segy.SegyFile,
+    iline: Literal[189, 193],
+    xline: Literal[189, 193],
+) -> None:
+    """Emit a UserWarning when default byte positions yield a crossline-sorted cube.
+
+    A crossline-sorted file read with the SEGY-standard byte positions (iline=189,
+    xline=193) is imported correctly — the data array is transposed to xtgeo
+    convention automatically.  However, if the file was actually written with
+    *non-standard* byte positions (e.g. inline at byte 193, crossline at byte 189),
+    the automatic transposition still produces the correct spatial layout but the
+    ``ilines`` / ``xlines`` label arrays will be swapped, causing wrong
+    inline/crossline identification in some vendor software.
+
+    Because the two situations are geometrically indistinguishable for a complete
+    rectangular cube, exact detection is impossible.  This warning therefore fires
+    whenever default bytes are used and the file is crossline-sorted, prompting the
+    user to verify the orientation.
+    """
+    if iline != 189 or xline != 193:
+        # User already overrode the defaults — they know what they are doing.
+        return
+    if segyfile.sorting == segyio.TraceSortingFormat.CROSSLINE_SORTING:
+        warn(
+            "SEGY file is crossline-sorted when read with the default byte positions "
+            "(iline=189, xline=193).  The cube values are imported correctly via an "
+            "automatic transposition, but the inline/crossline *number labels* may be "
+            "swapped if the file uses non-standard byte positions.  "
+            "If the orientation looks wrong in your interpretation software, reload "
+            "with the swapped positions: cube_from_file(..., iline=193, xline=189).",
+            UserWarning,
+            stacklevel=2,
+        )
 
 
 def _import_segy_all_traces(segyfile: segyio.segy.SegyFile) -> dict:
@@ -105,16 +159,31 @@ def _import_segy_all_traces(segyfile: segyio.segy.SegyFile) -> dict:
 
     values = _process_cube_values(segyio.tools.cube(segyfile))
 
-    ilines = segyfile.ilines
-    xlines = segyfile.xlines
-
     ncol, nrow, nlay = values.shape
 
     # get additional but required geometries for xtgeo; xori, yori, xinc, ..., rotation
+    # Pass the raw shape so corner-index calculation matches the file's trace order.
     attrs = _segy_all_traces_attributes(segyfile, ncol, nrow, nlay)
 
-    attrs["ilines"] = ilines
-    attrs["xlines"] = xlines
+    xlsort = segyfile.sorting == segyio.TraceSortingFormat.CROSSLINE_SORTING
+    if xlsort:
+        # segyio.tools.cube() returns (n_xlines, n_ilines, n_samples) for
+        # crossline-sorted files. Normalize to xtgeo convention (axis-0 = ilines)
+        # by applying the same transformation as swapaxes(): swap array axes 0/1
+        # and adjust rotation/yflip/xinc/yinc accordingly.
+        values = np.ascontiguousarray(np.swapaxes(values, 0, 1))
+        attrs["traceidcodes"] = np.ascontiguousarray(
+            np.swapaxes(attrs["traceidcodes"], 0, 1)
+        )
+        ncol, nrow = nrow, ncol
+        attrs["ncol"], attrs["nrow"] = ncol, nrow
+        attrs["xinc"], attrs["yinc"] = attrs["yinc"], attrs["xinc"]
+        yflip = attrs["yflip"]
+        attrs["rotation"] = (attrs["rotation"] + yflip * 90) % 360
+        attrs["yflip"] = yflip * -1
+
+    attrs["ilines"] = segyfile.ilines  # ncol entries (axis-0 = inlines)
+    attrs["xlines"] = segyfile.xlines  # nrow entries (axis-1 = xlines)
     attrs["values"] = values
 
     return attrs
@@ -177,7 +246,11 @@ def _segy_all_traces_attributes(
     }
 
 
-def _import_segy_incomplete_traces(segyfile: segyio.segy.SegyFile) -> dict:
+def _import_segy_incomplete_traces(
+    segyfile: segyio.segy.SegyFile,
+    iline: int = 189,
+    xline: int = 193,
+) -> dict:
     """Import a a cube SEGY with incomplete traces via the SegyIO library.
 
     Note that the undefined value will be xtgeo.UNDEF (large number)!
@@ -187,6 +260,8 @@ def _import_segy_incomplete_traces(segyfile: segyio.segy.SegyFile) -> dict:
 
     Args:
         segyfile: Filehandle from segyio
+        iline: Byte position of the inline number field in trace headers.
+        xline: Byte position of the crossline number field in trace headers.
     """
     segyfile.mmap()
     # get data (which will need padding later for missing traces)
@@ -195,8 +270,8 @@ def _import_segy_incomplete_traces(segyfile: segyio.segy.SegyFile) -> dict:
     trcode = segyio.TraceField.TraceIdentificationCode
     traceidcodes_input = segyfile.attributes(trcode)[:]
 
-    ilines_case = np.array([h[TF.INLINE_3D] for h in segyfile.header])
-    xlines_case = np.array([h[TF.CROSSLINE_3D] for h in segyfile.header])
+    ilines_case = np.array([h[iline] for h in segyfile.header])
+    xlines_case = np.array([h[xline] for h in segyfile.header])
 
     # detect minimum inline and xline spacing (e.g.sampling could be every second)
     idiff = np.diff(ilines_case)
@@ -238,6 +313,8 @@ def _import_segy_incomplete_traces(segyfile: segyio.segy.SegyFile) -> dict:
         xlines_case,
         ispacing,
         xspacing,
+        iline=iline,
+        xline=xline,
     )
 
     attrs["ncol"] = ncol
@@ -299,6 +376,8 @@ def _geometry_incomplete_traces(
     xlines_case: list[int],
     ispacing: int,
     xspacing: int,
+    iline: int = 189,
+    xline: int = 193,
 ) -> list:
     """Compute xtgeo attributes (mostly geometries) for incomplete trace cube."""
     attrs = {}
@@ -308,10 +387,7 @@ def _geometry_incomplete_traces(
 
     # need both partial and full reverse lookup of indices vs (iline, xxline)
     # for computing cube origin later
-    index_case = {
-        ind: (h[TF.INLINE_3D], h[TF.CROSSLINE_3D])
-        for ind, h in enumerate(segyfile.header)
-    }
+    index_case = {ind: (h[iline], h[xline]) for ind, h in enumerate(segyfile.header)}
 
     reverseindex_full = {
         (il, xl): (ind, xnd)

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -50,19 +50,31 @@ def _data_reader_factory(fmt: FileFormat):
     )
 
 
-def cube_from_file(mfile, fformat="guess"):
+def cube_from_file(
+    mfile,
+    fformat="guess",
+    iline: Literal[189, 193] = 189,
+    xline: Literal[189, 193] = 193,
+):
     """This makes an instance of a Cube directly from file import.
 
     Args:
         mfile (str): Name of file
         fformat (str): See :meth:`Cube.from_file`
+        iline (Literal[189, 193]): Byte position of the inline number field in
+            each trace header. Default is 189 (SEGY standard). Only 189 and 193
+            are valid; use ``iline=193, xline=189`` for files with non-standard
+            byte locations.
+        xline (Literal[189, 193]): Byte position of the crossline number field
+            in each trace header. Default is 193 (SEGY standard). Must differ
+            from *iline*.
 
     Example::
 
         >>> import xtgeo
         >>> mycube = xtgeo.cube_from_file(cube_dir + "/ib_test_cube2.segy")
     """
-    return Cube._read_file(mfile, fformat)
+    return Cube._read_file(mfile, fformat, iline=iline, xline=xline)
 
 
 def cube_from_roxar(project, name, folder=None):
@@ -823,7 +835,13 @@ class Cube:
     # =========================================================================
 
     @classmethod
-    def _read_file(cls, sfile, fformat="guess"):
+    def _read_file(
+        cls,
+        sfile,
+        fformat="guess",
+        iline: Literal[189, 193] = 189,
+        xline: Literal[189, 193] = 193,
+    ):
         """Import cube data from file.
 
         If fformat is not provided, the file type will be guessed based
@@ -833,8 +851,11 @@ class Cube:
             sfile (str): Filename (as string or pathlib.Path instance).
             fformat (str): file format guess/segy/rms_regular/xtgregcube
                 where 'guess' is default. Regard 'xtgrecube' format as experimental.
-            deadtraces (float): Set 'dead' trace values to this value (SEGY
-                only). Default is UNDEF value (a very large number).
+            iline (Literal[189, 193]): Byte position of the inline number in
+                trace headers.  Only ``(189, 193)`` or ``(193, 189)`` pairs
+                are accepted.  Applies to SEGY format only.
+            xline (Literal[189, 193]): Byte position of the crossline number in
+                trace headers.  Must differ from *iline*.
 
         Raises:
             OSError: if the file cannot be read (e.g. not found)
@@ -849,9 +870,22 @@ class Cube:
         """
         mfile = FileWrapper(sfile)
         fmt = mfile.fileformat(fformat)
-        kwargs = _data_reader_factory(fmt)(mfile)
-        kwargs["filesrc"] = mfile.file
-        return cls(**kwargs)
+        if fmt != FileFormat.SEGY and (iline != 189 or xline != 193):
+            from warnings import warn
+
+            warn(
+                "iline/xline parameters are only used for SEGY format and "
+                f"will be ignored for {fmt.value!r} files.",
+                UserWarning,
+                stacklevel=2,
+            )
+        reader = _data_reader_factory(fmt)
+        if fmt == FileFormat.SEGY:
+            attrs = reader(mfile, iline=iline, xline=xline)
+        else:
+            attrs = reader(mfile)
+        attrs["filesrc"] = mfile.file
+        return cls(**attrs)
 
     def to_file(self, sfile, fformat="segy", pristine=False, engine=None):
         """Export cube data to file.

--- a/tests/test_cube/test_cube.py
+++ b/tests/test_cube/test_cube.py
@@ -525,3 +525,205 @@ def test_swapaxis_xinc_yinc():
     cube.swapaxes()
 
     assert (cube.xinc, cube.yinc) == (2, 1)
+
+
+def test_segy_io_roundtrip(tmp_path):
+    """Round-trip SEGY with non-standard byte positions (il-byte 193, xl-byte 189).
+
+    Some vendor software writes inline numbers to byte 193 and crossline numbers to
+    byte 189 instead of the SEGY-standard positions (189/193).  xtgeo must:
+
+      - read the file correctly when the caller supplies the actual byte positions
+      - warn when the default positions are used (file then appears crossline-sorted
+        because the physical crosslines occupy the fast-varying byte 189)
+      - export to a standard-bytes file that round-trips values and labels correctly
+    """
+    n_ilines, n_xlines, n_samples = 4, 6, 8
+    xori, yori, zori = 500.0, 1000.0, 0.0
+    xinc_xl, yinc_il, zinc = 25.0, 50.0, 4.0
+
+    segyfile = tmp_path / "nonstandard_bytes.segy"
+    iline_nums = np.arange(1, n_ilines + 1, dtype=np.int32)
+    xline_nums = np.arange(1, n_xlines + 1, dtype=np.int32)
+
+    # Write inline numbers to byte 193 and crossline to byte 189.
+    # segyio.TraceField.INLINE_3D == 189, CROSSLINE_3D == 193 (fixed byte offsets),
+    # so we intentionally assign the values to the *opposite* fields.
+    spec = segyio.spec()
+    spec.sorting = None  # unstructured — headers written explicitly
+    spec.format = 5  # IEEE float32
+    spec.samples = np.arange(n_samples, dtype=np.float32) * zinc + zori
+    spec.tracecount = n_ilines * n_xlines
+
+    rng = np.random.default_rng(7)
+    trace_data = rng.random((n_ilines, n_xlines, n_samples), dtype=np.float32)
+
+    with segyio.create(str(segyfile), spec) as f:
+        tr = 0
+        for il_idx, il in enumerate(iline_nums):
+            for xl_idx, xl in enumerate(xline_nums):
+                x = xori + xl_idx * xinc_xl
+                y = yori + il_idx * yinc_il
+                f.header[tr] = {
+                    segyio.TraceField.CROSSLINE_3D: int(il),  # byte 193 ← inline
+                    segyio.TraceField.INLINE_3D: int(xl),  # byte 189 ← crossline
+                    segyio.TraceField.CDP_X: int(round(x * 100)),
+                    segyio.TraceField.CDP_Y: int(round(y * 100)),
+                    segyio.TraceField.SourceGroupScalar: -100,
+                    segyio.TraceField.TRACE_SAMPLE_INTERVAL: int(zinc * 1000),
+                    segyio.TraceField.TRACE_SAMPLE_COUNT: n_samples,
+                    segyio.TraceField.DelayRecordingTime: int(zori),
+                }
+                f.trace[tr] = trace_data[il_idx, xl_idx, :]
+                tr += 1
+        f.bin[segyio.BinField.Interval] = int(zinc * 1000)
+        f.bin[segyio.BinField.Samples] = n_samples
+
+    # --- Correct import: supply the actual byte positions ---
+    cube = xtgeo.cube_from_file(str(segyfile), iline=193, xline=189)
+    assert cube.ncol == n_ilines
+    assert cube.nrow == n_xlines
+    assert cube.ilines.tolist() == iline_nums.tolist()
+    assert cube.xlines.tolist() == xline_nums.tolist()
+
+    # --- Export to a standard-bytes file and verify round-trip ---
+    outfile = tmp_path / "roundtrip_cube.segy"
+    cube.to_file(outfile)
+    cube_rt = xtgeo.cube_from_file(outfile)
+    assert cube_rt.ncol == n_ilines
+    assert cube_rt.nrow == n_xlines
+    assert cube_rt.ilines.tolist() == iline_nums.tolist()
+    np.testing.assert_array_almost_equal(cube.values, cube_rt.values, decimal=4)
+
+    # --- Default bytes: must warn — byte 189 carries xline (fast) values ---
+    with pytest.warns(UserWarning, match="crossline-sorted"):
+        cube2 = xtgeo.cube_from_file(str(segyfile))
+    # With default bytes the labels are transposed: xl values appear as ilines, etc.
+    assert cube2.ilines.tolist() == xline_nums.tolist()
+    assert cube2.xlines.tolist() == iline_nums.tolist()
+
+
+def test_segy_crossline_sorted_import_export(tmp_path):
+    """Crossline-sorted SEGY must import and re-export with correct orientation.
+
+    segyio.tools.cube() returns (n_xlines, n_ilines, nsamples) for crossline-sorted
+    files. xtgeo must transpose to its convention (axis-0 = inlines) so that:
+      - exported INLINE_3D / CROSSLINE_3D headers are NOT swapped
+      - the CDP_X / CDP_Y for every (INLINE, CROSSLINE) pair is identical to
+        the original file
+
+    Uses deliberately asymmetric inline/xline spacings (12.5 vs 25.0) so a
+    xinc/yinc swap would produce wrong coordinates, catching the bug the user
+    reported (inlines appearing perpendicular in RMS after a round-trip).
+    """
+    n_ilines, n_xlines, n_samples = 3, 5, 4
+    xori, yori, zori = 1000.0, 2000.0, 0.0
+    # Deliberately different so a xinc/yinc swap is detectable
+    xinc_xline = 12.5  # spacing between adjacent xlines (East direction)
+    yinc_inline = 25.0  # spacing between adjacent inlines (North direction)
+    zinc = 4.0
+
+    segyfile = tmp_path / "xline_sorted.segy"
+
+    iline_nums = np.arange(1, n_ilines + 1, dtype=np.int32)
+    xline_nums = np.arange(1, n_xlines + 1, dtype=np.int32)
+
+    spec = segyio.spec()
+    spec.sorting = 1  # crossline sorting
+    spec.format = 5
+    spec.samples = np.arange(n_samples) * zinc + zori
+    spec.ilines = iline_nums
+    spec.xlines = xline_nums
+
+    rng = np.random.default_rng(42)
+    trace_data = rng.random((n_ilines, n_xlines, n_samples), dtype=np.float32)
+
+    # Build a lookup: (il, xl) -> (cdpx, cdpy) to check round-trip preservation
+    original_coords: dict[tuple[int, int], tuple[float, float]] = {}
+
+    with segyio.create(str(segyfile), spec) as f:
+        tr = 0
+        for xl_idx, xl in enumerate(xline_nums):
+            for il_idx, il in enumerate(iline_nums):
+                # xlines run East (+X), inlines run North (+Y)
+                x = xori + xl_idx * xinc_xline
+                y = yori + il_idx * yinc_inline
+                original_coords[(int(il), int(xl))] = (x, y)
+                f.header[tr] = {
+                    segyio.TraceField.INLINE_3D: int(il),
+                    segyio.TraceField.CROSSLINE_3D: int(xl),
+                    segyio.TraceField.CDP_X: int(round(x * 100)),
+                    segyio.TraceField.CDP_Y: int(round(y * 100)),
+                    segyio.TraceField.SourceGroupScalar: -100,
+                    segyio.TraceField.TRACE_SAMPLE_INTERVAL: int(zinc * 1000),
+                    segyio.TraceField.TRACE_SAMPLE_COUNT: n_samples,
+                    segyio.TraceField.DelayRecordingTime: int(zori),
+                }
+                f.trace[tr] = trace_data[il_idx, xl_idx, :]
+                tr += 1
+        f.bin[segyio.BinField.Interval] = int(zinc * 1000)
+        f.bin[segyio.BinField.Samples] = n_samples
+        f.bin[segyio.BinField.SortingCode] = 1
+
+    with pytest.warns(UserWarning, match="crossline-sorted"):
+        cube = xtgeo.cube_from_file(str(segyfile))
+
+    # After normalising to xtgeo convention: axis-0 = inlines
+    assert cube.ncol == n_ilines
+    assert cube.nrow == n_xlines
+    assert cube.nlay == n_samples
+    assert len(cube.ilines) == cube.ncol
+    assert len(cube.xlines) == cube.nrow
+
+    outfile = tmp_path / "roundtrip.segy"
+    cube.to_file(outfile)
+
+    # Read back exported file and verify every (INLINE, CROSSLINE) pair has
+    # the same CDP_X/CDP_Y as the original -- this is what RMS would check.
+    with segyio.open(str(outfile), "r", ignore_geometry=True) as f:
+        for hdr in f.header:
+            il = hdr[segyio.TraceField.INLINE_3D]
+            xl = hdr[segyio.TraceField.CROSSLINE_3D]
+            scaler = hdr[segyio.TraceField.SourceGroupScalar]
+            raw_x = hdr[segyio.TraceField.CDP_X]
+            raw_y = hdr[segyio.TraceField.CDP_Y]
+            scale = -1.0 / scaler if scaler < 0 else float(scaler)
+            exported_x = raw_x * scale
+            exported_y = raw_y * scale
+
+            expected_x, expected_y = original_coords[(il, xl)]
+            assert exported_x == pytest.approx(expected_x, abs=0.1), (
+                f"CDP_X mismatch for IL={il} XL={xl}"
+            )
+            assert exported_y == pytest.approx(expected_y, abs=0.1), (
+                f"CDP_Y mismatch for IL={il} XL={xl}"
+            )
+
+
+@pytest.mark.parametrize(
+    "iline, xline",
+    [
+        (189, 189),
+        (193, 193),
+        (181, 193),
+        (189, 197),
+        (0, 0),
+    ],
+)
+def test_invalid_iline_xline_raises(tmp_path, iline, xline):
+    """Only (189, 193) and (193, 189) are accepted for iline/xline."""
+    cube = xtgeo.Cube(ncol=2, nrow=2, nlay=2, xinc=1, yinc=1, zinc=1)
+    outfile = tmp_path / "tiny.segy"
+    cube.to_file(outfile)
+    with pytest.raises(
+        ValueError, match=r"Only \(189, 193\) and \(193, 189\) are accepted\."
+    ):
+        xtgeo.cube_from_file(outfile, iline=iline, xline=xline)
+
+
+def test_iline_xline_ignored_for_non_segy(tmp_path, testdata_path):
+    """Passing non-default iline/xline for a non-SEGY file should warn."""
+    with pytest.warns(UserWarning, match="only used for SEGY"):
+        xtgeo.cube_from_file(
+            testdata_path / SFILE3, fformat="storm", iline=193, xline=189
+        )


### PR DESCRIPTION

Resolves #1592 


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
