### PR TITLE
BUG: Add missing conf for depedency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,26 @@ docs = [
     "sphinx-toolbox>=3.5.0",
 ]
 
+[dependency-groups]
+dev = [
+    "clang-format",
+    "cmake-format",
+    "coverage>=4.1",
+    "hypothesis",
+    "mypy",
+    "pandas-stubs",
+    "psutil",
+    "pydocstyle",
+    "pytest",
+    "pytest-benchmark",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-runner",
+    "pytest-snapshot",
+    "pytest-xdist",
+    "ruff",
+]
+
 [tool.scikit-build]
 cmake.version = "CMakeLists.txt"
 build.verbose = true


### PR DESCRIPTION
Resolves #1702 

Add missing config for dependency group in `pyproject.toml`.

This would have failed in `testkomodo.sh`later on without this fix due to the changes made in https://github.com/equinor/xtgeo/commit/67a2a80be5a97fd2a0b489aaf85c36d596f0915d

To be able to run `pip install --group dev` we need a `[dependency-groups]` section in pyproject.toml where the depedencies for group `dev` are added.

## Checklist

- [ ] Tests added (if not, comment why): Only config
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
