### PR TITLE
ENH: adapt optional inputs used by fmu-tools nested grid

### DIFF
--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -67,9 +67,10 @@ def merge_grids(
 
     # create a new layer mapping for grid1 and grid2
     # group layers in the merged grid by the input layer number
-
-    lmap1 = lmap1 or np.arange(grid1.nlay, dtype=np.int32)
-    lmap2 = lmap2 or np.arange(grid2.nlay, dtype=np.int32)
+    if not isinstance(lmap1, np.ndarray):
+        lmap1 = lmap1 or np.arange(grid1.nlay, dtype=np.int32)
+    if not isinstance(lmap2, np.ndarray):
+        lmap2 = lmap2 or np.arange(grid2.nlay, dtype=np.int32)
 
     new_nlay = max(lmap1.max() + 1, lmap2.max() + 1)
 

--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -31,8 +31,12 @@ def merge_grids(
 
     if isinstance(lmap1, np.ndarray):
         _validate_layer_mapping(lmap1, grid1.nlay)
+    else:
+        lmap1 = np.arange(grid1.nlay, dtype=np.int32)
     if isinstance(lmap2, np.ndarray):
         _validate_layer_mapping(lmap2, grid2.nlay)
+    else:
+        lmap2 = np.arange(grid2.nlay, dtype=np.int32)
 
     # Ensure both grids have the same ijk_handedness
     if (
@@ -54,13 +58,6 @@ def merge_grids(
             grid1.ijk_handedness,
             grid2.ijk_handedness,
         )
-
-    # create a new layer mapping for grid1 and grid2
-    # group layers in the merged grid by the input layer number
-    if not isinstance(lmap1, np.ndarray):
-        lmap1 = np.arange(grid1.nlay, dtype=np.int32)
-    if not isinstance(lmap2, np.ndarray):
-        lmap2 = np.arange(grid2.nlay, dtype=np.int32)
 
     new_nlay = max(lmap1.max() + 1, lmap2.max() + 1)
 
@@ -622,7 +619,7 @@ def _create_merged_property(
 
 def _validate_layer_mapping(
     lmap: np.ndarray,
-    layers: int,
+    num_grid_layers: int,
 ) -> None:
     """Validate layer mapping arrays to ensure. They always
     only int equivalents
@@ -634,11 +631,11 @@ def _validate_layer_mapping(
 
     if lmap.min() < 0:
         raise ValueError("layer mapping must be >=0")
-    if len(lmap) != layers:
+    if len(lmap) != num_grid_layers:
         raise ValueError("layer mapping must map all layers")
     if not np.all(lmap % 1 == 0):
         raise ValueError("layer mapping must only contain int")
     if len(np.unique(lmap)) < len(lmap):
         raise ValueError("layer mapping must be unique")
-    if not np.array_equal(lmap, np.sort(lmap)):
-        raise ValueError("layer mapping must monotonical increase")
+    if not np.all(lmap[1:] >= lmap[:-1]):
+        raise ValueError("layer mapping must strictly monotonically increase")

--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -68,9 +68,9 @@ def merge_grids(
     # create a new layer mapping for grid1 and grid2
     # group layers in the merged grid by the input layer number
     if not isinstance(lmap1, np.ndarray):
-        lmap1 = lmap1 or np.arange(grid1.nlay, dtype=np.int32)
+        lmap1 = np.arange(grid1.nlay, dtype=np.int32)
     if not isinstance(lmap2, np.ndarray):
-        lmap2 = lmap2 or np.arange(grid2.nlay, dtype=np.int32)
+        lmap2 = np.arange(grid2.nlay, dtype=np.int32)
 
     new_nlay = max(lmap1.max() + 1, lmap2.max() + 1)
 

--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -30,19 +30,9 @@ def merge_grids(
     grid2._set_xtgformat2()
 
     if isinstance(lmap1, np.ndarray):
-        if lmap1.min() < 0:
-            raise ValueError("layer mapping 1 must be >=0")
-        if len(lmap1) != grid1.nlay:
-            raise ValueError("layer mapping 1 must map all layers")
-        if not np.all(lmap1 % 1 == 0):
-            raise ValueError("layer mapping 1 must only contrain int")
+        _validate_layer_mapping(lmap1, grid1.nlay)
     if isinstance(lmap2, np.ndarray):
-        if lmap2.min() < 0:
-            raise ValueError("layer mapping 2 must be >=0")
-        if len(lmap2) != grid2.nlay:
-            raise ValueError("layer mapping 2 must map all layers")
-        if not np.all(lmap2 % 1 == 0):
-            raise ValueError("layer mapping 2 must only contrain int")
+        _validate_layer_mapping(lmap2, grid2.nlay)
 
     # Ensure both grids have the same ijk_handedness
     if (
@@ -628,3 +618,27 @@ def _create_merged_property(
         values=merged_values,
         codes=first_prop.codes if first_prop.isdiscrete else None,
     )
+
+
+def _validate_layer_mapping(
+    lmap: np.ndarray,
+    layers: int,
+) -> None:
+    """Validate layer mapping arrays to ensure. They always
+    only int equivalents
+    >=0
+    monotonic increasing
+    unique values
+    all layers in input grid are mapped
+    """
+
+    if lmap.min() < 0:
+        raise ValueError("layer mapping must be >=0")
+    if len(lmap) != layers:
+        raise ValueError("layer mapping must map all layers")
+    if not np.all(lmap % 1 == 0):
+        raise ValueError("layer mapping must only contain int")
+    if len(np.unique(lmap)) < len(lmap):
+        raise ValueError("layer mapping must be unique")
+    if not np.array_equal(lmap, np.sort(lmap)):
+        raise ValueError("layer mapping must monotonical increase")

--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -29,11 +29,11 @@ def merge_grids(
     grid1._set_xtgformat2()
     grid2._set_xtgformat2()
 
-    if isinstance(lmap1, np.ndarray):
+    if lmap1 is not None:
         _validate_layer_mapping(lmap1, grid1.nlay)
     else:
         lmap1 = np.arange(grid1.nlay, dtype=np.int32)
-    if isinstance(lmap2, np.ndarray):
+    if lmap2 is not None:
         _validate_layer_mapping(lmap2, grid2.nlay)
     else:
         lmap2 = np.arange(grid2.nlay, dtype=np.int32)
@@ -629,6 +629,8 @@ def _validate_layer_mapping(
     all layers in input grid are mapped
     """
 
+    if not isinstance(lmap, np.ndarray):
+        raise ValueError("The layermap must be input as a numpy array")
     if lmap.min() < 0:
         raise ValueError("layer mapping must be >=0")
     if len(lmap) != num_grid_layers:

--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -68,10 +68,8 @@ def merge_grids(
     # create a new layer mapping for grid1 and grid2
     # group layers in the merged grid by the input layer number
 
-    if not isinstance(lmap1, np.ndarray) and lmap1 is None:
-        lmap1 = np.arange(grid1.nlay, dtype=np.int32)
-    if not isinstance(lmap2, np.ndarray) and lmap2 is None:
-        lmap2 = np.arange(grid2.nlay, dtype=np.int32)
+    lmap1 = lmap1 or np.arange(grid1.nlay, dtype=np.int32)
+    lmap2 = lmap2 or np.arange(grid2.nlay, dtype=np.int32)
 
     new_nlay = max(lmap1.max() + 1, lmap2.max() + 1)
 

--- a/src/xtgeo/grid3d/_grid_merge.py
+++ b/src/xtgeo/grid3d/_grid_merge.py
@@ -17,8 +17,8 @@ logger = null_logger(__name__)
 def merge_grids(
     grid1: Grid,
     grid2: Grid,
-    layer_offset: int = 0,
-    layer_refinement: int = 0,
+    lmap1: np.ndarray | None = None,
+    lmap2: np.ndarray | None = None,
 ) -> Grid:
     """Merge two areally-separated grids into a single grid instance.
 
@@ -29,10 +29,20 @@ def merge_grids(
     grid1._set_xtgformat2()
     grid2._set_xtgformat2()
 
-    if layer_offset < 0:
-        raise ValueError("layer offset must be >=0")
-    if layer_refinement < 0:
-        raise ValueError("layer refinement must be >=0")
+    if isinstance(lmap1, np.ndarray):
+        if lmap1.min() < 0:
+            raise ValueError("layer mapping 1 must be >=0")
+        if len(lmap1) != grid1.nlay:
+            raise ValueError("layer mapping 1 must map all layers")
+        if not np.all(lmap1 % 1 == 0):
+            raise ValueError("layer mapping 1 must only contrain int")
+    if isinstance(lmap2, np.ndarray):
+        if lmap2.min() < 0:
+            raise ValueError("layer mapping 2 must be >=0")
+        if len(lmap2) != grid2.nlay:
+            raise ValueError("layer mapping 2 must map all layers")
+        if not np.all(lmap2 % 1 == 0):
+            raise ValueError("layer mapping 2 must only contrain int")
 
     # Ensure both grids have the same ijk_handedness
     if (
@@ -57,24 +67,13 @@ def merge_grids(
 
     # create a new layer mapping for grid1 and grid2
     # group layers in the merged grid by the input layer number
-    lmap1 = np.arange(grid1.nlay, dtype=np.int32)
-    lmap2 = np.arange(grid2.nlay, dtype=np.int32)
 
-    if layer_refinement == 0:
-        new_nlay = max(grid1.nlay, layer_offset + grid2.nlay)
-    else:
-        new_nlay = (
-            layer_offset
-            + grid2.nlay
-            + max(0, grid1.nlay - layer_offset - int(grid2.nlay / layer_refinement))
-        )
-        lmap1 = lmap1 + np.where(
-            lmap1 < layer_offset,
-            0,
-            (layer_refinement - 1)
-            * np.minimum(int(grid2.nlay / layer_refinement), lmap1 - layer_offset),
-        )
-        lmap2 += layer_offset
+    if not isinstance(lmap1, np.ndarray) and lmap1 is None:
+        lmap1 = np.arange(grid1.nlay, dtype=np.int32)
+    if not isinstance(lmap2, np.ndarray) and lmap2 is None:
+        lmap2 = np.arange(grid2.nlay, dtype=np.int32)
+
+    new_nlay = max(lmap1.max() + 1, lmap2.max() + 1)
 
     # Place grid1 at (0, 0) and grid2 with a 1-cell gap
     offset1 = (0, 0)

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -405,7 +405,7 @@ def grid_merge(
     - nlay: max(grid1.nlay, grid2.nlay)
 
     Optionally a layer mapping for both grids can be specified. This is a numpy
-    array of length input grid that contrains the resulting layer in the merged
+    array of length input grid that contains the resulting layer in the merged
     grid. (Note this is zero indexed for input and output layers)
 
     - lmap[ INPUT_LAYER ] = NEW_LAYER

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -385,8 +385,8 @@ def grid_from_surfaces(
 def grid_merge(
     grid1: Grid,
     grid2: Grid,
-    layer_offset: int = 0,
-    layer_refinement: int = 0,
+    lmap1: np.ndarray | None = None,
+    lmap2: np.ndarray | None = None,
 ) -> Grid:
     """Merge two areally-separated grids into a single grid instance.
 
@@ -404,16 +404,16 @@ def grid_merge(
     - nrow: max(grid1.nrow, grid2.nrow)
     - nlay: max(grid1.nlay, grid2.nlay)
 
-    Optionally a layer offset and layer refinement can be specified. This is for
-    for the case where grid2 is a section of grid1 with refinement. In this case
-    grid2 is inserted starting at layer offset. Grid1 layer is adjusted based on
-    the specified refinement in the layer interval covered by grid2. This
-    ensures that the result grid groups all layers based on the input grid order.
+    Optionally a layer mapping for both grids can be specified. This is a numpy
+    array of length input grid that contrains the resulting layer in the merged
+    grid. (Note this is zero indexed for input and output layers)
+
+    - lmap[ INPUT_LAYER ] = NEW_LAYER
 
     The resulting grid dimensions will be:
     - ncol: grid1.ncol + 1 + grid2.ncol
     - nrow: max(grid1.nrow, grid2.nrow)
-    - nlay: offset + grid2.nlay + max(0, grid1.nlay - offset- grid2.nlay/refinment)
+    - nlay: max(grid1.nlay, grid2.nlay, max(lmap1)+1, max(lmap2)+1 )
 
     If the grids have different IJK handedness (left vs right), grid2 will be
     automatically adjusted to match grid1's handedness before merging.
@@ -430,8 +430,8 @@ def grid_merge(
     Args:
         grid1: First grid instance
         grid2: Second grid instance
-        layer_offset: Layer in grid1 where grid2 starts
-        layer_refinement: Refinement of each cell in grid2 versus grid1
+        lmap1: Optional numpy array with layer mapping for grid1
+        lmap2: Optional numpy array with layer mapping for grid2
 
     Returns:
         A new Grid instance containing both input grids with inactive cells in gaps.
@@ -456,7 +456,7 @@ def grid_merge(
 
     .. versionadded:: 4.18.0
     """
-    return _grid_merge.merge_grids(grid1, grid2, layer_offset, layer_refinement)
+    return _grid_merge.merge_grids(grid1, grid2, lmap1, lmap2)
 
 
 class _GridCache:

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -413,7 +413,7 @@ def grid_merge(
     The resulting grid dimensions will be:
     - ncol: grid1.ncol + 1 + grid2.ncol
     - nrow: max(grid1.nrow, grid2.nrow)
-    - nlay: max(grid1.nlay, grid2.nlay, max(lmap1)+1, max(lmap2)+1 )
+    - nlay: max(grid1.nlay, grid2.nlay, max(layer_map1)+1, max(layer_map2)+1 )
 
     If the grids have different IJK handedness (left vs right), grid2 will be
     automatically adjusted to match grid1's handedness before merging.
@@ -430,8 +430,8 @@ def grid_merge(
     Args:
         grid1: First grid instance
         grid2: Second grid instance
-        lmap1: Optional numpy array with layer mapping for grid1
-        lmap2: Optional numpy array with layer mapping for grid2
+        layer_map1: Optional numpy array with layer mapping for grid1
+        layer_map2: Optional numpy array with layer mapping for grid2
 
     Returns:
         A new Grid instance containing both input grids with inactive cells in gaps.
@@ -456,7 +456,7 @@ def grid_merge(
 
     .. versionadded:: 4.18.0
     """
-    return _grid_merge.merge_grids(grid1, grid2, lmap1, lmap2)
+    return _grid_merge.merge_grids(grid1, grid2, layer_map1, layer_map2)
 
 
 class _GridCache:

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -385,8 +385,8 @@ def grid_from_surfaces(
 def grid_merge(
     grid1: Grid,
     grid2: Grid,
-    lmap1: np.ndarray | None = None,
-    lmap2: np.ndarray | None = None,
+    layer_map1: np.ndarray | None = None,
+    layer_map2: np.ndarray | None = None,
 ) -> Grid:
     """Merge two areally-separated grids into a single grid instance.
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -408,7 +408,7 @@ def grid_merge(
     array of length input grid that contains the resulting layer in the merged
     grid. (Note this is zero indexed for input and output layers)
 
-    - lmap[ INPUT_LAYER ] = NEW_LAYER
+    - layer_map[ INPUT_LAYER ] = NEW_LAYER
 
     The resulting grid dimensions will be:
     - ncol: grid1.ncol + 1 + grid2.ncol

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -126,7 +126,9 @@ def test_lmap1_raises_if_not_increasing():
     lmap1 = np.arange(3, dtype=np.float32)[::-1]
     lmap2 = np.arange(2, dtype=np.float32)
 
-    with pytest.raises(ValueError, match="layer mapping must monotonical increase"):
+    with pytest.raises(
+        ValueError, match="layer mapping must strictly monotonically increase"
+    ):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -136,7 +138,9 @@ def test_lmap2_raises_if_not_increasing():
     lmap1 = np.arange(3, dtype=np.float32)
     lmap2 = np.arange(2, dtype=np.float32)[::-1]
 
-    with pytest.raises(ValueError, match="layer mapping must monotonical increase"):
+    with pytest.raises(
+        ValueError, match="layer mapping must strictly monotonically increase"
+    ):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -51,8 +51,7 @@ def test_lmap1_len():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_lmap2_len():
-    """Test layer offset is >=0."""
+def test_lmap2_raises_if_incorrect_length():
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
     lmap1 = np.arange(3)

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -40,8 +40,7 @@ def test_default_placement():
     assert merged.nactive == g1.nactive + g2.nactive
 
 
-def test_lmap1_len():
-    """Test layer offset is >=0."""
+def test_lmap1_raises_if_incorrect_length():
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
     lmap1 = np.arange(2)
@@ -61,8 +60,7 @@ def test_lmap2_raises_if_incorrect_length():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_lmap1_negative():
-    """Test layer offset is >=0."""
+def test_lmap1_raises_if_negative():
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
     lmap1 = np.arange(3) - 1
@@ -72,8 +70,7 @@ def test_lmap1_negative():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_lmap2_negative():
-    """Test layer offset is >=0."""
+def test_lmap2_raises_if_negative():
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
     lmap1 = np.arange(3)
@@ -83,8 +80,7 @@ def test_lmap2_negative():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_lmap1_int():
-    """Test layer offset is >=0."""
+def test_lmap1_raises_if_not_int():
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
     lmap1 = np.arange(3, dtype=np.float32) + 0.5
@@ -94,8 +90,7 @@ def test_lmap1_int():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_lmap2_int():
-    """Test layer offset is >=0."""
+def test_lmap2_raises_if_not_int():
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
     lmap1 = np.arange(3, dtype=np.float32)
@@ -105,8 +100,8 @@ def test_lmap2_int():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_merge_refinement_offset():
-    """Test merging grid with refinement and offset active"""
+def test_merge_with_lmap_inputs():
+    """Test merging grid with lmap1 and lmap2 active"""
     g1 = xtgeo.create_box_grid(dimension=(3, 3, 3))
     g2 = xtgeo.create_box_grid(dimension=(2, 2, 2))
 

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -40,22 +40,70 @@ def test_default_placement():
     assert merged.nactive == g1.nactive + g2.nactive
 
 
-def test_layer_offset():
+def test_lmap1_len():
     """Test layer offset is >=0."""
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(2)
+    lmap2 = np.arange(2)
 
     with pytest.raises(ValueError):
-        xtgeo.grid_merge(g1, g2, -1, 0)
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
-def test_layer_refinement():
-    """Test layer refinement is >=0."""
+def test_lmap2_len():
+    """Test layer offset is >=0."""
     g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
     g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3)
+    lmap2 = np.arange(3)
 
     with pytest.raises(ValueError):
-        xtgeo.grid_merge(g1, g2, 0, -1)
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap1_negative():
+    """Test layer offset is >=0."""
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3) - 1
+    lmap2 = np.arange(2)
+
+    with pytest.raises(ValueError):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap2_negative():
+    """Test layer offset is >=0."""
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3)
+    lmap2 = np.arange(2) - 1
+
+    with pytest.raises(ValueError):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap1_int():
+    """Test layer offset is >=0."""
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3, dtype=np.float32) + 0.5
+    lmap2 = np.arange(2, dtype=np.float32)
+
+    with pytest.raises(ValueError):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap2_int():
+    """Test layer offset is >=0."""
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3, dtype=np.float32)
+    lmap2 = np.arange(2, dtype=np.float32) + 0.5
+
+    with pytest.raises(ValueError):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
 def test_merge_refinement_offset():
@@ -63,7 +111,16 @@ def test_merge_refinement_offset():
     g1 = xtgeo.create_box_grid(dimension=(3, 3, 3))
     g2 = xtgeo.create_box_grid(dimension=(2, 2, 2))
 
-    merged = xtgeo.grid_merge(g1, g2, 1, 2)
+    lmap1 = np.arange(3, dtype=np.int32)
+    lmap1 = lmap1 + np.where(
+        lmap1 < 1,
+        0,
+        np.minimum(1, lmap1 - 1),
+    )
+
+    lmap2 = np.arange(2, dtype=np.int32) + 1
+
+    merged = xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
     assert merged.ncol == 6
     assert merged.nrow == 3

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -46,7 +46,7 @@ def test_lmap1_raises_if_incorrect_length():
     lmap1 = np.arange(2)
     lmap2 = np.arange(2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="layer mapping 1 must map all layers"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -56,7 +56,7 @@ def test_lmap2_raises_if_incorrect_length():
     lmap1 = np.arange(3)
     lmap2 = np.arange(3)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="layer mapping 2 must map all layers"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -66,7 +66,7 @@ def test_lmap1_raises_if_negative():
     lmap1 = np.arange(3) - 1
     lmap2 = np.arange(2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="layer mapping 1 must be >=0"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -76,7 +76,7 @@ def test_lmap2_raises_if_negative():
     lmap1 = np.arange(3)
     lmap2 = np.arange(2) - 1
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="layer mapping 2 must be >=0"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -86,7 +86,7 @@ def test_lmap1_raises_if_not_int():
     lmap1 = np.arange(3, dtype=np.float32) + 0.5
     lmap2 = np.arange(2, dtype=np.float32)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="layer mapping 1 must only contrain int"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -96,7 +96,7 @@ def test_lmap2_raises_if_not_int():
     lmap1 = np.arange(3, dtype=np.float32)
     lmap2 = np.arange(2, dtype=np.float32) + 0.5
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="layer mapping 2 must only contrain int"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -46,7 +46,7 @@ def test_lmap1_raises_if_incorrect_length():
     lmap1 = np.arange(2)
     lmap2 = np.arange(2)
 
-    with pytest.raises(ValueError, match="layer mapping 1 must map all layers"):
+    with pytest.raises(ValueError, match="layer mapping must map all layers"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -56,7 +56,7 @@ def test_lmap2_raises_if_incorrect_length():
     lmap1 = np.arange(3)
     lmap2 = np.arange(3)
 
-    with pytest.raises(ValueError, match="layer mapping 2 must map all layers"):
+    with pytest.raises(ValueError, match="layer mapping must map all layers"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -66,7 +66,7 @@ def test_lmap1_raises_if_negative():
     lmap1 = np.arange(3) - 1
     lmap2 = np.arange(2)
 
-    with pytest.raises(ValueError, match="layer mapping 1 must be >=0"):
+    with pytest.raises(ValueError, match="layer mapping must be >=0"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -76,7 +76,7 @@ def test_lmap2_raises_if_negative():
     lmap1 = np.arange(3)
     lmap2 = np.arange(2) - 1
 
-    with pytest.raises(ValueError, match="layer mapping 2 must be >=0"):
+    with pytest.raises(ValueError, match="layer mapping must be >=0"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -86,7 +86,7 @@ def test_lmap1_raises_if_not_int():
     lmap1 = np.arange(3, dtype=np.float32) + 0.5
     lmap2 = np.arange(2, dtype=np.float32)
 
-    with pytest.raises(ValueError, match="layer mapping 1 must only contrain int"):
+    with pytest.raises(ValueError, match="layer mapping must only contain int"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
@@ -96,7 +96,47 @@ def test_lmap2_raises_if_not_int():
     lmap1 = np.arange(3, dtype=np.float32)
     lmap2 = np.arange(2, dtype=np.float32) + 0.5
 
-    with pytest.raises(ValueError, match="layer mapping 2 must only contrain int"):
+    with pytest.raises(ValueError, match="layer mapping must only contain int"):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap1_raises_if_not_unique():
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.ones(3, dtype=np.float32)
+    lmap2 = np.arange(2, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="layer mapping must be unique"):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap2_raises_if_not_unique():
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3, dtype=np.float32)
+    lmap2 = np.ones(2, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="layer mapping must be unique"):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap1_raises_if_not_increasing():
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3, dtype=np.float32)[::-1]
+    lmap2 = np.arange(2, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="layer mapping must monotonical increase"):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap2_raises_if_not_increasing():
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3, dtype=np.float32)
+    lmap2 = np.arange(2, dtype=np.float32)[::-1]
+
+    with pytest.raises(ValueError, match="layer mapping must monotonical increase"):
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 

--- a/tests/test_grid3d/test_grid_merge.py
+++ b/tests/test_grid3d/test_grid_merge.py
@@ -144,6 +144,26 @@ def test_lmap2_raises_if_not_increasing():
         xtgeo.grid_merge(g1, g2, lmap1, lmap2)
 
 
+def test_lmap1_raises_if_not_np_array():
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = [0, 1, 2]
+    lmap2 = np.arange(2, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="The layermap must be input as a numpy array"):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
+def test_lmap2_raises_if_not_np_array():
+    g1 = xtgeo.create_box_grid(dimension=(5, 5, 3))
+    g2 = xtgeo.create_box_grid(dimension=(3, 3, 2))
+    lmap1 = np.arange(3, dtype=np.float32)
+    lmap2 = [0, 1]
+
+    with pytest.raises(ValueError, match="The layermap must be input as a numpy array"):
+        xtgeo.grid_merge(g1, g2, lmap1, lmap2)
+
+
 def test_merge_with_lmap_inputs():
     """Test merging grid with lmap1 and lmap2 active"""
     g1 = xtgeo.create_box_grid(dimension=(3, 3, 3))


### PR DESCRIPTION
fmu tools calls the merge_grid functionality with optional arguments. To align with the requested changes in fmu tools the optional arguements need changed. Previously inputs were used to build same numpy arrays in fmu.tools and xtgeo. Now the arrays are built in fmu.tools and passed directly to xtgeo.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
