### PR TITLE
ENH: Add feature to snap grid ZCORN to regular surface

### DIFF
--- a/src/lib/include/xtgeo/grid3d.hpp
+++ b/src/lib/include/xtgeo/grid3d.hpp
@@ -2,6 +2,7 @@
 #define XTGEO_GRID3D_HPP_
 #include <pybind11/pybind11.h>  // should be included first according to pybind11 docs
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -358,6 +359,13 @@ adjust_boxgrid_layers_from_regsurfs(Grid &grd,
                                     const std::vector<regsurf::RegularSurface> &rsurfs,
                                     const double tolerance = numerics::TOLERANCE);
 
+void
+conform_grid_to_surfaces(Grid &grd,
+                         const std::vector<regsurf::RegularSurface> &surfaces,
+                         const std::vector<int> &layers_per_zone,
+                         bool skip_faults = false,
+                         double tolerance = numerics::TOLERANCE);
+
 std::tuple<py::array_t<float>, py::array_t<int8_t>>
 refine_vertically(const Grid &grid_cpp, const py::array_t<uint16_t> refine_layer);
 
@@ -509,7 +517,11 @@ init(py::module &m)
            py::arg("active_only") = false,
            py::arg("method") = geometry::PointInHexahedronMethod::Optimized)
       .def("convert_to_hybrid_grid", &convert_to_hybrid_grid,
-           "Convert the grid to a hybrid grid.");
+           "Convert the grid to a hybrid grid.")
+      .def("conform_grid_to_surfaces", &conform_grid_to_surfaces,
+           "Conform grid ZCORN to a set of surfaces (in-place).", py::arg("surfaces"),
+           py::arg("layers_per_zone"), py::arg("skip_faults") = false,
+           py::arg("tolerance") = numerics::TOLERANCE);
 
     py::class_<CellCorners>(m_grid3d, "CellCorners")
       // a constructor that takes 8 xyz::Point objects

--- a/src/lib/src/grid3d/grid_surf_oper.cpp
+++ b/src/lib/src/grid3d/grid_surf_oper.cpp
@@ -2,10 +2,16 @@
 // and/or modified by surface(s) input. This file is part of the xtgeo library.
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <numeric>
 #include <tuple>
+#include <vector>
 #include <xtgeo/geometry.hpp>
 #include <xtgeo/grid3d.hpp>
 #include <xtgeo/regsurf.hpp>
@@ -165,6 +171,247 @@ adjust_boxgrid_layers_from_regsurfs(Grid &grd,
         }
     }
     return std::make_tuple(zcorn_result, actnum_result);
+}
+
+static constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+
+static inline double
+avg4(const std::array<double, 4> &a)
+{
+    return (a[0] + a[1] + a[2] + a[3]) * 0.25;
+}
+
+static bool
+is_pillar_faulted(const std::vector<std::array<double, 4>> &orig,
+                  size_t nkp1,
+                  double tol)
+{
+    return std::any_of(orig.begin(), orig.begin() + static_cast<ptrdiff_t>(nkp1),
+                       [tol](const auto &corners) {
+                           auto [mn, mx] =
+                             std::minmax_element(corners.begin(), corners.end());
+                           return (*mx - *mn) > tol;
+                       });
+}
+
+/*
+ * Find pillar parameter t where the pillar intersects a surface.
+ * P(t) = P_top + t*(P_bot - P_top), so t∈[0,1] is within the pillar extent.
+ * Returns NaN if no intersection is found.
+ */
+static double
+find_pillar_surface_intersection_t(double x_t,
+                                   double y_t,
+                                   double z_t,
+                                   double x_b,
+                                   double y_b,
+                                   double z_b,
+                                   const regsurf::RegularSurface &surf,
+                                   double tolerance)
+{
+    constexpr double eps = 1e-10;
+    const double dx = x_b - x_t, dy = y_b - y_t, dz = z_b - z_t;
+
+    if (std::abs(dz) < eps)
+        return NaN;
+
+    // Vertical pillar: direct Z lookup
+    if (std::abs(dx) < eps && std::abs(dy) < eps) {
+        double zs = regsurf::get_z_from_xy(surf, x_t, y_t, tolerance);
+        return std::isnan(zs) ? NaN : (zs - z_t) / dz;
+    }
+
+    // Compute distance between z_pillar (with extension) and z_surface
+    auto g = [&](double t) -> double {
+        double zs = regsurf::get_z_from_xy(surf, x_t + t * dx, y_t + t * dy, tolerance);
+        return std::isnan(zs) ? NaN : (z_t + t * dz) - zs;
+    };
+
+    // Scan t ∈ [-0.5, 1.5] to find where pillar intersect surface (g changes sign)
+    constexpr int N = 8;
+    constexpr double t0 = -0.5, t1 = 1.5, dt = (t1 - t0) / N;
+
+    double lo_t = 0, lo_g = 0, hi_t = 0, hi_g = 0;
+    bool found = false;
+    double prev_t = t0, prev_g = g(t0);
+
+    for (int i = 1; i <= N; ++i) {
+        double cur_t = t0 + i * dt;
+        double cur_g = g(cur_t);
+        if (!std::isnan(prev_g) && !std::isnan(cur_g) && prev_g * cur_g <= 0) {
+            lo_t = prev_t;
+            lo_g = prev_g;
+            hi_t = cur_t;
+            hi_g = cur_g;
+            found = true;
+            break;  // take first bracket found
+        }
+        prev_t = cur_t;
+        prev_g = cur_g;
+    }
+    if (!found)
+        return NaN;
+
+    // Bisect to convergence
+    for (int i = 0; i < 50; ++i) {
+        double mid_t = 0.5 * (lo_t + hi_t);
+        double mid_g = g(mid_t);
+        if (std::isnan(mid_g))
+            return NaN;
+        if (std::abs(mid_g) < 1e-8 || (hi_t - lo_t) < 1e-12)
+            return mid_t;
+        if (lo_g * mid_g <= 0) {
+            hi_t = mid_t;
+            hi_g = mid_g;
+        } else {
+            lo_t = mid_t;
+            lo_g = mid_g;
+        }
+    }
+    return 0.5 * (lo_t + hi_t);
+}
+
+/*
+ * Conform grid ZCORN to a set of zone-boundary surfaces (in-place).
+ *
+ * For each grid pillar the algorithm:
+ *   1. Finds the pillar/surface intersection (along the pillar line) for each surface,
+ *   2. Preserves per-corner offsets from the pillar average (maintaining fault
+ * geometry),
+ *   3. Distributes interior layers proportionally within each zone,
+ *   4. Enforces monotonicity (top-to-bottom) on the result.
+ *
+ * COORD is read-only (pillar geometry unchanged). ZCORN is modified in-place.
+ *
+ * @param grd Grid object (coordsv read-only, zcornsv modified in-place)
+ * @param surfaces Surfaces sorted top-to-bottom
+ * @param layers_per_zone Number of layers per zone
+ * @param skip_faults If true, leave faulted pillars (corner spread > 0.01m) unchanged
+ * @param tolerance Surface sampling tolerance
+ */
+void
+conform_grid_to_surfaces(Grid &grd,
+                         const std::vector<regsurf::RegularSurface> &surfaces,
+                         const std::vector<int> &layers_per_zone,
+                         bool skip_faults,
+                         double tolerance)
+{
+    constexpr double threshold = 1e-10;
+    constexpr double faults_tolerance = 0.01;
+
+    const size_t n_surfaces = surfaces.size();
+    const size_t n_zones = layers_per_zone.size();
+
+    if (n_surfaces < 2)
+        throw std::invalid_argument(
+          "At least 2 surfaces are required (top and bottom).");
+    if (n_surfaces != n_zones + 1)
+        throw std::invalid_argument(
+          "Number of surfaces must be len(layers_per_zone) + 1.");
+    if (std::any_of(layers_per_zone.begin(), layers_per_zone.end(),
+                    [](int v) { return v < 1; }))
+        throw std::invalid_argument("All values in layers_per_zone must be >= 1.");
+
+    const size_t total_layers =
+      std::accumulate(layers_per_zone.begin(), layers_per_zone.end(), size_t{ 0 },
+                      [](size_t a, int b) { return a + static_cast<size_t>(b); });
+
+    auto coord = grd.get_coordsv().unchecked<3>();
+    py::array_t<float> zcornsv = grd.get_zcornsv();
+    auto zcorn = zcornsv.mutable_unchecked<4>();
+
+    const size_t npil_i = static_cast<size_t>(coord.shape(0));
+    const size_t npil_j = static_cast<size_t>(coord.shape(1));
+    const size_t nkp1 = static_cast<size_t>(zcorn.shape(2));
+
+    if (total_layers + 1 != nkp1)
+        throw std::invalid_argument("Sum of layers_per_zone must equal grid nlay.");
+
+    // Zone boundary k-indices: [0, lpz[0], lpz[0]+lpz[1], ..., nlay]
+    std::vector<size_t> zone_k(n_zones + 1, 0);
+    std::partial_sum(layers_per_zone.begin(), layers_per_zone.end(), zone_k.begin() + 1,
+                     [](size_t a, int b) { return a + static_cast<size_t>(b); });
+
+    // Reusable per-pillar buffers (allocated once, reused per pillar)
+    std::vector<std::array<double, 4>> orig(nkp1);
+    std::vector<double> z_smooth(n_surfaces);
+    std::vector<std::array<double, 4>> z_bnd(n_surfaces);
+
+    for (size_t i = 0; i < npil_i; ++i) {
+        for (size_t j = 0; j < npil_j; ++j) {
+            const double x_t = coord(i, j, 0), y_t = coord(i, j, 1),
+                         z_t = coord(i, j, 2);
+            const double x_b = coord(i, j, 3), y_b = coord(i, j, 4),
+                         z_b = coord(i, j, 5);
+            const double dz = z_b - z_t;
+
+            if (std::abs(dz) < threshold)
+                continue;
+
+            for (size_t k = 0; k < nkp1; ++k)
+                for (size_t c = 0; c < 4; ++c)
+                    orig[k][c] = static_cast<double>(zcorn(i, j, k, c));
+
+            if (skip_faults && is_pillar_faulted(orig, nkp1, faults_tolerance))
+                continue;
+
+            // Find pillar/surface intersections
+            bool skip = false;
+            for (size_t s = 0; s < n_surfaces; ++s) {
+                double t = find_pillar_surface_intersection_t(
+                  x_t, y_t, z_t, x_b, y_b, z_b, surfaces[s], tolerance);
+                if (std::isnan(t)) {
+                    skip = true;
+                    break;
+                }
+                z_smooth[s] = z_t + t * dz;
+            }
+
+            if (skip)
+                continue;
+
+            for (size_t s = 1; s < n_surfaces; ++s)
+                z_smooth[s] = std::max(z_smooth[s], z_smooth[s - 1]);
+
+            // Compute per-corner zone boundaries
+            for (size_t s = 0; s < n_surfaces; ++s) {
+                const double avg = avg4(orig[zone_k[s]]);
+                for (size_t c = 0; c < 4; ++c)
+                    z_bnd[s][c] = z_smooth[s] + (orig[zone_k[s]][c] - avg);
+            }
+
+            for (size_t c = 0; c < 4; ++c)
+                for (size_t s = 1; s < n_surfaces; ++s)
+                    z_bnd[s][c] = std::max(z_bnd[s][c], z_bnd[s - 1][c]);
+
+            // Distribute thickness for each layer in the zone
+            for (size_t c = 0; c < 4; ++c) {
+                for (size_t s = 0; s < n_surfaces; ++s)
+                    zcorn(i, j, zone_k[s], c) = static_cast<float>(z_bnd[s][c]);
+
+                for (size_t zi = 0; zi < n_zones; ++zi) {
+                    const size_t kt = zone_k[zi], kb = zone_k[zi + 1];
+                    const double zt_orig = orig[kt][c];
+                    const double thick = orig[kb][c] - zt_orig;
+                    const double zt_new = z_bnd[zi][c];
+                    const double zb_new = z_bnd[zi + 1][c];
+
+                    for (size_t k = kt + 1; k < kb; ++k) {
+                        const double frac =
+                          (std::abs(thick) < 1e-6)
+                            ? 0.0
+                            : std::clamp((orig[k][c] - zt_orig) / thick, 0.0, 1.0);
+                        zcorn(i, j, k, c) =
+                          static_cast<float>(zt_new + frac * (zb_new - zt_new));
+                    }
+                }
+
+                for (size_t k = 1; k < nkp1; ++k)
+                    zcorn(i, j, k, c) =
+                      std::max(zcorn(i, j, k, c), zcorn(i, j, k - 1, c));
+            }
+        }
+    }
 }
 
 }  // namespace xtgeo::grid3d

--- a/src/xtgeo/grid3d/_grid_conform.py
+++ b/src/xtgeo/grid3d/_grid_conform.py
@@ -1,0 +1,64 @@
+"""Functions for conforming a grid's ZCORN to a set of surfaces."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import xtgeo._internal as _internal  # type: ignore
+from xtgeo.common import null_logger
+
+logger = null_logger(__name__)
+
+if TYPE_CHECKING:
+    from xtgeo.grid3d import Grid
+    from xtgeo.surface.regular_surface import RegularSurface
+
+
+def conform_grid_to_surfaces(
+    grid: Grid,
+    surfaces: list[RegularSurface],
+    layers_per_zone: list[int],
+    skip_faults: bool = False,
+    tolerance: float = 1e-6,
+) -> None:
+    """Conform grid ZCORN to a set of surfaces."""
+    n_surfaces = len(surfaces)
+    n_zones = len(layers_per_zone)
+
+    if n_surfaces < 2:
+        raise ValueError("At least 2 surfaces are required (top and bottom).")
+
+    if n_surfaces != n_zones + 1:
+        raise ValueError(
+            f"Number of surfaces ({n_surfaces}) must be "
+            f"len(layers_per_zone) + 1 ({n_zones + 1})."
+        )
+
+    total_layers = sum(layers_per_zone)
+    if total_layers != grid.nlay:
+        raise ValueError(
+            f"Sum of layers_per_zone ({total_layers}) must equal "
+            f"grid nlay ({grid.nlay})."
+        )
+
+    if any(lpz < 1 for lpz in layers_per_zone):
+        raise ValueError("All values in layers_per_zone must be >= 1.")
+
+    grid._set_xtgformat2()
+
+    # Convert surfaces to C++ objects for fast sampling
+    cpp_surfs = [_internal.regsurf.RegularSurface(s) for s in surfaces]
+
+    # Modify zcornsv in-place via C++ Grid method
+    _internal.grid3d.Grid(grid).conform_grid_to_surfaces(
+        cpp_surfs,
+        list(layers_per_zone),
+        skip_faults,
+        tolerance,
+    )
+
+    # Set subgrids to reflect the zone structure
+    subgrids = {f"zone_{i + 1}": layers_per_zone[i] for i in range(n_zones)}
+    grid.set_subgrids(subgrids)
+
+    logger.info("Grid conformed to %d surfaces with %d zones", n_surfaces, n_zones)

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -21,6 +21,7 @@ from xtgeo.surface.regular_surface import surface_from_grid3d
 from . import (
     _grid3d_fence,
     _grid_boundary,
+    _grid_conform,
     _grid_etc1,
     _grid_export,
     _grid_hybrid,
@@ -3096,6 +3097,73 @@ class Grid(_Grid3D):
 
         """
         _grid_refine.refine_vertically(self, rfactor, zoneprop=zoneprop)
+
+    def conform_to_surfaces(
+        self,
+        surfaces: list[xtgeo.RegularSurface],
+        layers_per_zone: list[int],
+        skip_faults: bool = False,
+        tolerance: float = 1e-6,
+    ) -> None:
+        """Conform grid ZCORN to a set of surfaces.
+
+        The surfaces define zone boundaries, ordered from top to bottom. The grid's
+        layer boundary z values (ZCORN) are updated so that zone boundaries match
+        the surfaces, while interior layer boundaries within each zone are
+        redistributed proportionally to the original layer thickness distribution
+        at each corner. COORD (pillar geometry) is unchanged.
+
+        The first surface is aligned to the top of the first grid layer, and the last
+        surface to the bottom of the last layer.
+
+        Surface sampling is done along the pillar line: the 3D intersection of each
+        pillar with each surface is found via bisection. If a surface cannot be
+        sampled at a pillar position (e.g. the pillar is outside the surface extent),
+        the original ZCORN for that pillar is kept.
+
+        Args:
+            surfaces: List of RegularSurface instances ordered from top to bottom.
+                Number of surfaces must be len(layers_per_zone) + 1.
+            layers_per_zone: Number of layers in each zone. The sum must equal
+                the grid's nlay. Each value must be >= 1.
+            skip_faults: If True, pillars where corners differ by more than 0.01m
+                at any k-level are left unchanged, preserving original fault
+                geometry. If False (default), the original per-corner offset from
+                the pillar average is preserved at each layer boundary.
+            tolerance: Tolerance for surface sampling at pillar positions.
+
+        Raises:
+            ValueError: If input dimensions are inconsistent.
+
+        Example::
+
+            import xtgeo
+            grid = xtgeo.grid_from_file("my_grid.roff")
+            surf_top = xtgeo.surface_from_file("top.gri")
+            surf_mid = xtgeo.surface_from_file("mid.gri")
+            surf_base = xtgeo.surface_from_file("base.gri")
+
+            # 2 zones: 3 layers in zone 1, 5 layers in zone 2
+            grid.conform_to_surfaces(
+                surfaces=[surf_top, surf_mid, surf_base],
+                layers_per_zone=[3, 5],
+            )
+
+            # Skip faulted pillars
+            grid.conform_to_surfaces(
+                surfaces=[surf_top, surf_mid, surf_base],
+                layers_per_zone=[3, 5],
+                skip_faults=True,
+            )
+
+        """
+        _grid_conform.conform_grid_to_surfaces(
+            self,
+            surfaces,
+            layers_per_zone,
+            skip_faults,
+            tolerance,
+        )
 
     def report_zone_mismatch(
         self,

--- a/tests/test_grid3d/test_grid_conform.py
+++ b/tests/test_grid3d/test_grid_conform.py
@@ -1,0 +1,331 @@
+"""Tests for conform_to_surfaces grid method."""
+
+import numpy as np
+import pytest
+
+from xtgeo import RegularSurface
+from xtgeo.grid3d.grid import create_box_grid
+
+
+def _make_flat_surface(ncol, nrow, xinc, yinc, depth, xori=0.0, yori=0.0):
+    """Helper to create a flat surface at a given depth."""
+    surf = RegularSurface(
+        ncol=ncol, nrow=nrow, xinc=xinc, yinc=yinc, xori=xori, yori=yori
+    )
+    surf.values = np.full((ncol, nrow), depth)
+    return surf
+
+
+def _make_tilted_surface(
+    ncol, nrow, xinc, yinc, depth_min, depth_max, xori=0.0, yori=0.0
+):
+    """Helper to create a surface tilted in the x direction."""
+    surf = RegularSurface(
+        ncol=ncol, nrow=nrow, xinc=xinc, yinc=yinc, xori=xori, yori=yori
+    )
+    values = np.zeros((ncol, nrow))
+    for i in range(ncol):
+        frac = i / max(ncol - 1, 1)
+        values[i, :] = depth_min + frac * (depth_max - depth_min)
+    surf.values = values
+    return surf
+
+
+def _make_faulted_grid(nlay=4):
+    """Create a 3x3 grid with a fault at pillar column i=2 (50m throw)."""
+    grid = create_box_grid(
+        dimension=(3, 3, nlay),
+        origin=(0.0, 0.0, 1000.0),
+        increment=(100.0, 100.0, 50.0),
+    )
+    for j in range(grid.nrow + 1):
+        for k in range(grid.nlay + 1):
+            grid._zcornsv[2, j, k, 1] += 50.0
+            grid._zcornsv[2, j, k, 3] += 50.0
+    return grid
+
+
+# --- Core behaviour ---
+
+
+def test_single_zone_flat_surfaces():
+    """Single zone: ZCORN snapped to surfaces, COORD unchanged."""
+    grid = create_box_grid(
+        dimension=(4, 3, 5),
+        origin=(0.0, 0.0, 1000.0),
+        increment=(100.0, 100.0, 10.0),
+    )
+    original_coord = grid._coordsv.copy()
+    surf_top = _make_flat_surface(5, 4, 100.0, 100.0, 900.0)
+    surf_bot = _make_flat_surface(5, 4, 100.0, 100.0, 1100.0)
+
+    grid.conform_to_surfaces(surfaces=[surf_top, surf_bot], layers_per_zone=[5])
+
+    dz = (1100.0 - 900.0) / 5.0
+    for k in range(6):
+        assert np.allclose(grid._zcornsv[:, :, k, :], 900.0 + k * dz, atol=0.01)
+    np.testing.assert_array_equal(grid._coordsv, original_coord)
+
+
+def test_two_zones_proportional_distribution():
+    """Two zones with different thicknesses; subgrids set correctly."""
+    grid = create_box_grid(
+        dimension=(3, 3, 6),
+        origin=(0.0, 0.0, 0.0),
+        increment=(100.0, 100.0, 10.0),
+    )
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 100.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 400.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1000.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[3, 3])
+
+    # Zone 1: 100->400, dz=100; Zone 2: 400->1000, dz=200
+    for k in range(3):
+        dz = grid._zcornsv[1, 1, k + 1, 0] - grid._zcornsv[1, 1, k, 0]
+        assert np.isclose(dz, 100.0, atol=0.01)
+    for k in range(3, 6):
+        dz = grid._zcornsv[1, 1, k + 1, 0] - grid._zcornsv[1, 1, k, 0]
+        assert np.isclose(dz, 200.0, atol=0.01)
+
+    assert grid.get_subgrids() == {"zone_1": 3, "zone_2": 3}
+
+
+def test_tilted_surface():
+    """Zone boundaries vary with x position for tilted surfaces."""
+    grid = create_box_grid(
+        dimension=(4, 3, 4),
+        origin=(0.0, 0.0, 1000.0),
+        increment=(100.0, 100.0, 10.0),
+    )
+    surf_top = _make_tilted_surface(5, 4, 100.0, 100.0, 800.0, 1200.0)
+    surf_bot = _make_tilted_surface(5, 4, 100.0, 100.0, 1200.0, 1600.0)
+
+    grid.conform_to_surfaces(surfaces=[surf_top, surf_bot], layers_per_zone=[4])
+
+    assert np.isclose(grid._zcornsv[0, 0, 0, 0], 800.0, atol=1.0)
+    assert np.isclose(grid._zcornsv[0, 0, 4, 0], 1200.0, atol=1.0)
+    assert np.isclose(grid._zcornsv[4, 0, 0, 0], 1200.0, atol=1.0)
+    assert np.isclose(grid._zcornsv[4, 0, 4, 0], 1600.0, atol=1.0)
+
+
+def test_single_layer():
+    """Minimum grid: single layer snapped to two surfaces."""
+    grid = create_box_grid(
+        dimension=(3, 3, 1),
+        origin=(0.0, 0.0, 0.0),
+        increment=(100.0, 100.0, 100.0),
+    )
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 500.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 600.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[1])
+
+    assert np.allclose(grid._zcornsv[:, :, 0, :], 500.0, atol=0.01)
+    assert np.allclose(grid._zcornsv[:, :, 1, :], 600.0, atol=0.01)
+
+
+def test_idempotent():
+    """Conforming to surfaces matching original grid is a no-op."""
+    grid = create_box_grid(
+        dimension=(3, 3, 4),
+        origin=(0.0, 0.0, 1000.0),
+        increment=(100.0, 100.0, 50.0),
+    )
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 1000.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1200.0),
+    ]
+    zcorn_before = grid._zcornsv.copy()
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[4])
+
+    np.testing.assert_allclose(grid._zcornsv, zcorn_before, atol=0.1)
+
+
+# --- Inclined pillars ---
+
+
+def test_inclined_pillars():
+    """Inclined pillars: COORD preserved, ZCORN updated to surface values."""
+    grid = create_box_grid(
+        dimension=(3, 3, 4),
+        origin=(100.0, 100.0, 1000.0),
+        increment=(100.0, 100.0, 50.0),
+    )
+    grid._coordsv[:, :, 3] += 20.0  # X shift
+    grid._coordsv[:, :, 4] += 10.0  # Y shift
+    original_coord = grid._coordsv.copy()
+
+    surfs = [
+        _make_flat_surface(8, 8, 100.0, 100.0, 900.0),
+        _make_flat_surface(8, 8, 100.0, 100.0, 1300.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[4])
+
+    np.testing.assert_allclose(grid._coordsv, original_coord, atol=1e-10)
+    assert np.allclose(grid._zcornsv[:, :, 0, :], 900.0, atol=1.0)
+    assert np.allclose(grid._zcornsv[:, :, 4, :], 1300.0, atol=1.0)
+
+
+# --- Faulted grids ---
+
+
+def test_faulted_preserves_throw():
+    """Fault throw is preserved: corner averages match surfaces, no inversions."""
+    grid = _make_faulted_grid()
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 800.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1400.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[4])
+
+    for j in range(grid.nrow + 1):
+        assert np.isclose(np.mean(grid._zcornsv[2, j, 0, :]), 800.0, atol=1.0)
+        assert np.isclose(np.mean(grid._zcornsv[2, j, 4, :]), 1400.0, atol=1.0)
+        for c in range(4):
+            for k in range(grid.nlay):
+                assert grid._zcornsv[2, j, k + 1, c] >= grid._zcornsv[2, j, k, c] - 0.01
+
+
+def test_faulted_two_zone_distribution():
+    """Proportional layer distribution at faulted pillars with two zones."""
+    grid = _make_faulted_grid()
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 900.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1100.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1500.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[2, 2])
+
+    expected = [900.0, 1000.0, 1100.0, 1300.0, 1500.0]
+    for j in range(grid.nrow + 1):
+        for k, z_exp in enumerate(expected):
+            assert np.isclose(np.mean(grid._zcornsv[2, j, k, :]), z_exp, atol=1.0)
+
+
+def test_pinched_faulted():
+    """Pinched faulted grid: no inversions, zone boundaries match surfaces."""
+    grid = _make_faulted_grid(nlay=6)
+    # Pinch layers 2-3 on the east side of fault at pillar i=2
+    pinch_z = 1100.0 + 50.0  # = 1150
+    for j in range(grid.nrow + 1):
+        for k in [2, 3, 4]:
+            grid._zcornsv[2, j, k, 1] = pinch_z
+            grid._zcornsv[2, j, k, 3] = pinch_z
+
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 900.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1200.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1500.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[3, 3])
+
+    # No inversions anywhere
+    for i in range(grid.ncol + 1):
+        for j in range(grid.nrow + 1):
+            for c in range(4):
+                for k in range(grid.nlay):
+                    assert (
+                        grid._zcornsv[i, j, k + 1, c]
+                        >= grid._zcornsv[i, j, k, c] - 0.01
+                    )
+
+    # Zone boundaries match surfaces at non-faulted pillars
+    for i in [0, 1, 3]:
+        for j in range(grid.nrow + 1):
+            assert np.isclose(np.mean(grid._zcornsv[i, j, 0, :]), 900.0, atol=1.0)
+            assert np.isclose(np.mean(grid._zcornsv[i, j, 3, :]), 1200.0, atol=1.0)
+            assert np.isclose(np.mean(grid._zcornsv[i, j, 6, :]), 1500.0, atol=1.0)
+
+
+def test_skip_faults():
+    """skip_faults=True: faulted pillars unchanged, non-faulted conformed."""
+    grid = _make_faulted_grid()
+    original_zcorn = grid._zcornsv.copy()
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 800.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1400.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[4], skip_faults=True)
+
+    # Faulted pillar (i=2) unchanged
+    for j in range(grid.nrow + 1):
+        np.testing.assert_array_equal(
+            grid._zcornsv[2, j, :, :], original_zcorn[2, j, :, :]
+        )
+
+    # Non-faulted pillars modified
+    for i in [0, 1, 3]:
+        for j in range(grid.nrow + 1):
+            assert not np.array_equal(
+                grid._zcornsv[i, j, :, :], original_zcorn[i, j, :, :]
+            )
+
+
+def test_pillar_outside_surface_unchanged():
+    """Pillars outside the surface extent keep their original ZCORN."""
+    grid = create_box_grid(
+        dimension=(3, 3, 4),
+        origin=(0.0, 0.0, 1000.0),
+        increment=(100.0, 100.0, 50.0),
+    )
+    original_zcorn = grid._zcornsv.copy()
+
+    # Surfaces cover only x=[500, 800], far from grid x=[0, 300]
+    surfs = [
+        _make_flat_surface(4, 4, 100.0, 100.0, 900.0, xori=500.0),
+        _make_flat_surface(4, 4, 100.0, 100.0, 1300.0, xori=500.0),
+    ]
+
+    grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[4])
+
+    np.testing.assert_array_equal(grid._zcornsv, original_zcorn)
+
+
+# --- Validation ---
+
+
+def test_too_few_surfaces():
+    grid = create_box_grid(
+        dimension=(3, 3, 3), origin=(0, 0, 0), increment=(100, 100, 10)
+    )
+    surf = _make_flat_surface(4, 4, 100.0, 100.0, 100.0)
+    with pytest.raises(ValueError, match="At least 2 surfaces"):
+        grid.conform_to_surfaces(surfaces=[surf], layers_per_zone=[])
+
+
+def test_surface_count_mismatch():
+    grid = create_box_grid(
+        dimension=(3, 3, 3), origin=(0, 0, 0), increment=(100, 100, 10)
+    )
+    surfs = [_make_flat_surface(4, 4, 100, 100, d) for d in [100, 200, 300]]
+    with pytest.raises(ValueError, match="Number of surfaces"):
+        grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[3])
+
+
+def test_layer_count_mismatch():
+    grid = create_box_grid(
+        dimension=(3, 3, 5), origin=(0, 0, 0), increment=(100, 100, 10)
+    )
+    surfs = [_make_flat_surface(4, 4, 100, 100, d) for d in [100, 200]]
+    with pytest.raises(ValueError, match="Sum of layers_per_zone"):
+        grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[3])
+
+
+def test_zero_layers_in_zone():
+    grid = create_box_grid(
+        dimension=(3, 3, 3), origin=(0, 0, 0), increment=(100, 100, 10)
+    )
+    surfs = [_make_flat_surface(4, 4, 100, 100, d) for d in [100, 200, 300]]
+    with pytest.raises(ValueError, match="layers_per_zone must be >= 1"):
+        grid.conform_to_surfaces(surfaces=surfs, layers_per_zone=[0, 3])


### PR DESCRIPTION
Resolves #1616 

This PR add method `conform_to_surfaces` which will snap ZCORN to a set of regular surfaces.

The grid's layer boundary z values (ZCORN) are updated so that zone boundaries match the surfaces, while layers within each zone are distributed with proportional thickness. 

<img width="1727" height="1219" alt="image" src="https://github.com/user-attachments/assets/bbeac7a6-b0f4-4971-9680-bd4b17b0fb10" />


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
