### PR TITLE
DEP: Deprecate RegularSurface(masked= ... )

### DIFF
--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -540,7 +540,7 @@ class RegularSurface:
         values: Optional[Union[List[float], float]] = None,
         ilines: Optional[List[float]] = None,
         xlines: Optional[List[float]] = None,
-        masked: Optional[bool] = True,
+        masked: Optional[bool] = None,
         name: Optional[str] = "unknown",
         filesrc: Optional[str] = None,
         fformat: Optional[str] = None,
@@ -568,7 +568,7 @@ class RegularSurface:
             values: A scalar (for constant values) or a "array-like" input that has
                 ncol * nrow elements. As result, a 2D (masked) numpy array of shape
                 (ncol, nrow), C order will be made.
-            masked: Indicating if numpy array shall be masked or not. Default is True.
+            masked: Deprecated and ignored.
             name: A given name for the surface, default is file name root or
                 'unknown' if constructed from scratch.
 
@@ -623,7 +623,15 @@ class RegularSurface:
             self._ilines = ilines
             self._xlines = xlines
 
-        self._masked = masked  # TODO: check usecase
+        if masked is not None:
+            warnings.warn(
+                "The 'masked' parameter is deprecated and will be removed in a "
+                "future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self._masked = True if masked is None else masked
         self._metadata.required = self
 
     def __repr__(self):

--- a/tests/test_surface/test_regular_surface.py
+++ b/tests/test_surface/test_regular_surface.py
@@ -3,6 +3,7 @@
 import logging
 import pathlib
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -36,6 +37,32 @@ FENCE1 = pathlib.Path("polygons/reek/1/fence.pol")
 def test_surface_from_file_missing(tmp_path):
     with pytest.raises(ValueError, match="missing"):
         xtgeo.surface_from_file(tmp_path / "nosuchfile", fformat="irap_binary")
+
+
+def test_masked_constructor_argument_is_deprecated():
+    """
+    Verify that a warning is raised when the deprecated 'masked' argument
+    is used in the RegularSurface constructor.
+    """
+    with pytest.warns(DeprecationWarning, match="'masked' parameter is deprecated"):
+        xtgeo.RegularSurface(
+            ncol=2,
+            nrow=2,
+            xinc=1.0,
+            yinc=1.0,
+            values=1.0,
+            masked=False,
+        )
+
+
+def test_omitted_masked_constructor_argument_does_not_warn():
+    """
+    Verify that a warning is _not_ raised when the deprecated 'masked' argument
+    is _not_ used in the RegularSurface constructor.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        xtgeo.RegularSurface(ncol=2, nrow=2, xinc=1.0, yinc=1.0, values=1.0)
 
 
 @pytest.mark.filterwarnings("ignore:Default values*")


### PR DESCRIPTION
Resolves #1681 

RegularSurface(masked = ...), the masked parameter has no effect and is deprecated.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
