### PR TITLE
TST: Add ResInsight test to coverage report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
 
   codecov:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
         with:
@@ -181,8 +181,15 @@ jobs:
       - name: Setup testdata
         uses: "./.github/actions/setup_testdata"
 
+      - name: Set up ResInsight
+        id: resinsight
+        uses: './.github/actions/setup_resinsight'
+
       - name: Generate coverage report
-        run: uv run pytest -n 4 tests --doctest-modules --generate-plots --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml;
+        run: |
+          ${{ steps.resinsight.outputs.install-path}}/bin/ResInsight --console --version
+          export RESINSIGHT_EXECUTABLE="${{ steps.resinsight.outputs.install-path}}/bin/ResInsight"
+          uv run pytest -n 4 --dist=loadgroup tests --doctest-modules --generate-plots --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -211,26 +218,3 @@ jobs:
 
       - name: Integration test
         run: HAS_OPM=1 uv run pytest -m requires_opm --disable-warnings
-
-  resinsight-integration:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: "./.github/actions/setup_xtgeo"
-        with:
-          python-version: "3.11"
-
-      - name: Setup testdata
-        uses: "./.github/actions/setup_testdata"
-
-      - name: Set up ResInsight
-        id: resinsight
-        uses: './.github/actions/setup_resinsight'
-
-      - name: ResInsight test
-        run: |
-          ${{ steps.resinsight.outputs.install-path}}/bin/ResInsight --console --version
-          export RESINSIGHT_EXECUTABLE="${{ steps.resinsight.outputs.install-path}}/bin/ResInsight"
-          uv run pytest -m requires_resinsight --disable-warnings

--- a/tests/test_interfaces/test_resinsight/test_grid_public_api.py
+++ b/tests/test_interfaces/test_resinsight/test_grid_public_api.py
@@ -17,7 +17,10 @@ import pytest
 
 import xtgeo
 
-pytestmark = pytest.mark.requires_resinsight
+pytestmark = [
+    pytest.mark.requires_resinsight,
+    pytest.mark.xdist_group(name="resinsight"),
+]  # Avoid running multiple tests in parallel against the same ResInsight instance
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interfaces/test_resinsight/test_resinsight_grid.py
+++ b/tests/test_interfaces/test_resinsight/test_resinsight_grid.py
@@ -148,6 +148,7 @@ def test_roundtrip_hypothesis(grid: xtgeo.Grid):
 
 
 @pytest.mark.requires_resinsight
+@pytest.mark.xdist_group(name="resinsight")
 def test_reader_init(resinsight_instance):
     """Test that GridReader can load grid metadata from ResInsight cases."""
 
@@ -161,6 +162,7 @@ def test_reader_init(resinsight_instance):
 
 
 @pytest.mark.requires_resinsight
+@pytest.mark.xdist_group(name="resinsight")
 def test_reader_select_first_matching_case(resinsight_instance):
     """Test that GridReader selects the first matching case when find_last is False."""
 
@@ -176,6 +178,7 @@ def test_reader_select_first_matching_case(resinsight_instance):
 
 
 @pytest.mark.requires_resinsight
+@pytest.mark.xdist_group(name="resinsight")
 def test_reader_no_matching_case(resinsight_instance):
     """Test that GridReader raises an error when no matching case is found."""
     reader = GridReader(resinsight_instance)
@@ -186,6 +189,7 @@ def test_reader_no_matching_case(resinsight_instance):
 
 
 @pytest.mark.requires_resinsight
+@pytest.mark.xdist_group(name="resinsight")
 def test_writer_roundtrip_new_case(resinsight_instance):
     reader = GridReader(resinsight_instance)
     data = reader.load("EXAMPLE")
@@ -214,6 +218,7 @@ def test_writer_roundtrip_new_case(resinsight_instance):
 
 
 @pytest.mark.requires_resinsight
+@pytest.mark.xdist_group(name="resinsight")
 def test_writer_replace_case(resinsight_instance: RipsInstanceType):
     grid = xtgeo.create_box_grid((2, 2, 2), increment=(2.0, 2.0, 2.0))
 
@@ -265,6 +270,7 @@ def test_writer_replace_case(resinsight_instance: RipsInstanceType):
 
 
 @pytest.mark.requires_resinsight
+@pytest.mark.xdist_group(name="resinsight")
 def test_writer_roundtrip_replace_case(resinsight_instance):
     reader = GridReader(resinsight_instance)
     data = reader.load("EXAMPLE")

--- a/tests/test_interfaces/test_resinsight/test_rips_utils.py
+++ b/tests/test_interfaces/test_resinsight/test_rips_utils.py
@@ -6,7 +6,10 @@ import pytest
 
 from xtgeo.interfaces.resinsight.rips_utils import RipsApiUtils
 
-pytestmark = pytest.mark.requires_resinsight
+pytestmark = [
+    pytest.mark.requires_resinsight,
+    pytest.mark.xdist_group(name="resinsight"),
+]  # Avoid running multiple tests in parallel against the same ResInsight instance
 
 
 def test_init_with_none_auto_discovers(resinsight_instance):


### PR DESCRIPTION
Currently, ResInsight interface tests are not tested in coverage report, causing wrong coverage report.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
