### PR TITLE
TST: Fix ResInsight test (always use latest grpcio)

### DIFF
--- a/.github/actions/setup_resinsight/action.yml
+++ b/.github/actions/setup_resinsight/action.yml
@@ -32,3 +32,4 @@ runs:
       shell: bash
       run: |
         uv pip install "/opt/${{ inputs.install-dir }}/bin/Python"
+        uv pip install --upgrade --no-cache-dir --force-reinstall --verbose "grpcio>=1.81.0" "grpcio-tools>=1.81.0"


### PR DESCRIPTION
Attempt to fix ResInsight test by making sure grpcio is always the latest.

Briefly describe changes here, e.g. "Added a precise description about the
changes made to the code, and what the PR is solving."

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
