### PR TITLE
ENH: Add interface to ResInsight grid property

### DIFF
--- a/docs/api-grids.rst
+++ b/docs/api-grids.rst
@@ -36,6 +36,8 @@ Functions
 
 .. autofunction:: xtgeo.gridproperty_from_roxar
 
+.. autofunction:: xtgeo.gridproperty_from_resinsight
+
 Classes
 """""""
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -115,3 +115,33 @@ Create a new ResInsight corner-point grid from XTGeo::
         instance_or_port=50051,
         gname="CPG from XTGeo",
     )
+
+Read a grid property (e.g. porosity) from a ResInsight case::
+
+    import xtgeo
+
+    poro = xtgeo.gridproperty_from_resinsight(
+        instance_or_port=50051,
+        case_name="EXAMPLE",
+        property_name="PORO",
+        property_type="STATIC_NATIVE",
+    )
+    print(poro.values.mean())
+
+Read a dynamic property at a specific time step::
+
+    pressure = xtgeo.gridproperty_from_resinsight(
+        instance_or_port=50051,
+        case_name="EXAMPLE",
+        property_name="PRESSURE",
+        property_type="DYNAMIC_NATIVE",
+        time_step_index=5,
+    )
+
+Write a property back to ResInsight as a "GENERATED" result::
+
+    poro.to_resinsight(
+        instance_or_port=50051,
+        case_name="EXAMPLE",
+        property_name="PORO_MODIFIED",
+    )

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -108,6 +108,7 @@ from xtgeo.grid3d.grid_property import (
     GridProperty,
     gridproperty_from_cube,
     gridproperty_from_file,
+    gridproperty_from_resinsight,
     gridproperty_from_roxar,
 )
 
@@ -236,6 +237,7 @@ __all__ = [
     "gridproperties_from_file",
     "gridproperty_from_cube",
     "gridproperty_from_file",
+    "gridproperty_from_resinsight",
     "gridproperty_from_roxar",
     "list_gridproperties",
     "points",

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -44,6 +44,10 @@ if TYPE_CHECKING:
 
     from xtgeo.common.types import FileLike
     from xtgeo.cube.cube1 import Cube
+    from xtgeo.interfaces.resinsight._rips_package import (
+        PropertyType,
+        ResInsightInstanceOrPortType,
+    )
     from xtgeo.xyz.polygons import Polygons
 
     from ._gridprop_op1 import XYValueLists
@@ -193,6 +197,60 @@ def gridproperty_from_roxar(
         realisation=realisation,
         faciescodes=faciescodes,
     )
+
+
+def gridproperty_from_resinsight(
+    instance_or_port: ResInsightInstanceOrPortType | None,
+    case_name: str,
+    property_name: str,
+    property_type: str | PropertyType = "STATIC_NATIVE",
+    time_step_index: int = 0,
+    find_last: bool = True,
+) -> GridProperty:
+    """Load a grid property from a ResInsight case into an XTGeo ``GridProperty``.
+
+    Args:
+        instance_or_port: Optional ``rips.Instance`` or gRPC port. Use ``None``
+            to auto-discover a running ResInsight instance.
+        case_name: Name of the ResInsight case.
+        property_name: Name of the property (e.g. ``"PORO"``, ``"PRESSURE"``).
+        property_type: A :class:`~xtgeo.interfaces.resinsight.PropertyType`
+            member or a plain string such as ``"STATIC_NATIVE"``,
+            ``"DYNAMIC_NATIVE"``, ``"GENERATED"``, or ``"INPUT_PROPERTY"``.
+            Strings are validated and coerced to the enum internally.
+        time_step_index: Time step index (default 0).
+        find_last: If multiple cases share the same name, select the last match.
+
+    Returns:
+        A populated :class:`xtgeo.GridProperty`.
+
+    Raises:
+        ValueError: If *property_type* is not a valid
+            :class:`~xtgeo.interfaces.resinsight.PropertyType`.
+
+    Example::
+
+        import xtgeo
+
+        poro = xtgeo.gridproperty_from_resinsight(
+            5000, "MY_CASE", "PORO",
+            property_type="STATIC_NATIVE",
+        )
+        print(poro.values.mean())
+
+    """
+    import xtgeo.interfaces.resinsight
+
+    data = xtgeo.interfaces.resinsight.GridPropertyReader(
+        instance_or_port=instance_or_port,
+    ).load(
+        case_name=case_name,
+        property_name=property_name,
+        property_type=property_type,
+        time_step_index=time_step_index,
+        find_last=find_last,
+    )
+    return data.to_xtgeo_gridproperty()
 
 
 def gridproperty_from_cube(
@@ -946,6 +1004,66 @@ class GridProperty(_Grid3D):
             realisation=realisation,
             casting=casting,
         )
+
+    def to_resinsight(
+        self,
+        instance_or_port: ResInsightInstanceOrPortType | None,
+        case_name: str,
+        property_type: str | PropertyType = "GENERATED",
+        property_name: str | None = None,
+        time_step_index: int = 0,
+        find_last: bool = True,
+    ) -> None:
+        """Export this grid property to a ResInsight case.
+
+        Args:
+            instance_or_port: Optional ``rips.Instance`` or gRPC port. Use
+                ``None`` to auto-discover a running ResInsight instance.
+            case_name: Name of the target ResInsight case.
+            property_type: A
+                :class:`~xtgeo.interfaces.resinsight.PropertyType`
+                member or a plain string such as ``"GENERATED"``.
+                Strings are validated and coerced to the enum internally.
+            property_name: Name to give the property in ResInsight. If ``None``,
+                the current :attr:`name` is used.
+            time_step_index: Time step index (default 0).
+            find_last: Controls which case to target when multiple cases share
+                the same name. If ``True`` (default), the last matching case is
+                used; if ``False``, the first.
+
+        Raises:
+            ValueError: If *property_type* is not a valid
+                :class:`~xtgeo.interfaces.resinsight.PropertyType`.
+
+        Example::
+
+            import xtgeo
+
+            poro = xtgeo.gridproperty_from_file("poro.roff", name="PORO")
+            poro.to_resinsight(5000, "MY_CASE", property_name="PORO_MODIFIED")
+
+        """
+        import xtgeo.interfaces.resinsight as resinsight_interface
+
+        pname = property_name if property_name is not None else self.name
+        if pname is None:
+            raise ValueError("property_name must be given (GridProperty.name is None)")
+
+        data = resinsight_interface.GridPropertyDataResInsight.from_xtgeo_gridproperty(
+            self,
+            property_type=property_type,
+            time_step_index=time_step_index,
+            grid=self.geometry,
+        )
+        if pname != data.name:
+            from dataclasses import replace
+
+            data = replace(data, name=pname)
+
+        writer = resinsight_interface.GridPropertyWriter(
+            instance_or_port=instance_or_port
+        )
+        writer.save(data, case_name, find_last)
 
     # ==================================================================================
     # Various public methods

--- a/src/xtgeo/interfaces/resinsight/__init__.py
+++ b/src/xtgeo/interfaces/resinsight/__init__.py
@@ -1,13 +1,23 @@
 """XTGeo interface.resinsight package."""
 
 from ._grid import GridDataResInsight, GridReader, GridWriter
-from ._rips_package import rips
+from ._grid_property import (
+    GridPropertyDataResInsight,
+    GridPropertyReader,
+    GridPropertyWriter,
+)
+from ._rips_package import PropertyDataType, PropertyType, rips
 from .rips_utils import RipsApiUtils
 
 __all__ = [
     "GridDataResInsight",
+    "GridPropertyDataResInsight",
+    "GridPropertyReader",
+    "GridPropertyWriter",
     "GridReader",
     "GridWriter",
+    "PropertyDataType",
+    "PropertyType",
     "RipsApiUtils",
     "rips",
 ]

--- a/src/xtgeo/interfaces/resinsight/_grid_property.py
+++ b/src/xtgeo/interfaces/resinsight/_grid_property.py
@@ -1,0 +1,329 @@
+"""ResInsight API helpers for grid properties via rips."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from xtgeo.common.constants import UNDEF, UNDEF_INT
+from xtgeo.common.log import null_logger
+
+from ._resinsight_base import _BaseResInsightDataRW
+from ._rips_package import PropertyDataType, PropertyType, rips
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from xtgeo.grid3d.grid import Grid
+    from xtgeo.grid3d.grid_property import GridProperty
+
+    from ._rips_package import ResInsightInstanceOrPortType
+
+logger = null_logger(__name__)
+
+
+def _validate_property_type(property_type: str | PropertyType) -> PropertyType:
+    """Coerce *property_type* to ``rips.PropertyType``.
+
+    Raises ``RuntimeError`` if rips is not installed, ``ValueError`` on invalid input.
+    """
+    if rips is None:
+        raise RuntimeError("rips package is not available")
+    if isinstance(property_type, PropertyType):
+        return property_type
+    try:
+        return PropertyType(property_type)
+    except ValueError:
+        valid = ", ".join(f'"{m.value}"' for m in PropertyType)
+        raise ValueError(
+            f"Invalid property_type {property_type!r}. Must be one of: {valid}"
+        ) from None
+
+
+@dataclass(frozen=True, eq=False)
+class GridPropertyDataResInsight:
+    """Immutable data container for a ResInsight grid property.
+
+    Stores property values for all cells (nx x ny x nz), together with the
+    grid dimensions and actnum needed to reconstruct a full 3-D XTGeo
+    ``GridProperty``.
+    """
+
+    name: str
+    nx: int
+    ny: int
+    nz: int
+    values: npt.NDArray[np.float64] | npt.NDArray[np.int32] = field(repr=False)
+    actnumsv: npt.NDArray[np.int32] = field(repr=False)
+    property_type: str | PropertyType
+    time_step_index: int
+    discrete: bool
+    codes: dict[int, str]
+    filesrc: str
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, GridPropertyDataResInsight):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.nx == other.nx
+            and self.ny == other.ny
+            and self.nz == other.nz
+            and np.array_equal(self.values, other.values)
+            and np.array_equal(self.actnumsv, other.actnumsv)
+            and self.property_type == other.property_type
+            and self.time_step_index == other.time_step_index
+            and self.discrete == other.discrete
+            and self.codes == other.codes
+            and self.filesrc == other.filesrc
+        )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "property_type", _validate_property_type(self.property_type)
+        )
+
+        total_cells = self.nx * self.ny * self.nz
+        if self.actnumsv.size != total_cells:
+            raise ValueError(
+                f"actnumsv should have length {total_cells}, but got "
+                f"length {self.actnumsv.size}"
+            )
+        if self.values.size != total_cells:
+            raise ValueError(
+                f"values should have length {total_cells}, but got "
+                f"length {self.values.size}"
+            )
+
+    def to_xtgeo_gridproperty(self) -> GridProperty:
+        """Convert this data container to an XTGeo ``GridProperty``."""
+        from xtgeo.grid3d.grid_property import GridProperty
+
+        shape = (self.nx, self.ny, self.nz)
+        dtype = np.int32 if self.discrete else np.float64
+        vals = np.asarray(self.values, dtype=dtype).reshape(shape, order="F")
+        mask = (self.actnumsv == 0).reshape(shape, order="F")
+
+        return GridProperty(
+            ncol=self.nx,
+            nrow=self.ny,
+            nlay=self.nz,
+            values=np.ma.MaskedArray(vals, mask=mask),
+            name=self.name,
+            discrete=self.discrete,
+            codes=dict(self.codes) if self.codes else None,
+            filesrc=self.filesrc,
+        )
+
+    @classmethod
+    def from_xtgeo_gridproperty(
+        cls,
+        prop: GridProperty,
+        property_type: str | PropertyType,
+        time_step_index: int = 0,
+        grid: Grid | None = None,
+    ) -> GridPropertyDataResInsight:
+        """Create from an XTGeo ``GridProperty``."""
+        validated_type = _validate_property_type(property_type)
+
+        # Active = unmasked in property, intersected with grid actnum if given.
+        # Ravel in Fortran order (i fastest) to match Eclipse/ResInsight convention.
+        active = ~np.ma.getmaskarray(prop.values).ravel(order="F")
+        if grid is not None:
+            grid_actnum = np.asarray(
+                grid.get_actnum().values.data, dtype=np.int32
+            ).ravel(order="F")
+            active &= grid_actnum != 0
+
+        dtype = np.int32 if prop.isdiscrete else np.float64
+        fill = UNDEF_INT if prop.isdiscrete else UNDEF
+
+        values = np.asarray(prop.values.filled(fill), dtype=dtype).ravel(order="F")
+        values = values.copy()  # type: ignore[assignment]
+        values[~active] = fill
+
+        return cls(
+            name=prop.name or "unknown",
+            nx=prop.ncol,
+            ny=prop.nrow,
+            nz=prop.nlay,
+            values=values,  # type: ignore[arg-type]
+            actnumsv=active.astype(np.int32),
+            property_type=validated_type,
+            time_step_index=time_step_index,
+            discrete=prop.isdiscrete,
+            codes=dict(prop.codes) if prop.isdiscrete and prop.codes else {},
+            filesrc=prop.filesrc or "",
+        )
+
+
+def _read_actnum(case: object, expected_size: int) -> npt.NDArray[np.int32]:
+    """Read ACTNUM from ResInsight as a grid property.
+
+    Tries STATIC_NATIVE first, then INPUT_PROPERTY as fallback.
+    Active cells have value 1, inactive cells have value 0.  Non-finite
+    values (inf at inactive cells) are treated as inactive.
+    """
+    for ptype in (PropertyType.STATIC_NATIVE, PropertyType.INPUT_PROPERTY):
+        try:
+            raw = np.asarray(
+                case.grid_property(ptype, "ACTNUM", 0),  # type: ignore[attr-defined]
+                dtype=np.float64,
+            )
+            if raw.size == expected_size:
+                return (np.isfinite(raw) & (raw != 0)).astype(np.int32)
+        except Exception:  # noqa: BLE001
+            continue
+
+    raise RuntimeError(
+        f"Could not read ACTNUM from case (tried STATIC_NATIVE and "
+        f"INPUT_PROPERTY, expected {expected_size} cells)"
+    )
+
+
+class GridPropertyReader(_BaseResInsightDataRW):
+    """Read grid properties from ResInsight using rips."""
+
+    def __init__(
+        self,
+        instance_or_port: ResInsightInstanceOrPortType | None = None,
+    ) -> None:
+        super().__init__(instance_or_port)
+
+    def load(
+        self,
+        case_name: str,
+        property_name: str,
+        property_type: str | PropertyType = "STATIC_NATIVE",
+        time_step_index: int = 0,
+        find_last: bool = True,
+    ) -> GridPropertyDataResInsight:
+        """Load a grid property from selected ResInsight case."""
+        validated_type = _validate_property_type(property_type)
+
+        case = self.get_case(case_name=case_name, find_last=find_last)
+        if case is None:
+            raise RuntimeError(f"Cannot find any case with name '{case_name}'")
+
+        dims = case.grids()[0].dimensions()  # type: ignore[attr-defined]
+        nx, ny, nz = dims.i, dims.j, dims.k
+
+        actnum = _read_actnum(case, nx * ny * nz)
+
+        discrete = (
+            case.property_data_type(  # type: ignore[attr-defined]
+                property_type=validated_type,
+                property_name=property_name,
+            )
+            == PropertyDataType.INTEGER
+        )
+
+        raw = np.asarray(
+            case.grid_property(  # type: ignore[attr-defined]
+                validated_type, property_name, time_step_index
+            ),
+            dtype=np.float64,
+        )
+        # Replace non-finite values (inf at inactive cells) with fill sentinel.
+        fill = UNDEF_INT if discrete else UNDEF
+        non_finite = ~np.isfinite(raw)
+        if np.any(non_finite):
+            raw[non_finite] = fill
+
+        values = raw.astype(np.int32) if discrete else raw.astype(np.float64)
+
+        codes: dict[int, str] = {}
+        if discrete:
+            raw_codes = (
+                case.discrete_property_category_names(  # type: ignore[attr-defined]
+                    property_name
+                )
+                or {}
+            )
+            codes = {int(k): str(v) for k, v in raw_codes.items()}
+
+        return GridPropertyDataResInsight(
+            name=property_name,
+            nx=nx,
+            ny=ny,
+            nz=nz,
+            values=values,
+            actnumsv=actnum,
+            property_type=validated_type,
+            time_step_index=time_step_index,
+            discrete=discrete,
+            codes=codes,
+            filesrc=getattr(case, "file_path", "") or "",
+        )
+
+
+class GridPropertyWriter(_BaseResInsightDataRW):
+    """Write grid properties to ResInsight using rips."""
+
+    def __init__(
+        self,
+        instance_or_port: ResInsightInstanceOrPortType | None = None,
+    ) -> None:
+        super().__init__(instance_or_port)
+
+    def save(
+        self,
+        data: GridPropertyDataResInsight,
+        case_name: str,
+        find_last: bool = True,
+    ) -> None:
+        """Save a grid property into selected ResInsight case."""
+        case = self.get_case(case_name=case_name, find_last=find_last)
+        if case is None:
+            raise RuntimeError(
+                f"Cannot find any case with name '{case_name}' for property export"
+            )
+
+        # Validate grid dimensions before writing.
+        dims = case.grids()[0].dimensions()  # type: ignore[attr-defined]
+        if (data.nx, data.ny, data.nz) != (dims.i, dims.j, dims.k):
+            raise ValueError(
+                f"Property '{data.name}' has dimensions "
+                f"{data.nx}x{data.ny}x{data.nz}, but case '{case_name}' grid "
+                f"has {dims.i}x{dims.j}x{dims.k}"
+            )
+
+        validated_type = _validate_property_type(data.property_type)
+        try:
+            extra = {"data_type": PropertyDataType.INTEGER} if data.discrete else {}
+
+            # ResInsight expects NaN for inactive cells.
+            send_values = data.values.astype(np.float64)
+            send_values[data.actnumsv == 0] = np.nan
+
+            case.set_grid_property(  # type: ignore[attr-defined]
+                send_values.tolist(),
+                validated_type,
+                data.name,
+                data.time_step_index,
+                **extra,
+            )
+
+            if data.discrete and data.codes:
+                case.set_discrete_property_category_names(  # type: ignore[attr-defined]
+                    property_name=data.name,
+                    value_names={int(k): str(v) for k, v in data.codes.items()},
+                )
+
+            logger.debug(
+                "Saved property '%s' (type=%s, time_step=%d) to case '%s'",
+                data.name,
+                validated_type,
+                data.time_step_index,
+                case_name,
+            )
+
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to save property '{data.name}' to ResInsight case "
+                f"'{case_name}': {exc}"
+            ) from exc

--- a/src/xtgeo/interfaces/resinsight/_rips_package.py
+++ b/src/xtgeo/interfaces/resinsight/_rips_package.py
@@ -21,11 +21,15 @@ try:
         Case as _RipsCase,
         Instance as _RipsInstance,
         Project as _RipsProject,
+        PropertyDataType,
+        PropertyType,
     )
 except ImportError:
     _RipsCase = Any  # type: ignore[misc,assignment]
     _RipsInstance = Any  # type: ignore[misc,assignment]
     _RipsProject = Any  # type: ignore[misc,assignment]
+    PropertyDataType = Any  # type: ignore[misc,assignment]
+    PropertyType = Any  # type: ignore[misc,assignment]
 
 RipsCaseType: TypeAlias = _RipsCase  # type: ignore[misc]
 RipsInstanceType: TypeAlias = _RipsInstance  # type: ignore[misc]

--- a/tests/test_interfaces/test_resinsight/test_gridprop_public_api.py
+++ b/tests/test_interfaces/test_resinsight/test_gridprop_public_api.py
@@ -1,0 +1,190 @@
+"""Tests for the public xtgeo grid property ↔ ResInsight API.
+
+Covers:
+- ``xtgeo.gridproperty_from_resinsight``
+- ``xtgeo.GridProperty.to_resinsight``
+
+These tests require a live ResInsight instance and the ``rips`` package.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import xtgeo
+
+pytestmark = pytest.mark.requires_resinsight
+
+
+def _write_generated_property(resinsight_instance, case_name="EXAMPLE"):
+    """Write a GENERATED continuous property to the case, return the created data."""
+    from xtgeo.interfaces.resinsight._grid_property import (
+        GridPropertyDataResInsight,
+        GridPropertyWriter,
+        _read_actnum,
+    )
+    from xtgeo.interfaces.resinsight._resinsight_base import _BaseResInsightDataRW
+
+    base = _BaseResInsightDataRW(resinsight_instance)
+    case = base.get_case(case_name=case_name, find_last=True)
+    dims = case.grids()[0].dimensions()
+    nx, ny, nz = dims.i, dims.j, dims.k
+    total = nx * ny * nz
+    actnum = _read_actnum(case, total)
+
+    rng = np.random.default_rng(42)
+    values = rng.random(total).astype(np.float64) * 0.4
+
+    data = GridPropertyDataResInsight(
+        name="SYNTH_PORO",
+        nx=nx,
+        ny=ny,
+        nz=nz,
+        values=values,
+        actnumsv=actnum,
+        property_type="GENERATED",
+        time_step_index=0,
+        discrete=False,
+        codes={},
+        filesrc="",
+    )
+    GridPropertyWriter(resinsight_instance).save(data, case_name)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# gridproperty_from_resinsight
+# ---------------------------------------------------------------------------
+
+
+def test_gridproperty_from_resinsight_returns_valid_gridproperty(resinsight_instance):
+    """gridproperty_from_resinsight should return an xtgeo.GridProperty instance."""
+    data = _write_generated_property(resinsight_instance)
+    prop = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance, "EXAMPLE", "SYNTH_PORO", property_type="GENERATED"
+    )
+
+    assert isinstance(prop, xtgeo.GridProperty)
+    assert not prop.isdiscrete
+    assert prop.name == "SYNTH_PORO"
+    assert prop.ncol == data.nx and prop.nrow == data.ny and prop.nlay == data.nz
+    active_vals = prop.values.compressed()
+    assert active_vals.min() >= 0.0
+    assert active_vals.max() <= 0.4
+
+
+def test_gridproperty_from_resinsight_no_case_raises(resinsight_instance):
+    """Should raise RuntimeError for an unknown case name."""
+    with pytest.raises(RuntimeError, match="Cannot find any case with name"):
+        xtgeo.gridproperty_from_resinsight(
+            resinsight_instance, "NON_EXISTENT_CASE", "ANY"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GridProperty.to_resinsight
+# ---------------------------------------------------------------------------
+
+
+def test_to_resinsight_continuous(resinsight_instance):
+    """A continuous property should survive a write → read roundtrip."""
+    _write_generated_property(resinsight_instance)
+    original = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance, "EXAMPLE", "SYNTH_PORO", property_type="GENERATED"
+    )
+
+    original.to_resinsight(
+        resinsight_instance,
+        case_name="EXAMPLE",
+        property_name="SYNTH_PORO_COPY",
+        property_type="GENERATED",
+    )
+
+    reloaded = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance,
+        "EXAMPLE",
+        "SYNTH_PORO_COPY",
+        property_type="GENERATED",
+    )
+
+    assert_allclose(
+        original.values.compressed(), reloaded.values.compressed(), atol=1e-6
+    )
+
+
+def test_to_resinsight_discrete(resinsight_instance):
+    """A discrete property should roundtrip correctly."""
+    _write_generated_property(resinsight_instance)
+    base_prop = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance, "EXAMPLE", "SYNTH_PORO", property_type="GENERATED"
+    )
+
+    # Create a discrete property from the continuous values
+    active_vals = base_prop.values.compressed()
+    region_vals = np.asarray([int(v * 100) % 4 for v in active_vals], dtype=np.int32)
+
+    total = base_prop.ncol * base_prop.nrow * base_prop.nlay
+    full_vals = np.zeros(total, dtype=np.int32)
+    active_mask = ~np.ma.getmaskarray(base_prop.values).ravel()
+    full_vals[active_mask] = region_vals
+
+    masked = np.ma.MaskedArray(
+        full_vals.reshape(base_prop.ncol, base_prop.nrow, base_prop.nlay),
+        mask=np.ma.getmaskarray(base_prop.values),
+    )
+    region_prop = xtgeo.GridProperty(
+        ncol=base_prop.ncol,
+        nrow=base_prop.nrow,
+        nlay=base_prop.nlay,
+        values=masked,
+        name="REGION_TEST",
+        discrete=True,
+        codes={0: "Sand", 1: "Shale", 2: "Coal", 3: "Limestone"},
+    )
+
+    region_prop.to_resinsight(
+        resinsight_instance,
+        case_name="EXAMPLE",
+        property_type="GENERATED",
+    )
+
+    reloaded = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance,
+        "EXAMPLE",
+        "REGION_TEST",
+        property_type="GENERATED",
+    )
+
+    assert np.array_equal(region_prop.values.compressed(), reloaded.values.compressed())
+
+
+# ---------------------------------------------------------------------------
+# Full roundtrip: box grid property
+# ---------------------------------------------------------------------------
+
+
+def test_roundtrip_box_grid_property(resinsight_instance):
+    """A synthetic box grid + property should roundtrip through ResInsight."""
+    grid = xtgeo.create_box_grid((4, 3, 2), increment=(5.0, 5.0, 2.0))
+    grid.to_resinsight(resinsight_instance, gname="PROP_TEST_GRID")
+
+    prop = xtgeo.GridProperty(grid, name="SYNTH", values=0.42, discrete=False)
+    prop.to_resinsight(
+        resinsight_instance,
+        case_name="PROP_TEST_GRID",
+        property_name="SYNTH",
+        property_type="GENERATED",
+    )
+
+    reloaded = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance,
+        "PROP_TEST_GRID",
+        "SYNTH",
+        property_type="GENERATED",
+    )
+    assert reloaded.ncol == 4
+    assert reloaded.nrow == 3
+    assert reloaded.nlay == 2
+    assert_allclose(reloaded.values.compressed(), 0.42, atol=1e-6)


### PR DESCRIPTION
Resolves #1637 

Add interface between XTGeo GridProperty and ResInsight grid property. This will allow user to visualize XTGeo grid property (along with grid geometry) in ResInsight. In addition, it is also possible to load grid and grid property in ResInsight to XTGeo for post processing.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
