### PR TITLE
ENH: Specify minimum rips version

### DIFF
--- a/src/xtgeo/interfaces/resinsight/_resinsight_base.py
+++ b/src/xtgeo/interfaces/resinsight/_resinsight_base.py
@@ -40,8 +40,6 @@ class _BaseResInsightDataRW:
 
     def get_project(self) -> RipsProjectType:
         """Get the active ResInsight project."""
-        if not hasattr(self.get_ripsapi_utils().instance, "project"):
-            raise RuntimeError("Connected rips.Instance does not have a project API")
         return self.get_ripsapi_utils().project
 
     def get_case(self, case_name: str, find_last: bool = True) -> RipsCaseType | None:

--- a/src/xtgeo/interfaces/resinsight/_rips_package.py
+++ b/src/xtgeo/interfaces/resinsight/_rips_package.py
@@ -1,28 +1,88 @@
-"""Load the optional rips package and expose type aliases."""
+"""Load the optional rips package and expose type aliases.
+
+The ResInsight interface requires a minimum ``rips`` version that provides the
+complete API surface used by xtgeo.  Rather than conditionally importing
+individual symbols to support older releases, we enforce an all-or-nothing
+version gate: either the installed ``rips`` meets :data:`MIN_RIPS_VERSION` and
+every import succeeds, or the user is told to upgrade.
+"""
 
 from __future__ import annotations
 
 import importlib
-from typing import Any, TypeAlias
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+from packaging.version import InvalidVersion, Version
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+# Minimum rips version that exposes the full API used by xtgeo
+MIN_RIPS_VERSION = "2026.2"
 
 
-def load_package(package_name: str) -> Any | None:
-    """Load a Python package by name, return None if unavailable."""
+def _check_rips_version() -> None:
+    """Raise ``RuntimeError`` if the installed rips version is too old or unparseable.
+
+    Called at runtime (from :func:`require_rips`) rather than at import time so
+    that the module can be loaded and inspected even when the installed ``rips``
+    version does not meet the minimum requirement.
+    """
+    try:
+        installed = version("rips")
+    except PackageNotFoundError:
+        raise RuntimeError(
+            "rips package is installed but its version metadata is missing. "
+            f"Please reinstall: pip install 'rips>={MIN_RIPS_VERSION}'"
+        ) from None
+
+    try:
+        installed_ver = Version(installed)
+    except InvalidVersion:
+        raise RuntimeError(
+            f"rips package reports version '{installed}' which is not a valid "
+            f"PEP 440 version string. Please install a supported release: "
+            f"pip install 'rips>={MIN_RIPS_VERSION}'"
+        ) from None
+
+    if installed_ver < Version(MIN_RIPS_VERSION):
+        raise RuntimeError(
+            f"xtgeo requires rips >= {MIN_RIPS_VERSION}, "
+            f"but {installed} is installed. "
+            f"Please upgrade: pip install 'rips>={MIN_RIPS_VERSION}'"
+        )
+
+
+def _load_package(package_name: str) -> Any | None:
+    """Load a Python package by name, return ``None`` if unavailable."""
     try:
         return importlib.import_module(package_name)
     except ImportError:
         return None
 
 
-rips = load_package("rips")
+rips = _load_package("rips")
+_rips_import_error: str | None = None
 
-try:
-    from rips import (
-        Case as _RipsCase,
-        Instance as _RipsInstance,
-        Project as _RipsProject,
-    )
-except ImportError:
+if rips is not None:
+    try:
+        from rips import (
+            Case as _RipsCase,
+            Instance as _RipsInstance,
+            Project as _RipsProject,
+        )
+    except ImportError as err:
+        _rips_import_error = (
+            f"The installed rips package does not provide the required API "
+            f"symbols (Case, Instance, Project): {err}. "
+            f"Please upgrade: pip install 'rips>={MIN_RIPS_VERSION}'"
+        )
+        rips = None
+        _RipsCase = Any  # type: ignore[misc,assignment]
+        _RipsInstance = Any  # type: ignore[misc,assignment]
+        _RipsProject = Any  # type: ignore[misc,assignment]
+else:
     _RipsCase = Any  # type: ignore[misc,assignment]
     _RipsInstance = Any  # type: ignore[misc,assignment]
     _RipsProject = Any  # type: ignore[misc,assignment]
@@ -32,3 +92,23 @@ RipsInstanceType: TypeAlias = _RipsInstance  # type: ignore[misc]
 RipsProjectType: TypeAlias = _RipsProject  # type: ignore[misc]
 
 ResInsightInstanceOrPortType: TypeAlias = int | RipsInstanceType
+
+
+def require_rips() -> ModuleType:
+    """Return the ``rips`` module or raise ``RuntimeError`` if unavailable/too old.
+
+    Call this at the top of any function that requires the rips package.
+    The return value is the validated ``rips`` module, which eliminates
+    the need for ``assert rips is not None`` type-narrowing at each call
+    site.
+    """
+    if rips is None:
+        raise RuntimeError(
+            _rips_import_error
+            or (
+                "rips package is not available. Please install "
+                f"rips >= {MIN_RIPS_VERSION} to use ResInsight features."
+            )
+        )
+    _check_rips_version()
+    return rips

--- a/src/xtgeo/interfaces/resinsight/rips_utils.py
+++ b/src/xtgeo/interfaces/resinsight/rips_utils.py
@@ -10,7 +10,7 @@ from ._rips_package import (
     ResInsightInstanceOrPortType,
     RipsInstanceType,
     RipsProjectType,
-    rips,
+    require_rips,
 )
 
 if TYPE_CHECKING:
@@ -33,15 +33,7 @@ class RipsApiUtils:
         self,
         instance_or_port: ResInsightInstanceOrPortType | None = None,
     ) -> None:
-        if rips is None:
-            raise RuntimeError(
-                "rips package is not available. Please install it to use "
-                "ResInsight features."
-            )
-
-        instance_cls = getattr(rips, "Instance", None)
-        if instance_cls is None:
-            raise RuntimeError("rips does not expose Instance API")
+        rips = require_rips()
 
         self._instance: RipsInstanceType
 
@@ -49,7 +41,7 @@ class RipsApiUtils:
             isinstance(instance_or_port, int) and not isinstance(instance_or_port, bool)
         ):
             self._instance = self.find_instance(port=instance_or_port)
-        elif isinstance(instance_or_port, instance_cls):
+        elif isinstance(instance_or_port, rips.Instance):
             self._instance = instance_or_port
         else:
             raise TypeError(
@@ -102,8 +94,7 @@ class RipsApiUtils:
                 - ``0``: Let gRPC automatically select an available free port.
                 - ``> 0``: Attempt to launch ResInsight using the given port number.
         """
-        if rips is None:
-            raise RuntimeError("rips package is not available")
+        rips = require_rips()
         instance = rips.Instance.launch(
             resinsight_executable=str(executable),
             console=console_mode,
@@ -125,8 +116,7 @@ class RipsApiUtils:
         Note:
             Connection is port-driven.
         """
-        if rips is None:
-            raise RuntimeError("rips package is not available")
+        rips = require_rips()
 
         if port is None:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,12 +59,13 @@ def in_roxar_env():
 
 @functools.lru_cache(maxsize=1)
 def has_rips():
-    """Helper function to check if rips is available"""
+    """Helper function to check if rips is available and meets minimum version."""
     try:
-        import rips  # noqa
+        from xtgeo.interfaces.resinsight._rips_package import require_rips
 
+        require_rips()
         return True
-    except ImportError:
+    except (RuntimeError, ImportError):
         return False
 
 

--- a/tests/test_interfaces/test_resinsight/test_rips_package.py
+++ b/tests/test_interfaces/test_resinsight/test_rips_package.py
@@ -1,0 +1,97 @@
+"""Tests for _rips_package version gating (no ResInsight required).
+
+These tests patch the version metadata and module-level state
+(via ``unittest.mock.patch``) to exercise the error paths in _check_rips_version() and
+require_rips() without needing an actual rips installation or ResInsight executable.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+import pytest
+
+from xtgeo.interfaces.resinsight import _rips_package
+
+
+# Tests for _check_rips_version()
+def test_check_rips_version_missing_metadata_raises():
+    with (
+        patch.object(
+            _rips_package, "version", side_effect=PackageNotFoundError("rips")
+        ),
+        pytest.raises(RuntimeError, match="version metadata is missing"),
+    ):
+        _rips_package._check_rips_version()
+
+
+def test_check_rips_version_invalid_version_string_raises():
+    with (
+        patch.object(_rips_package, "version", return_value="not-a-version!"),
+        pytest.raises(RuntimeError, match="not a valid PEP 440"),
+    ):
+        _rips_package._check_rips_version()
+
+
+def test_check_rips_version_old_version_raises():
+    with (
+        patch.object(_rips_package, "version", return_value="2020.1"),
+        pytest.raises(RuntimeError, match="Please upgrade"),
+    ):
+        _rips_package._check_rips_version()
+
+
+def test_check_rips_version_sufficient_version_passes():
+    with patch.object(
+        _rips_package, "version", return_value=_rips_package.MIN_RIPS_VERSION
+    ):
+        _rips_package._check_rips_version()
+
+
+def test_check_rips_version_newer_version_passes():
+    with patch.object(_rips_package, "version", return_value="9999.1"):
+        _rips_package._check_rips_version()
+
+
+# Tests for require_rips()
+
+
+def test_require_rips_raises_when_rips_is_none():
+    with (
+        patch.object(_rips_package, "rips", None),
+        patch.object(_rips_package, "_rips_import_error", None),
+        pytest.raises(RuntimeError, match="not available"),
+    ):
+        _rips_package.require_rips()
+
+
+def test_require_rips_raises_with_import_error_message():
+    msg = "missing symbols (Case, Instance, Project)"
+    with (
+        patch.object(_rips_package, "rips", None),
+        patch.object(_rips_package, "_rips_import_error", msg),
+        pytest.raises(RuntimeError, match="missing symbols"),
+    ):
+        _rips_package.require_rips()
+
+
+def test_require_rips_delegates_to_version_check():
+    sentinel = object()
+    with (
+        patch.object(_rips_package, "rips", sentinel),
+        patch.object(_rips_package, "version", return_value="2020.1"),
+        pytest.raises(RuntimeError, match="Please upgrade"),
+    ):
+        _rips_package.require_rips()
+
+
+def test_require_rips_passes_when_rips_available_and_version_ok():
+    sentinel = object()
+    with (
+        patch.object(_rips_package, "rips", sentinel),
+        patch.object(
+            _rips_package, "version", return_value=_rips_package.MIN_RIPS_VERSION
+        ),
+    ):
+        _rips_package.require_rips()


### PR DESCRIPTION
Allow specifying minimum RIPS version which support **all** the required API for XTGeo interface. 

For testing, use `unittest.mock.patch` as there is no mechanism to download a specific ResInsight + rips version through Github Action.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
