### PR TITLE
ENH: Handle US_SURVE as FEET and issue warning

### DIFF
--- a/src/xtgeo/grid3d/_ecl_grid.py
+++ b/src/xtgeo/grid3d/_ecl_grid.py
@@ -49,6 +49,13 @@ class Units(Enum):
             return cls.FEET
         if match_keyword(unit_string, "CM"):
             return cls.CM
+        if match_keyword(unit_string, "US_SURVE"):
+            warnings.warn(
+                "The provided unit system 'US_SURVE' (US. Survey Foot) is a "
+                "discontinued standard. The international foot definition "
+                "will be used instead."
+            )
+            return cls.FEET
         raise ValueError(f"Unknown unit string {unit_string}")
 
     @classmethod

--- a/tests/test_grid3d/test_grid_ecl_grid.py
+++ b/tests/test_grid3d/test_grid_ecl_grid.py
@@ -47,6 +47,20 @@ def test_unit_conversion_factors():
     assert feet.conversion_factor(feet) == 1.0
 
 
+def test_unit_from_grdecl_us_surve_returns_feet_and_warns():
+    """
+    Tests that FEET is returned and warning is issued when unit system is US_SURVE
+
+    When the discontinued standard 'US_SURVE' is provided as unit string to the method
+    ggrid.Units.from_grdecl(), ggrid.Units.FEET should be returned and warning issued.
+
+    """
+
+    with pytest.warns(match="is a discontinued standard."):
+        unit: ggrid.Units = ggrid.Units.from_grdecl("US_SURVE")
+        assert unit == ggrid.Units.FEET
+
+
 def ecl_grids(*args, **kwargs):
     return st.one_of([grdecl_grids(*args, **kwargs), egrids(*args, **kwargs)])
 


### PR DESCRIPTION
Resolves #1690 

Handle the legacy imperial unit system `US_SURVE` as unit system `FEET` and issue a warning to the user.

Will also add a test, just creating this PR first to let @perolavsvendsen give his feedback on the warning message.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
