### PR TITLE
ENH: add text parsing utilities in io module

### DIFF
--- a/src/xtgeo/io/_text_parsing_utils.py
+++ b/src/xtgeo/io/_text_parsing_utils.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
+# A constituent string, typically representing a word or a number
+Token = str
+TokenizedLine = list[Token]
+
+_BASE10_NUMBER: re.Pattern[str] = re.compile(
+    r"[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?"
+)
+
+
+def iter_lines(
+    stream: Iterable[str],
+) -> Iterator[TokenizedLine]:
+    """
+    Lazily iterate over text lines, yielding lists of tokens (strings),
+    typically representing words and numbers.
+    Filters out empty lines.
+    """
+    for line in stream:
+        split_line = line.strip().split()
+
+        if not split_line:
+            continue
+
+        yield split_line
+
+
+def iter_noncomment_lines(
+    stream: Iterable[str], comment_prefixes: Sequence[str]
+) -> Iterator[TokenizedLine]:
+    """
+    Lazily iterate over text lines, yielding lists of tokens (strings).
+    Filters out empty lines and comment lines.
+    """
+    for line in iter_lines(stream):
+        if is_comment(line, comment_prefixes):
+            continue
+
+        yield line
+
+
+def is_comment(line: Sequence[Token], comment_prefixes: Sequence[str]) -> bool:
+    """
+    Check if a line is a comment line,
+    namely starting with any of the comment prefixes.
+    """
+    if not line:
+        return False
+    return any(line[0].startswith(prefix) for prefix in comment_prefixes)
+
+
+def contains_single_token(line: Sequence[Token]) -> bool:
+    """Check if the line consists of a single token."""
+    return len(line) == 1
+
+
+def strip_surrounding_delimiters(token: Token, delimiter: str) -> Token:
+    """Remove one matching pair of surrounding delimiters, if present."""
+    if (
+        delimiter
+        and len(token) >= 2 * len(delimiter)
+        and token.startswith(delimiter)
+        and token.endswith(delimiter)
+    ):
+        return token[len(delimiter) : -len(delimiter)]
+    return token
+
+
+def is_base10_number(token: Token) -> bool:
+    """
+    Base-10 number or not
+        (base-10 numbers include integers, decimals and scientific notation)
+    """
+    return _BASE10_NUMBER.fullmatch(token) is not None
+
+
+def is_finite_number(token: Token) -> bool:
+    """
+    Finite number or not
+        (finite numbers include base-10 numbers, but exclude infinities and NaNs)
+    """
+    try:
+        float_value = float(token)
+        return math.isfinite(float_value)
+    except ValueError:
+        return False

--- a/tests/test_io/test_text_parsing_utils.py
+++ b/tests/test_io/test_text_parsing_utils.py
@@ -1,0 +1,138 @@
+import io
+from collections.abc import Sequence
+
+import pytest
+
+from xtgeo.io._text_parsing_utils import (
+    TokenizedLine,
+    contains_single_token,
+    is_base10_number,
+    is_comment,
+    is_finite_number,
+    iter_lines,
+    iter_noncomment_lines,
+    strip_surrounding_delimiters,
+)
+
+
+def test_iter_lines_strips_splits_and_skips_blank_lines() -> None:
+    stream = io.StringIO("\n  KEY   1  2  \n\t\n  VALUE\t3\n")
+
+    assert list(iter_lines(stream)) == [
+        ["KEY", "1", "2"],
+        ["VALUE", "3"],
+    ]
+
+
+def test_iter_noncomment_lines_skips_configured_comment_prefixes() -> None:
+    stream = io.StringIO("\n  \n# comment\nVRTX 1 0.0 0.0 0.0 CNXYZ\nTRGL 1 2 3\n")
+
+    result = list(iter_noncomment_lines(stream, ["#"]))
+
+    assert result == [
+        ["VRTX", "1", "0.0", "0.0", "0.0", "CNXYZ"],
+        ["TRGL", "1", "2", "3"],
+    ]
+
+
+def test_iter_noncomment_lines_only_uses_configured_prefixes() -> None:
+    stream = io.StringIO("! comment\n#POINTS\n3\nVALUE ! not a comment\n")
+
+    result = list(iter_noncomment_lines(stream, ["!"]))
+
+    assert result == [["#POINTS"], ["3"], ["VALUE", "!", "not", "a", "comment"]]
+
+
+@pytest.mark.parametrize(
+    "line, comment_prefixes, expected",
+    [
+        (["#", "comment"], ["#", "--"], True),
+        (["--comment"], ["#", "--"], True),
+        (["value", "#", "comment"], ["#", "--"], False),
+        ([], ["#", "--"], False),
+    ],
+)
+def test_is_comment(
+    line: Sequence[str], comment_prefixes: Sequence[str], expected: bool
+) -> None:
+    assert is_comment(line, comment_prefixes) is expected
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        (["value"], True),
+        (["value", "other"], False),
+        ([], False),
+    ],
+)
+def test_contains_single_token(line: TokenizedLine, expected: bool) -> None:
+    assert contains_single_token(line) is expected
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "0",
+        "-1",
+        "+1",
+        "1.",
+        ".5",
+        "1.5",
+        "1e-3",
+        "-1.5E+3",
+    ],
+)
+def test_is_base10_number_accepts_supported_number_formats(token: str) -> None:
+    assert is_base10_number(token) is True
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        ".",
+        "1,2",
+        "nan",
+        "inf",
+        "0x10",
+        "1_000",
+        "1e",
+    ],
+)
+def test_is_base10_number_rejects_unsupported_number_formats(token: str) -> None:
+    assert is_base10_number(token) is False
+
+
+@pytest.mark.parametrize(
+    "token, delimiter, expected",
+    [
+        ('"1.25"', '"', "1.25"),
+        ('""1.25""', '"', '"1.25"'),
+        ('"1.25', '"', '"1.25'),
+        ('1.25"', '"', '1.25"'),
+        ("1.25", '"', "1.25"),
+        ("--1.25--", "--", "1.25"),
+        ("!1.25!", "!", "1.25"),
+        ("$1.25$", "$", "1.25"),
+        ("1.25", "", "1.25"),
+    ],
+)
+def test_strip_surrounding_delimiters_removes_only_one_matching_pair(
+    token: str, delimiter: str, expected: str
+) -> None:
+    assert strip_surrounding_delimiters(token, delimiter) == expected
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [
+        ("1.25", True),
+        ("1e309", False),
+        ("nan", False),
+        ("inf", False),
+        ("not-a-number", False),
+    ],
+)
+def test_is_finite_number(token: str, expected: bool) -> None:
+    assert is_finite_number(token) is expected


### PR DESCRIPTION
Resolves #1626 

Implement general text parsing helper functions in utility namespace in io module

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
