### PR TITLE
ENH: set default format to 'tsurf' when writing TriangulatedSurface to file

### DIFF
--- a/src/xtgeo/surface/triangulated_surface.py
+++ b/src/xtgeo/surface/triangulated_surface.py
@@ -773,7 +773,7 @@ class TriangulatedSurface:
     def to_file(
         self,
         filepath: FileLike,
-        fformat: str = "guess",
+        fformat: str = "tsurf",
     ) -> Path | BytesIO | StringIO | None:
         """
         Write triangulated surface to a file with format selection.

--- a/tests/test_surface/test_triangulated_surface.py
+++ b/tests/test_surface/test_triangulated_surface.py
@@ -1305,6 +1305,25 @@ class TestWriteFile:
         with pytest.raises(InvalidFileFormatError):
             surf.to_file(filepath, fformat="irap_binary")
 
+    def test_to_file_guess_format_from_content(self, tmp_path: Path) -> None:
+        surf = _create_surface(name="guess_format_test")
+        filepath = tmp_path / "guess_format.no_format_hint"
+        # Raises FileNotFoundError because file doesn't exist when trying
+        # to guess format from content.
+        # This behaviour is awkward and could be improved
+        with pytest.raises(FileNotFoundError):
+            surf.to_file(filepath, fformat="guess")
+
+    def test_to_file_default_format(self, tmp_path: Path) -> None:
+        surf = _create_surface(name="default_format_test")
+        filepath = tmp_path / "default_format.no_format_hint"
+        result_file = surf.to_file(filepath)
+
+        assert result_file == filepath
+        loaded = triangulated_surface_from_file(filepath, fformat="guess")
+        np.testing.assert_array_almost_equal(loaded.vertices, surf.vertices)
+        assert loaded.num_triangles == surf.num_triangles
+
     def test_to_file_bytes_io(self) -> None:
         surf = _create_surface(fformat=FileFormat.TSURF.value[0], name="bytes_io_test")
         buf = BytesIO()


### PR DESCRIPTION
Resolves #1633 

Default fformat ("guess") in TriangulatedSurface.to_file() causes an error, fixed by setting it to "tsurf"

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
