### PR TITLE
TST: exclude TYPE_CHECKING blocks for test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,3 +21,6 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise NotImplementedError
 
+    # Exclude TYPE_CHECKING-only imports (never executed at runtime)
+    if TYPE_CHECKING:
+


### PR DESCRIPTION
Resolves #1653 

`TYPE_CHECKING` blocks are included in test coverage measurements, although they are not executed at runtime.
To avoid this, they are excluded in `.coveragerc` (which takes precedence over `pyproject.toml`)

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
