### PR TITLE
Use build.verbose over cmake.verbose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docs = [
 
 [tool.scikit-build]
 cmake.version = "CMakeLists.txt"
-cmake.verbose = true
+build.verbose = true
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["src/xtgeo/common/version.py"]
 wheel.install-dir = "xtgeo"


### PR DESCRIPTION
From scikit-build-core >= 1.0.0, this is required, but has worked since version 0.10.

Resolves build failure after release of scikit-build-core 1.0.0 July 6. 

Briefly describe changes here, e.g. "Added a precise description about the
changes made to the code, and what the PR is solving."

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
