### PR TITLE
ENH: Return RipsCase for  XTGeo Grid to_resInsight method

### DIFF
--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     from xtgeo.common.types import FileLike
     from xtgeo.interfaces.resinsight._rips_package import (
         ResInsightInstanceOrPortType,
+        RipsCaseType,
     )
     from xtgeo.interfaces.rms._rmsapi_package import RmsProjectOrPathType
     from xtgeo.xyz.points import Points
@@ -1269,7 +1270,7 @@ class Grid(_Grid3D):
         instance_or_port: ResInsightInstanceOrPortType | None,
         gname: str,
         find_last: bool = True,
-    ) -> None:
+    ) -> RipsCaseType:
         """Export this grid as a new corner-point grid in ResInsight.
 
         The case named ``gname`` will be created if it does not already exist,
@@ -1283,6 +1284,9 @@ class Grid(_Grid3D):
                 share the same ``gname``. If ``True`` (default), the last matching
                 case is replaced; if ``False``, the first matching case is replaced.
 
+        Returns:
+            The ResInsight case that was created or replaced.
+
         """
         import xtgeo.interfaces.resinsight
 
@@ -1295,7 +1299,7 @@ class Grid(_Grid3D):
         writer = xtgeo.interfaces.resinsight.GridWriter(
             instance_or_port=instance_or_port
         )
-        writer.save(data, gname, find_last)
+        return writer.save(data, gname, find_last)
 
     def convert_units(self, units: Units) -> None:
         """

--- a/src/xtgeo/interfaces/resinsight/_grid.py
+++ b/src/xtgeo/interfaces/resinsight/_grid.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from xtgeo.grid3d.grid import Grid
 
-    from ._rips_package import ResInsightInstanceOrPortType
+    from ._rips_package import ResInsightInstanceOrPortType, RipsCaseType
 
 logger = null_logger(__name__)
 
@@ -159,7 +159,7 @@ class GridWriter(_BaseResInsightDataRW):
 
     def save(
         self, data: GridDataResInsight, gname: str, find_last: bool = True
-    ) -> None:
+    ) -> RipsCaseType:
         """Save grid to selected ResInsight case.
 
         Args:
@@ -173,6 +173,9 @@ class GridWriter(_BaseResInsightDataRW):
             find_last: Controls which existing case to replace when multiple cases
                 share the same `gname`. If `True` (default), the last matching case is
                 replaced; if `False`, the first matching case is replaced.
+
+        Returns:
+            The ResInsight case that was created or replaced.
 
         Note: If an existing case with the same name is found but is not replaceable
         (e.g. it's loaded from grid file), a warning is logged and a new case with the
@@ -198,7 +201,7 @@ class GridWriter(_BaseResInsightDataRW):
                     )
                     case.file_path = data.filesrc
                     case.update()
-                    return
+                    return case
                 logger.warning(
                     "Existing case named '%s' is of type '%s', which is not "
                     "compatible with grid data. Creating a new case with same name "
@@ -223,6 +226,7 @@ class GridWriter(_BaseResInsightDataRW):
             )
             new_case.file_path = data.filesrc
             new_case.update()
+            return new_case
 
         except Exception as exc:
             raise RuntimeError(f"Failed to save ResInsight case data: {exc}") from exc

--- a/tests/test_interfaces/test_resinsight/test_grid_public_api.py
+++ b/tests/test_interfaces/test_resinsight/test_grid_public_api.py
@@ -78,9 +78,12 @@ def test_grid_from_resinsight_auto_discover(resinsight_instance):
 
 
 def test_to_resinsight_creates_new_case(resinsight_instance):
-    """to_resinsight should create a new case in ResInsight."""
+    """to_resinsight should create a new case in ResInsight and return it."""
     grid = xtgeo.create_box_grid((3, 3, 2), increment=(10.0, 10.0, 5.0))
-    grid.to_resinsight(resinsight_instance, gname="GRID_NEW")
+    case = grid.to_resinsight(resinsight_instance, gname="GRID_NEW")
+
+    assert case is not None, "to_resinsight should return the created case"
+    assert case.name == "GRID_NEW"
 
     reloaded = xtgeo.grid_from_resinsight(resinsight_instance, "GRID_NEW")
     assert reloaded.ncol == grid.ncol
@@ -94,7 +97,10 @@ def test_to_resinsight_replaces_existing_case(resinsight_instance):
     grid_a.to_resinsight(resinsight_instance, gname="GRID_REPLACE")
 
     grid_b = xtgeo.create_box_grid((5, 4, 3))
-    grid_b.to_resinsight(resinsight_instance, gname="GRID_REPLACE")
+    case = grid_b.to_resinsight(resinsight_instance, gname="GRID_REPLACE")
+
+    assert case is not None, "to_resinsight should return the replaced case"
+    assert case.name == "GRID_REPLACE"
 
     reloaded = xtgeo.grid_from_resinsight(resinsight_instance, "GRID_REPLACE")
     assert reloaded.ncol == grid_b.ncol

--- a/tests/test_interfaces/test_resinsight/test_resinsight_grid.py
+++ b/tests/test_interfaces/test_resinsight/test_resinsight_grid.py
@@ -195,7 +195,10 @@ def test_writer_roundtrip_new_case(resinsight_instance):
     data = reader.load("EXAMPLE")
 
     writer = GridWriter(resinsight_instance)
-    writer.save(data, gname="NEW_CASE")
+    case = writer.save(data, gname="NEW_CASE")
+
+    assert case is not None, "save should return the created case"
+    assert case.name == "NEW_CASE"
 
     reloaded_data = reader.load("NEW_CASE")
     assert reloaded_data.name == "NEW_CASE", "Should reload the grid with the new name"
@@ -225,7 +228,10 @@ def test_writer_replace_case(resinsight_instance: RipsInstanceType):
     writer = GridWriter(resinsight_instance)
     data = GridDataResInsight.from_xtgeo_grid(grid, name="TEST_GRID", filesrc="")
 
-    writer.save(data, gname="SIMPLE", find_last=False)
+    case = writer.save(data, gname="SIMPLE", find_last=False)
+
+    assert case is not None, "save should return the created case"
+    assert case.name == "SIMPLE"
 
     reloaded_data = GridReader(resinsight_instance).load("SIMPLE", find_last=False)
     assert reloaded_data.name == "SIMPLE", "Should reload the grid with the new name"
@@ -248,7 +254,10 @@ def test_writer_replace_case(resinsight_instance: RipsInstanceType):
     # Create a new grid with different dimensions and save it with the same case name
     grid2 = xtgeo.create_box_grid((3, 3, 3))
     data2 = GridDataResInsight.from_xtgeo_grid(grid2, name="TEST_GRID_2", filesrc="")
-    writer.save(data2, gname="SIMPLE", find_last=False)
+    case2 = writer.save(data2, gname="SIMPLE", find_last=False)
+
+    assert case2 is not None, "save should return the replaced case"
+    assert case2.name == "SIMPLE"
 
     reloaded_data2 = GridReader(resinsight_instance).load("SIMPLE", find_last=False)
     assert reloaded_data2.name == "SIMPLE", "Should reload the grid with the new name"


### PR DESCRIPTION
Resolves #1714 

Improve XTGeo ResInsight interface for grid.to_resinsight() to return the RipsCaseType instance. This will allow user to process the object in ResInsight using RIPS API.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
