### PR TITLE
fix(xyz): reject points_from_surface zname colliding with X/Y column

### DIFF
--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -74,6 +74,13 @@ def _surface_importer(
     surf: RegularSurface, zname: str = _AttrName.ZNAME.value
 ) -> dict[str, Any]:
     """General function for _read_surface()"""
+    if zname in (_AttrName.XNAME.value, _AttrName.YNAME.value):
+        raise ValueError(
+            f"The zname '{zname}' collides with a coordinate column name; "
+            f"it must differ from '{_AttrName.XNAME.value}' and "
+            f"'{_AttrName.YNAME.value}'."
+        )
+
     val = surf.values
     xc, yc = surf.get_xy_values()
 

--- a/tests/test_xyz/test_points_from_surface.py
+++ b/tests/test_xyz/test_points_from_surface.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pandas as pd
+import pytest
 
 import xtgeo
 
@@ -30,3 +31,13 @@ def test_init_with_surface_classmethod(testdata_path):
 
     poi.zname = "VALUES"
     pd.testing.assert_frame_equal(poi.get_dataframe(), surf.get_dataframe())
+
+
+@pytest.mark.parametrize("zname", ["X_UTME", "Y_UTMN"])
+def test_zname_colliding_with_coordinate_column(zname):
+    """A zname equal to a coordinate column would overwrite those coordinates."""
+    surf = xtgeo.RegularSurface(
+        ncol=4, nrow=5, xori=0, yori=0, xinc=25, yinc=25, values=1234.0
+    )
+    with pytest.raises(ValueError, match="collides with a coordinate column"):
+        xtgeo.points_from_surface(surf, zname=zname)


### PR DESCRIPTION
Resolves #1677

`points_from_surface()` renamed the third column to the caller-supplied `zname` without checking it against the coordinate column names. Passing `zname="X_UTME"` or `"Y_UTMN"` therefore produced a DataFrame where that coordinate column held the surface Z values and the real coordinates were silently lost. The importer now raises `ValueError` for those two names, which is the "error/exception" option listed in the issue.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary (N/A - no user-facing doc change beyond the new error)
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers (N/A - diff is small)
- [ ] Moved issue status on project board (no access)
- [x] Checked the boxes in this checklist
