### PR TITLE
CI: Cache xtgeo C++ build dependencies Eigen/fmt

### DIFF
--- a/ci/testrmsenv.sh
+++ b/ci/testrmsenv.sh
@@ -29,6 +29,16 @@ copy_test_files () {
 
 install_test_dependencies () {
     echo "Installing test dependencies..."
+
+    # Cache CMake FetchContent deps (Eigen/fmt) per Python version so they are
+    # fetched once instead of re-cloned on every run. Reuse the CI cache dir if
+    # provided, otherwise fall back to a temp location for local runs.
+    local cache_root="${CACHE_DIR:+$HOME/$CACHE_DIR}"
+    cache_root="${cache_root:-${CI_ROOT:-/tmp}/cache}"
+    local py_tag="${PYTHON_VERSION:-$(python -c 'import sys; print(f"py{sys.version_info.major}{sys.version_info.minor}")')}"
+    export SKBUILD_CMAKE_DEFINE="FETCHCONTENT_BASE_DIR=${cache_root}/xtgeo-cmake-deps/${py_tag}"
+    echo "SKBUILD_CMAKE_DEFINE=$SKBUILD_CMAKE_DEFINE"
+
     pip install ".[dev]"
 
     echo "Dependencies installed successfully. Listing installed dependencies..."


### PR DESCRIPTION
Xtgeo's C++ extension downloads Eigen and fmt via CMake FetchContent during the build. With no build cache these were re-fetched on every run, and the Eigen clone from gitlab.com

Point FetchContent at a persistent per-Python-version cache via SKBUILD_CMAKE_DEFINE so the dependencies are fetched once and reused, removing the per-run network hit and the associated flakiness.

Resolves #https://github.com/equinor/xtgeo/issues/1691



## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
