### PR TITLE
ENH: testkomodo should only install dev deps

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -36,7 +36,7 @@ install_and_test () {
 
 install_package () {
     pushd $CI_SOURCE_ROOT
-    pip install ".[dev]"
+    pip install --group dev
     popd
 }
 


### PR DESCRIPTION
Resolves #1702 

Update `testkomodo.sh` to only install dev dependencies before running tests and not reinstall the whole xtgeo package. In this way we let the Komodo env decide which version of xtgeo to test so that we dont get mismatches between the version that is tested and the version that is actually in the Komodo env that is tested.

This change is required to make the xtgeo tests in Komodo testing environment pass. Once merged to main this commit will be cherry picked to a new patch release of xtgeo.

## Checklist

- [ ] Tests added (if not, comment why): Only CI
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
