### PR TITLE
BUG: Support pandas 3 in roxar XYZ values

### DIFF
--- a/src/xtgeo/xyz/_xyz_roxapi.py
+++ b/src/xtgeo/xyz/_xyz_roxapi.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Type, cast
 
@@ -449,7 +450,8 @@ def _replace_undefined_values(
     Set xtgeo UNDEF values to np.nan or empty string dependent on type.
     With option to return array with masked values instead of np.nan.
     """
-    values = pd.to_numeric(values, errors="ignore")  # type: ignore[call-overload]
+    with suppress(TypeError, ValueError):
+        values = pd.to_numeric(values, errors="raise")
 
     dtype = dtype or _get_attribute_type_from_values(values)
 

--- a/tests/test_xyz/test_xyz_roxapi_mock.py
+++ b/tests/test_xyz/test_xyz_roxapi_mock.py
@@ -88,6 +88,23 @@ def test_polygons_invalid_stype():
         xtgeo.polygons_from_roxar("project", "Name", "Category", stype="")
 
 
+def test_replace_undefined_values_converts_numeric_strings():
+    values = np.array(["1.0", "2.0", str(xtgeo.UNDEF)])
+
+    result = _xyz_roxapi._replace_undefined_values(values)
+
+    assert result[:2].tolist() == [1.0, 2.0]
+    assert np.isnan(result[2])
+
+
+def test_replace_undefined_values_keeps_non_numeric_strings():
+    values = np.array(["alpha", "UNDEF", "beta"])
+
+    result = _xyz_roxapi._replace_undefined_values(values)
+
+    assert result.tolist() == ["alpha", "", "beta"]
+
+
 @pytest.mark.usefixtures("mock_roxutils", "polygon_set_in_roxvalues")
 def test_load_polygons_from_roxar():
     pol = xtgeo.polygons_from_roxar("project", "Name", "Category")


### PR DESCRIPTION
Resolves #1656

Replaces `pd.to_numeric(..., errors="ignore")` in the Roxar XYZ value handling with explicit fallback behavior that is compatible with pandas 3. The old behavior is preserved: numeric-looking values are converted, while non-numeric/string values are kept unchanged.

This fixes the failure seen in the RMS 15.2 / Python 3.14 rms-sys integration tests, where RMS bundles `pandas==3.0.0` and pandas no longer accepts `errors="ignore"` for `pd.to_numeric`.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅