### PR TITLE
BUG: Fix C integer overflow and format warnings

### DIFF
--- a/src/lib/src/cube/cube.cpp
+++ b/src/lib/src/cube/cube.cpp
@@ -214,7 +214,7 @@ cube_stats_along_z(const Cube &cube,
                 min_val = std::min(min_val, static_cast<double>(value));
                 max_val = std::max(max_val, static_cast<double>(value));
                 sum += value;
-                sum_sq += value * value;
+                sum_sq += static_cast<double>(value) * static_cast<double>(value);
                 double abs_value = std::abs(value);
                 sum_abs += abs_value;
                 if (value >= 0) {

--- a/src/lib/src/cube/cube.cpp
+++ b/src/lib/src/cube/cube.cpp
@@ -205,26 +205,26 @@ cube_stats_along_z(const Cube &cube,
                 if (depth < upper_z || depth > lower_z) {
                     continue;
                 }
-                float value = refined_trace[k];
+                double value = refined_trace[k];
                 if (std::isnan(value)) {
                     continue;
                 }
                 n_items++;
 
-                min_val = std::min(min_val, static_cast<double>(value));
-                max_val = std::max(max_val, static_cast<double>(value));
+                min_val = std::min(min_val, value);
+                max_val = std::max(max_val, value);
                 sum += value;
-                sum_sq += static_cast<double>(value) * static_cast<double>(value);
+                sum_sq += value * value;
                 double abs_value = std::abs(value);
                 sum_abs += abs_value;
                 if (value >= 0) {
                     sum_pos += value;
                     n_items_pos++;
-                    max_pos = std::max(max_pos, static_cast<double>(value));
+                    max_pos = std::max(max_pos, value);
                 } else {
                     sum_neg += value;
                     n_items_neg++;
-                    max_neg = std::min(max_neg, static_cast<double>(value));
+                    max_neg = std::min(max_neg, value);
                 }
                 max_abs = std::max(max_abs, abs_value);
 

--- a/src/lib/src/cube_get_randomline.c
+++ b/src/lib/src/cube_get_randomline.c
@@ -57,7 +57,8 @@ cube_get_randomline(double *xvec,
 {
     /* locals */
     int ib, ic, izc, ier;
-    float val, zsam;
+    float val;
+    double zsam;
 
     zsam = (zmax - zmin) / (nzsam - 1);
 
@@ -68,7 +69,7 @@ cube_get_randomline(double *xvec,
 
         for (izc = 0; izc < nzsam; izc++) {
 
-            float zc = zmin + izc * zsam;
+            double zc = zmin + (double)izc * zsam;
 
             if (option == 0) {
                 ier =

--- a/src/lib/src/grd3d_get_randomline.c
+++ b/src/lib/src/grd3d_get_randomline.c
@@ -69,7 +69,7 @@ _get_ij_range(int *i1,
     long nmap;
     int itop, jtop, ibas, jbas, ii1, ii2, jj1, jj2;
 
-    nmap = mcol * mrow;
+    nmap = (long)mcol * (long)mrow;
 
     /* get map value for I J from x y */
     int opt = 2; /* nearest sampling */

--- a/src/lib/src/grdcp3d_calc_dxdydz.c
+++ b/src/lib/src/grdcp3d_calc_dxdydz.c
@@ -179,15 +179,15 @@ grdcp3d_calc_dy(int nx,
                 metric m)
 
 {
-    if (ncoord != (nx + 1) * (ny + 1) * 6) {
+    if (ncoord != ((long)nx + 1L) * ((long)ny + 1L) * 6L) {
         throw_exception("Incorrect size of coordsv.");
         return EXIT_FAILURE;
     }
-    if (nzcorn != (nx + 1) * (ny + 1) * (nz + 1) * 4) {
+    if (nzcorn != ((long)nx + 1L) * ((long)ny + 1L) * ((long)nz + 1L) * 4L) {
         throw_exception("Incorrect size of zcornsv.");
         return EXIT_FAILURE;
     }
-    if (ndy != nx * ny * nz) {
+    if (ndy != (long)nx * (long)ny * (long)nz) {
         throw_exception("Incorrect size of dx.");
         return EXIT_FAILURE;
     }
@@ -207,7 +207,7 @@ grdcp3d_calc_dy(int nx,
     }
     size_t corner_line1_start = 0;
 
-    size_t num_plane = (nx + 1) * (ny + 1);
+    size_t num_plane = ((size_t)nx + 1U) * ((size_t)ny + 1U);
     for (size_t pair_index = 1, cell_plane_index = 0; pair_index < num_plane;
          pair_index++) {
 
@@ -221,16 +221,16 @@ grdcp3d_calc_dy(int nx,
         // of cells. Those having the edges of that pair to the west and those
         // having them to the east (west/east is x direction). We go through
         // each layer in that pillar/line pair.
-        size_t west_pillar_start = nz * cell_plane_index;
-        size_t corner_line1_end = corner_line1_start + (nz + 1);
-        size_t corner_line2_start = (nz + 1) * pair_index;
+        size_t west_pillar_start = (size_t)nz * cell_plane_index;
+        size_t corner_line1_end = corner_line1_start + ((size_t)nz + 1U);
+        size_t corner_line2_start = ((size_t)nz + 1U) * pair_index;
 
         // Skip the pair of corners going from the end of a row
         // to the start of the next row
-        if (pair_index % (ny + 1) != 0) {
+        if (pair_index % ((size_t)ny + 1U) != 0) {
 
-            char west_in_bounds = pair_index >= ny + 1;
-            char east_in_bounds = pair_index < num_plane - (ny + 1);
+            char west_in_bounds = pair_index >= ((size_t)ny + 1U);
+            char east_in_bounds = pair_index < num_plane - ((size_t)ny + 1U);
 
             for (size_t j = corner_line1_start, k = corner_line2_start,
                         jj = west_pillar_start;
@@ -264,12 +264,12 @@ grdcp3d_calc_dy(int nx,
                     if (l == 0 && west_in_bounds) {
                         // the cell to the west and above the edge
                         if (!at_top) {
-                            dy[jj - (ny * nz)] += vector_len;
+                            dy[jj - ((size_t)ny * (size_t)nz)] += vector_len;
                         }
 
                         // the cell to the west and below the edge
                         if (!at_bottom) {
-                            dy[(jj - (ny * nz)) - 1] += vector_len;
+                            dy[(jj - ((size_t)ny * (size_t)nz)) - 1] += vector_len;
                         }
                     } else if (l == 1 && east_in_bounds) {
                         // the cell to the east and above the edge
@@ -308,15 +308,15 @@ grdcp3d_calc_dx(int nx,
                 metric m)
 
 {
-    if (ncoord != (nx + 1) * (ny + 1) * 6) {
+    if (ncoord != ((long)nx + 1L) * ((long)ny + 1L) * 6L) {
         throw_exception("Incorrect size of coordsv.");
         return EXIT_FAILURE;
     }
-    if (nzcorn != (nx + 1) * (ny + 1) * (nz + 1) * 4) {
+    if (nzcorn != ((long)nx + 1L) * ((long)ny + 1L) * ((long)nz + 1L) * 4L) {
         throw_exception("Incorrect size of zcornsv.");
         return EXIT_FAILURE;
     }
-    if (ndx != nx * ny * nz) {
+    if (ndx != (long)nx * (long)ny * (long)nz) {
         throw_exception("Incorrect size of dx.");
         return EXIT_FAILURE;
     }
@@ -329,11 +329,11 @@ grdcp3d_calc_dx(int nx,
     // their corners and adds it contribution to the average of the cells
     // it is an edge of.
 
-    size_t num_line_pairs = nx * (ny + 1);
+    size_t num_line_pairs = (size_t)nx * ((size_t)ny + 1U);
 
     for (size_t pair_index = 0, cell_plane_index = 0; pair_index < num_line_pairs;
          pair_index++) {
-        if (pair_index % (ny + 1) != 0) {
+        if (pair_index % ((size_t)ny + 1U) != 0) {
             // There is one more line in the y direction then there
             // are cells, so we have to keep two indices.
             cell_plane_index++;
@@ -347,7 +347,8 @@ grdcp3d_calc_dx(int nx,
 
         // The next corner line in x direction (second in the pair)
         PlanarMap pm2;
-        if (pm_from_corner_line(coordsv, pair_index + ny + 1, &pm2) == EXIT_FAILURE) {
+        if (pm_from_corner_line(coordsv, pair_index + ((size_t)ny + 1U), &pm2) ==
+            EXIT_FAILURE) {
             return EXIT_FAILURE;
         }
 
@@ -355,13 +356,14 @@ grdcp3d_calc_dx(int nx,
         // of cells. Those having the edges of that pair to the north and those
         // having them to the south (north/south is y direction). We go through
         // each layer in that pillar/line pair.
-        size_t north_pillar_start = nz * cell_plane_index;
-        size_t corner_line1_start = (nz + 1) * pair_index;
-        size_t corner_line1_end = corner_line1_start + (nz + 1);
-        size_t corner_line2_start = (nz + 1) * (pair_index + (ny + 1));
+        size_t north_pillar_start = (size_t)nz * cell_plane_index;
+        size_t corner_line1_start = ((size_t)nz + 1U) * pair_index;
+        size_t corner_line1_end = corner_line1_start + ((size_t)nz + 1U);
+        size_t corner_line2_start =
+          ((size_t)nz + 1U) * (pair_index + ((size_t)ny + 1U));
 
-        char north_in_bounds = pair_index % (ny + 1) != ny;
-        char south_in_bounds = pair_index % (ny + 1) != 0;
+        char north_in_bounds = pair_index % ((size_t)ny + 1U) != (size_t)ny;
+        char south_in_bounds = pair_index % ((size_t)ny + 1U) != 0;
 
         for (size_t j = corner_line1_start, k = corner_line2_start,
                     jj = north_pillar_start;
@@ -395,12 +397,12 @@ grdcp3d_calc_dx(int nx,
                 if (l == 0 && south_in_bounds) {
                     // the cell to the south and above the edge
                     if (!at_top) {
-                        dx[jj - nz] += vector_len;
+                        dx[jj - (size_t)nz] += vector_len;
                     }
 
                     // the cell to the south and below the edge
                     if (!at_bottom) {
-                        dx[(jj - nz) - 1] += vector_len;
+                        dx[(jj - (size_t)nz) - 1] += vector_len;
                     }
                 } else if (l == 2 && north_in_bounds) {
                     // the cell to the south and above the edge
@@ -432,15 +434,15 @@ grdcp3d_calc_dz(int nx,
                 metric m)
 
 {
-    if (ncoord != (nx + 1) * (ny + 1) * 6) {
+    if (ncoord != ((long)nx + 1L) * ((long)ny + 1L) * 6L) {
         throw_exception("Incorrect size of coordsv.");
         return EXIT_FAILURE;
     }
-    if (nzcorn != (nx + 1) * (ny + 1) * (nz + 1) * 4) {
+    if (nzcorn != ((long)nx + 1L) * ((long)ny + 1L) * ((long)nz + 1L) * 4L) {
         throw_exception("Incorrect size of zcornsv.");
         return EXIT_FAILURE;
     }
-    if (ndx != nx * ny * nz) {
+    if (ndx != (long)nx * (long)ny * (long)nz) {
         throw_exception("Incorrect size of dx.");
         return EXIT_FAILURE;
     }
@@ -453,11 +455,11 @@ grdcp3d_calc_dz(int nx,
     // z direction, and adds the contribution of length average to
     // corresponding cells.
 
-    size_t num_corner_lines = (nx + 1) * (ny + 1);
+    size_t num_corner_lines = ((size_t)nx + 1U) * ((size_t)ny + 1U);
 
     for (size_t pair_index = 0, cell_plane_index = 0; pair_index < num_corner_lines;
          pair_index++) {
-        if (pair_index % (ny + 1) != 0) {
+        if (pair_index % ((size_t)ny + 1U) != 0) {
             // There is one more line in the y direction then there
             // are cells, so we have to keep two indecies.
             cell_plane_index++;
@@ -468,14 +470,14 @@ grdcp3d_calc_dz(int nx,
             return EXIT_FAILURE;
         }
 
-        size_t north_east_pillar_start = nz * cell_plane_index;
-        size_t corner_line_start = (nz + 1) * pair_index;
-        size_t corner_line_end = corner_line_start + (nz + 1);
+        size_t north_east_pillar_start = (size_t)nz * cell_plane_index;
+        size_t corner_line_start = ((size_t)nz + 1U) * pair_index;
+        size_t corner_line_end = corner_line_start + ((size_t)nz + 1U);
 
-        char north_in_bounds = pair_index % (ny + 1) != ny;
-        char south_in_bounds = pair_index % (ny + 1) != 0;
-        char west_in_bounds = pair_index >= ny + 1;
-        char east_in_bounds = pair_index < num_corner_lines - (ny + 1);
+        char north_in_bounds = pair_index % ((size_t)ny + 1U) != (size_t)ny;
+        char south_in_bounds = pair_index % ((size_t)ny + 1U) != 0;
+        char west_in_bounds = pair_index >= ((size_t)ny + 1U);
+        char east_in_bounds = pair_index < num_corner_lines - ((size_t)ny + 1U);
 
         for (size_t j = corner_line_start, jj = north_east_pillar_start;
              j < corner_line_end - 1; j += 1, jj += 1) {
@@ -498,11 +500,11 @@ grdcp3d_calc_dz(int nx,
                 double vector_len = 0.25 * m(x1, y1, z1, x2, y2, z2);
 
                 if (l == 0 && south_in_bounds && west_in_bounds) {
-                    dx[jj - nz * (ny + 1)] += vector_len;
+                    dx[jj - ((size_t)nz * ((size_t)ny + 1U))] += vector_len;
                 } else if (l == 1 && south_in_bounds && east_in_bounds) {
-                    dx[jj - nz] += vector_len;
+                    dx[jj - (size_t)nz] += vector_len;
                 } else if (l == 2 && north_in_bounds && west_in_bounds) {
-                    dx[jj - nz * ny] += vector_len;
+                    dx[jj - ((size_t)nz * (size_t)ny)] += vector_len;
                 } else if (l == 3 && north_in_bounds && east_in_bounds) {
                     dx[jj] += vector_len;
                 }

--- a/src/lib/src/grdcp3d_xtgformat2to1_geom.c
+++ b/src/lib/src/grdcp3d_xtgformat2to1_geom.c
@@ -51,7 +51,7 @@ grd3cp3d_xtgformat2to1_geom(long ncol,
     long nnrow = nrow + 1;
     long nnlay = nlay + 1;
 
-    logger_info(LI, FI, FU, "Dimensions: %d %d %d", ncol, nrow, nlay);
+    logger_info(LI, FI, FU, "Dimensions: %ld %ld %ld", ncol, nrow, nlay);
     logger_info(LI, FI, FU, "Transforming grid coordsv -> XTG internal format 2 to 1");
     long ib = 0;
     long j;

--- a/src/lib/src/grid3d/grid.cpp
+++ b/src/lib/src/grid3d/grid.cpp
@@ -195,7 +195,9 @@ std::vector<CellCorners>
 cell_refinement(const CellCorners &cell, const int rx, const int ry, const int rz)
 {
     std::vector<CellCorners> refined_corners;
-    refined_corners.reserve(rx * ry * rz);
+    refined_corners.reserve(static_cast<std::size_t>(rx) *
+                            static_cast<std::size_t>(ry) *
+                            static_cast<std::size_t>(rz));
 
     const double inv_rx = 1.0 / rx;
     const double inv_ry = 1.0 / ry;

--- a/src/lib/src/grid3d/grid.cpp
+++ b/src/lib/src/grid3d/grid.cpp
@@ -192,19 +192,20 @@ get_cell_volumes(const Grid &grd,
  */
 
 std::vector<CellCorners>
-cell_refinement(const CellCorners &cell, const int rx, const int ry, const int rz)
+cell_refinement(const CellCorners &cell,
+                const size_t rx,
+                const size_t ry,
+                const size_t rz)
 {
     std::vector<CellCorners> refined_corners;
-    refined_corners.reserve(static_cast<std::size_t>(rx) *
-                            static_cast<std::size_t>(ry) *
-                            static_cast<std::size_t>(rz));
+    refined_corners.reserve(rx * ry * rz);
 
     const double inv_rx = 1.0 / rx;
     const double inv_ry = 1.0 / ry;
     const double inv_rz = 1.0 / rz;
 
     // Loop through all refined cells
-    for (int ix = 0; ix < rx; ix++) {
+    for (size_t ix = 0; ix < rx; ix++) {
         const double tx1 = ix * inv_rx;
         const double tx2 = (ix + 1) * inv_rx;
         const double dtx = inv_rx;
@@ -225,7 +226,7 @@ cell_refinement(const CellCorners &cell, const int rx, const int ry, const int r
         const xyz::Point u_n1 = cell.upper_nw + (cell.upper_ne - cell.upper_nw) * tx1;
         const xyz::Point u_n2 = u_n1 + (cell.upper_ne - cell.upper_nw) * dtx;
 
-        for (int iy = 0; iy < ry; iy++) {
+        for (size_t iy = 0; iy < ry; iy++) {
             const double ty1 = iy * inv_ry;
             const double ty2 = (iy + 1) * inv_ry;
 

--- a/src/lib/src/surf_get_dist_values.c
+++ b/src/lib/src/surf_get_dist_values.c
@@ -65,10 +65,10 @@ surf_get_dist_values(double xori,
     azi = (azimuth)*PI / 180.0; /* radians, positive */
 
     /* get the coordinates */
-    xv = calloc(nn, sizeof(double));
-    yv = calloc(nn, sizeof(double));
+    xv = calloc((size_t)nx * (size_t)ny, sizeof(double));
+    yv = calloc((size_t)nx * (size_t)ny, sizeof(double));
 
-    nn = nx * ny;
+    nn = (long)nx * (long)ny;
     ier = surf_xy_as_values(xori, xinc, yori, yinc, nx, ny, rot_deg, xv, nn, yv, nn, 0);
 
     if (ier != 0) {

--- a/src/lib/src/surf_get_z_from_xy.c
+++ b/src/lib/src/surf_get_z_from_xy.c
@@ -64,7 +64,7 @@ surf_get_z_from_xy(double x,
     double x_v[4], y_v[4], z_v[4];
     double xx, yy, zz, z = 0.0, rx, ry;
 
-    if (nx * ny != nn)
+    if ((long)nx * (long)ny != nn)
         logger_error(LI, FI, FU, "Fatal error in %s", FU);
 
     /* get i and j for lower left corner, given a point X Y*/

--- a/src/lib/src/surf_get_zv_from_xyv.c
+++ b/src/lib/src/surf_get_zv_from_xyv.c
@@ -55,7 +55,7 @@ surf_get_zv_from_xyv(double *xv,
 {
     int i;
 
-    nn = nx * ny;
+    nn = (long)nx * (long)ny;
 
     for (i = 0; i < nxv; i++) {
         zv[i] = surf_get_z_from_xy(xv[i], yv[i], nx, ny, xori, yori, xinc, yinc, yflip,

--- a/src/lib/src/surf_import_petromod_bin.c
+++ b/src/lib/src/surf_import_petromod_bin.c
@@ -47,7 +47,7 @@ surf_import_petromod_bin(FILE *fc,
 
     logger_info(LI, FI, FU, "Read PETROMOD binary map file: %s", FU);
 
-    if (mx * my != nsurf) {
+    if ((long)mx * (long)my != nsurf) {
         memset(surfzv, 0, nsurf * sizeof(double));
         dsc[0] = '\0';
         throw_exception("mx * my != nsurf, bug in surf_import_petromod_bin");

--- a/src/lib/src/surf_slice_grd3d.c
+++ b/src/lib/src/surf_slice_grd3d.c
@@ -75,7 +75,7 @@ surf_slice_grd3d(int mcol,
     if (ier == -2)
         logger_error(LI, FI, FU, "Only UNDEF in input map!");
 
-    for (ic = 0; ic < mcol * mrow; ic++)
+    for (ic = 0; ic < (long)mcol * (long)mrow; ic++)
         p_map_v[ic] = UNDEF;
 
     /* loop grid3d columns innermost, and find approximate area for map

--- a/src/lib/src/surf_xy_as_values.c
+++ b/src/lib/src/surf_xy_as_values.c
@@ -55,7 +55,7 @@ surf_xy_as_values(double xori,
     double angle, xdist, ydist, dist, beta, gamma, dxrot = 0.0, dyrot = 0.0;
     int i, j, ib, yflip;
 
-    if (nx * ny != nn1 || nn1 != nn2) {
+    if ((long)nx * (long)ny != nn1 || nn1 != nn2) {
         logger_error(LI, FI, FU, "Error? in length nn1 vs nx*ny or nn1 vs nn2 in %s",
                      FU);
     }

--- a/src/lib/src/surf_zminmax.c
+++ b/src/lib/src/surf_zminmax.c
@@ -31,7 +31,7 @@ surf_zminmax(int nx, int ny, double *p_map_v, double *zmin, double *zmax)
 {
     /* locals */
 
-    long mxy = nx * ny;
+    long mxy = (long)nx * (long)ny;
     long ic;
     int found = 0;
 

--- a/src/lib/src/x_general.c
+++ b/src/lib/src/x_general.c
@@ -20,6 +20,6 @@ x_fread(void *ptr, size_t size, size_t nmemb, FILE *stream)
     ier = fread(ptr, size, nmemb, stream);
 
     if (ier != nmemb) {
-        logger_error(LI, FI, FU, "Problem in fread: IER=%d nmemb=%d", ier, nmemb);
+        logger_error(LI, FI, FU, "Problem in fread: IER=%zu nmemb=%zu", ier, nmemb);
     }
 }

--- a/src/lib/src/x_ib2ijk.c
+++ b/src/lib/src/x_ib2ijk.c
@@ -14,7 +14,7 @@ x_ib2ijk(long ib, int *i, int *j, int *k, int nx, int ny, int nz, int ia_start)
     long ir, nxy;
     long ix = 1, iy = 1, iz = 1;
 
-    nxy = nx * ny;
+    nxy = (long)nx * (long)ny;
 
     if (ia_start == 0)
         ib = ib + 1; /* offset number to counter number */
@@ -50,7 +50,7 @@ x_ic2ijk(long ic, int *i, int *j, int *k, int nx, int ny, int nz, int ia_start)
     long ir, nzy;
     long ix = 1, iy = 1, iz = 1;
 
-    nzy = nz * ny;
+    nzy = (long)nz * (long)ny;
 
     if (ia_start == 0)
         ic = ic + 1; /* offset number to counter number */

--- a/src/lib/src/x_memory.c
+++ b/src/lib/src/x_memory.c
@@ -7,11 +7,11 @@
 double **
 x_allocate_2d_double(int n1, int n2)
 {
-    double **ptr_array = calloc(sizeof(double *), n1);
+    double **ptr_array = calloc((size_t)n1, sizeof(double *));
 
-    double *data = calloc(sizeof(double), n1 * n2);
+    double *data = calloc((size_t)n1 * (size_t)n2, sizeof(double));
     for (int i = 0; i < n1; i++) {
-        ptr_array[i] = data + (i * n2);
+        ptr_array[i] = data + ((size_t)i * (size_t)n2);
     }
     return ptr_array;
 }
@@ -31,11 +31,11 @@ x_allocate_2d_bool(int n1, int n2)
 {
     int i;
 
-    bool *data = malloc(sizeof(bool) * n1 * n2);
+    bool *data = malloc(sizeof(bool) * (size_t)n1 * (size_t)n2);
 
-    bool **ptr_array = malloc(sizeof(bool *) * n1);
+    bool **ptr_array = malloc(sizeof(bool *) * (size_t)n1);
     for (i = 0; i < n1; i++) {
-        ptr_array[i] = data + (i * n2);
+        ptr_array[i] = data + ((size_t)i * (size_t)n2);
     }
     return ptr_array;
 }


### PR DESCRIPTION
Resolves #1619 

Fixed the CodeQL alerts found here: https://github.com/equinor/xtgeo/security/code-scanning

- Cast dimension products before multiplication so they do not overflow as `int` first
- Fixed `printf` logger specifiers:
   `size_t` uses `%zu`
   `long` uses `%ld`
- Promoted float math where needed before accumulating into `double`

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
