### PR TITLE
CI: Add CODEOWNERS policy & PR approval rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS policy for the xtgeo repository
+# This file declares the code owners recognized by GitHub for review assignment.
+# Pull requests to the protected branches `main` must be approved by the 
+# designated code owner team.
+# The rule below explicitly protects this file to prevent unauthorized
+# changes to ownership.
+
+/.github/CODEOWNERS @equinor/atlas
+* @equinor/atlas

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,10 @@ Before you submit a pull request, check that it meets these guidelines:
    public method make sure it displays helpful information in the
    documentation.
 
+3. This repository uses `.github/CODEOWNERS` to define code ownership for all
+   files. Pull requests that target the `main` branch in `equinor/xtgeo` must
+   have at least one approval from the code owner team `@equinor/atlas`.
+
 ## Tips
 
 - To run a subset of tests, e.g. only surface tests:


### PR DESCRIPTION
Add a CODEOWNERS file under .github to assign repository ownership to @equinor/atlas team, including explicit ownership of the CODEOWNERS file itself.  Also updated the  CONTRIBUTING.md that pull request targeting main require code owner approval.

Closes#1658

Resolves #issue

Briefly describe changes here, e.g. "Added a precise description about the
changes made to the code, and what the PR is solving."

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
