### PR TITLE
TST: Use latest release ResInsight for testing instead of nightly version

### DIFF
--- a/.github/actions/setup_resinsight/action.yml
+++ b/.github/actions/setup_resinsight/action.yml
@@ -14,9 +14,20 @@ runs:
   steps:
     - name: Download ResInsight
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        wget https://nightly.link/OPM/ResInsight/workflows/ResInsightWithCache/dev/ResInsight-Ubuntu%2024.04%20gcc.zip -O /tmp/resinsight.zip
-        unzip /tmp/resinsight.zip -d /tmp/${{ inputs.install-dir }}
+        tmpdir="$(mktemp -d)"
+        gh release download --repo OPM/ResInsight \
+          --pattern 'ResInsight-Ubuntu_24.04_gcc*.zip' \
+          --dir "$tmpdir"
+        set -- "$tmpdir"/ResInsight-Ubuntu_24.04_gcc*.zip
+        [ "$#" -eq 1 ] || { echo "Expected exactly one ResInsight archive, found $# : $*"; exit 1; }
+        unzip "$1" -d "$tmpdir/resinsight_extract"
+        mkdir -p "/tmp/${{ inputs.install-dir }}"
+        # Release archives nest everything under a single top-level directory;
+        # flatten it so bin/Python is directly under the install directory.
+        mv "$tmpdir/resinsight_extract"/*/* "/tmp/${{ inputs.install-dir }}/"
     - name: Extract ResInsight
       id: extract
       shell: bash


### PR DESCRIPTION
Resolves #1712 

Current ResInsight interface testing is using latest (nightly) build of ResInsight. This could create issue with stability.

Since ResInsight 2026.06.01, it includes binary for Ubuntu in the release which should be more stable than its nightly version.


## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
