### PR TITLE
Allow user to specify grid/case object directly when interacting with ResInsight

### DIFF
--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -268,9 +268,9 @@ def grid_from_resinsight(
     if case is None:
         raise TypeError("grid_from_resinsight() missing required argument: 'case'")
 
-    import xtgeo.interfaces.resinsight
+    from xtgeo.interfaces.resinsight._grid import GridReader
 
-    grid_resinsight = xtgeo.interfaces.resinsight.GridReader(
+    grid_resinsight = GridReader(
         instance_or_port=instance_or_port,
     ).load(case=case, find_last=find_last)
     return grid_resinsight.to_xtgeo_grid()
@@ -1326,20 +1326,21 @@ class Grid(_Grid3D):
         if case is None:
             raise TypeError("to_resinsight() missing required argument: 'case'")
 
-        import xtgeo.interfaces.resinsight
+        from xtgeo.interfaces.resinsight._grid import (
+            GridDataResInsight,
+            GridWriter,
+        )
         from xtgeo.interfaces.resinsight._resinsight_base import validate_case
 
         validate_case(case)  # fail fast before extracting grid data
         name = case if isinstance(case, str) else case.name
-        data = xtgeo.interfaces.resinsight.GridDataResInsight.from_xtgeo_grid(
+        data = GridDataResInsight.from_xtgeo_grid(
             self,
             name=name,
             filesrc=str(self.filesrc) if self.filesrc else "",
         )
 
-        writer = xtgeo.interfaces.resinsight.GridWriter(
-            instance_or_port=instance_or_port
-        )
+        writer = GridWriter(instance_or_port=instance_or_port)
         return writer.save(data, case, find_last)
 
     def convert_units(self, units: Units) -> None:

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -225,17 +225,23 @@ def grid_from_roxar(
 
 def grid_from_resinsight(
     instance_or_port: ResInsightInstanceOrPortType | None,
-    case_name: str,
+    case: str | RipsCaseType | None = None,
     find_last: bool = True,
+    *,
+    case_name: str | RipsCaseType | None = None,
 ) -> Grid:
     """Load a corner-point grid from a ResInsight case into an XTGeo ``Grid``.
 
     Args:
         instance_or_port: Optional ``rips.Instance`` or gRPC port. Use ``None``
             to auto-discover a running ResInsight instance.
-        case_name: Name of the ResInsight case to load.
+        case: The name of the ResInsight case to load, or a ``rips`` case object.
+            Since case names are not unique in ResInsight, passing a case object
+            avoids the ambiguity that name-based lookup can introduce.
         find_last: If multiple cases have the same name, select the last match.
-            Set to ``False`` to select the first match instead.
+            Set to ``False`` to select the first match instead. Ignored when
+            *case* is a case object.
+        case_name: Deprecated alias for *case*, kept for backward compatibility.
 
     Returns:
         A populated :class:`xtgeo.Grid`.
@@ -244,15 +250,29 @@ def grid_from_resinsight(
 
         import xtgeo
 
+        # By case name
         grid = xtgeo.grid_from_resinsight(5000, "EXAMPLE")
         print(grid.dimensions)
 
+        # By case object
+        case = instance.project.cases()[0]
+        grid = xtgeo.grid_from_resinsight(instance, case)
+
     """
+    if case_name is not None:
+        from xtgeo.interfaces.resinsight._deprecation import resolve_deprecated_alias
+
+        case = resolve_deprecated_alias(
+            case, case_name, new_name="case", old_name="case_name"
+        )
+    if case is None:
+        raise TypeError("grid_from_resinsight() missing required argument: 'case'")
+
     import xtgeo.interfaces.resinsight
 
     grid_resinsight = xtgeo.interfaces.resinsight.GridReader(
         instance_or_port=instance_or_port,
-    ).load(case_name=case_name, find_last=find_last)
+    ).load(case=case, find_last=find_last)
     return grid_resinsight.to_xtgeo_grid()
 
 
@@ -1268,38 +1288,59 @@ class Grid(_Grid3D):
     def to_resinsight(
         self,
         instance_or_port: ResInsightInstanceOrPortType | None,
-        gname: str,
+        case: str | RipsCaseType | None = None,
         find_last: bool = True,
+        *,
+        gname: str | RipsCaseType | None = None,
     ) -> RipsCaseType:
         """Export this grid as a new corner-point grid in ResInsight.
 
-        The case named ``gname`` will be created if it does not already exist,
-        or an existing case with that name will be replaced.
+        The case named ``case`` will be created if it does not already exist,
+        or an existing case will be replaced.
 
         Args:
             instance_or_port: Optional ``rips.Instance`` or gRPC port. Use
                 ``None`` to auto-discover a running ResInsight instance.
-            gname: Name of the ResInsight case to create or replace.
+            case: Name of the ResInsight case to create or replace, or a ``rips``
+                case object to replace directly. Passing a case object avoids the
+                ambiguity that name-based lookup can introduce, since case names
+                are not unique in ResInsight.
             find_last: Controls which existing case to replace when multiple cases
-                share the same ``gname``. If ``True`` (default), the last matching
+                share the same name. If ``True`` (default), the last matching
                 case is replaced; if ``False``, the first matching case is replaced.
+                Ignored when *case* is a case object.
+            gname: Deprecated alias for *case*, kept for backward compatibility.
 
         Returns:
             The ResInsight case that was created or replaced.
 
         """
-        import xtgeo.interfaces.resinsight
+        if gname is not None:
+            from xtgeo.interfaces.resinsight._deprecation import (
+                resolve_deprecated_alias,
+            )
 
+            case = resolve_deprecated_alias(
+                case, gname, new_name="case", old_name="gname"
+            )
+        if case is None:
+            raise TypeError("to_resinsight() missing required argument: 'case'")
+
+        import xtgeo.interfaces.resinsight
+        from xtgeo.interfaces.resinsight._resinsight_base import validate_case
+
+        validate_case(case)  # fail fast before extracting grid data
+        name = case if isinstance(case, str) else case.name
         data = xtgeo.interfaces.resinsight.GridDataResInsight.from_xtgeo_grid(
             self,
-            name=gname,
+            name=name,
             filesrc=str(self.filesrc) if self.filesrc else "",
         )
 
         writer = xtgeo.interfaces.resinsight.GridWriter(
             instance_or_port=instance_or_port
         )
-        return writer.save(data, gname, find_last)
+        return writer.save(data, case, find_last)
 
     def convert_units(self, units: Units) -> None:
         """

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -262,13 +262,12 @@ def gridproperty_from_resinsight(
         )
     if property_name is _REQUIRED:
         raise TypeError(
-            "gridproperty_from_resinsight() missing required argument: "
-            "'property_name'"
+            "gridproperty_from_resinsight() missing required argument: 'property_name'"
         )
 
-    import xtgeo.interfaces.resinsight
+    from xtgeo.interfaces.resinsight._grid_property import GridPropertyReader
 
-    data = xtgeo.interfaces.resinsight.GridPropertyReader(
+    data = GridPropertyReader(
         instance_or_port=instance_or_port,
     ).load(
         case=case,
@@ -1091,7 +1090,10 @@ class GridProperty(_Grid3D):
         if case is None:
             raise TypeError("to_resinsight() missing required argument: 'case'")
 
-        import xtgeo.interfaces.resinsight as resinsight_interface
+        from xtgeo.interfaces.resinsight._grid_property import (
+            GridPropertyDataResInsight,
+            GridPropertyWriter,
+        )
         from xtgeo.interfaces.resinsight._resinsight_base import validate_case
 
         validate_case(case)  # fail fast before extracting property data
@@ -1099,7 +1101,7 @@ class GridProperty(_Grid3D):
         if pname is None:
             raise ValueError("property_name must be given (GridProperty.name is None)")
 
-        data = resinsight_interface.GridPropertyDataResInsight.from_xtgeo_gridproperty(
+        data = GridPropertyDataResInsight.from_xtgeo_gridproperty(
             self,
             property_type=property_type,
             time_step_index=time_step_index,
@@ -1110,9 +1112,7 @@ class GridProperty(_Grid3D):
 
             data = replace(data, name=pname)
 
-        writer = resinsight_interface.GridPropertyWriter(
-            instance_or_port=instance_or_port
-        )
+        writer = GridPropertyWriter(instance_or_port=instance_or_port)
         writer.save(data, case, find_last)
 
     # ==================================================================================

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -36,6 +36,8 @@ from ._gridprop_import_xtgcpprop import import_xtgcpprop
 xtg = XTGeoDialog()
 logger = null_logger(__name__)
 
+_REQUIRED: Any = object()
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Union
@@ -47,6 +49,7 @@ if TYPE_CHECKING:
     from xtgeo.interfaces.resinsight._rips_package import (
         PropertyType,
         ResInsightInstanceOrPortType,
+        RipsCaseType,
     )
     from xtgeo.xyz.polygons import Polygons
 
@@ -201,18 +204,22 @@ def gridproperty_from_roxar(
 
 def gridproperty_from_resinsight(
     instance_or_port: ResInsightInstanceOrPortType | None,
-    case_name: str,
-    property_name: str,
+    case: str | RipsCaseType | None = None,
+    property_name: str = _REQUIRED,
     property_type: str | PropertyType = "STATIC_NATIVE",
     time_step_index: int = 0,
     find_last: bool = True,
+    *,
+    case_name: str | RipsCaseType | None = None,
 ) -> GridProperty:
     """Load a grid property from a ResInsight case into an XTGeo ``GridProperty``.
 
     Args:
         instance_or_port: Optional ``rips.Instance`` or gRPC port. Use ``None``
             to auto-discover a running ResInsight instance.
-        case_name: Name of the ResInsight case.
+        case: The name of the ResInsight case, or a ``rips`` case object.
+            Since case names are not unique in ResInsight, passing a case object
+            avoids the ambiguity that name-based lookup can introduce.
         property_name: Name of the property (e.g. ``"PORO"``, ``"PRESSURE"``).
         property_type: A :class:`~xtgeo.interfaces.resinsight.PropertyType`
             member or a plain string such as ``"STATIC_NATIVE"``,
@@ -220,6 +227,8 @@ def gridproperty_from_resinsight(
             Strings are validated and coerced to the enum internally.
         time_step_index: Time step index (default 0).
         find_last: If multiple cases share the same name, select the last match.
+            Ignored when *case* is a case object.
+        case_name: Deprecated alias for *case*, kept for backward compatibility.
 
     Returns:
         A populated :class:`xtgeo.GridProperty`.
@@ -241,12 +250,28 @@ def gridproperty_from_resinsight(
         print(poro.values.mean())
 
     """
+    if case_name is not None:
+        from xtgeo.interfaces.resinsight._deprecation import resolve_deprecated_alias
+
+        case = resolve_deprecated_alias(
+            case, case_name, new_name="case", old_name="case_name"
+        )
+    if case is None:
+        raise TypeError(
+            "gridproperty_from_resinsight() missing required argument: 'case'"
+        )
+    if property_name is _REQUIRED:
+        raise TypeError(
+            "gridproperty_from_resinsight() missing required argument: "
+            "'property_name'"
+        )
+
     import xtgeo.interfaces.resinsight
 
     data = xtgeo.interfaces.resinsight.GridPropertyReader(
         instance_or_port=instance_or_port,
     ).load(
-        case_name=case_name,
+        case=case,
         property_name=property_name,
         property_type=property_type,
         time_step_index=time_step_index,
@@ -1010,18 +1035,23 @@ class GridProperty(_Grid3D):
     def to_resinsight(
         self,
         instance_or_port: ResInsightInstanceOrPortType | None,
-        case_name: str,
+        case: str | RipsCaseType | None = None,
         property_type: str | PropertyType = "GENERATED",
         property_name: str | None = None,
         time_step_index: int = 0,
         find_last: bool = True,
+        *,
+        case_name: str | RipsCaseType | None = None,
     ) -> None:
         """Export this grid property to a ResInsight case.
 
         Args:
             instance_or_port: Optional ``rips.Instance`` or gRPC port. Use
                 ``None`` to auto-discover a running ResInsight instance.
-            case_name: Name of the target ResInsight case.
+            case: Name of the target ResInsight case, or a ``rips`` case
+                object. Since case names are not unique in ResInsight, passing a
+                case object avoids the ambiguity that name-based lookup can
+                introduce.
             property_type: A
                 :class:`~xtgeo.interfaces.resinsight.PropertyType`
                 member or a plain string such as ``"GENERATED"``.
@@ -1031,7 +1061,10 @@ class GridProperty(_Grid3D):
             time_step_index: Time step index (default 0).
             find_last: Controls which case to target when multiple cases share
                 the same name. If ``True`` (default), the last matching case is
-                used; if ``False``, the first.
+                used; if ``False``, the first. Ignored when *case* is a case
+                object.
+            case_name: Deprecated alias for *case*, kept for backward
+                compatibility.
 
         Raises:
             RuntimeError: If rips is unavailable/too old, or if the
@@ -1047,8 +1080,21 @@ class GridProperty(_Grid3D):
             poro.to_resinsight(5000, "MY_CASE", property_name="PORO_MODIFIED")
 
         """
-        import xtgeo.interfaces.resinsight as resinsight_interface
+        if case_name is not None:
+            from xtgeo.interfaces.resinsight._deprecation import (
+                resolve_deprecated_alias,
+            )
 
+            case = resolve_deprecated_alias(
+                case, case_name, new_name="case", old_name="case_name"
+            )
+        if case is None:
+            raise TypeError("to_resinsight() missing required argument: 'case'")
+
+        import xtgeo.interfaces.resinsight as resinsight_interface
+        from xtgeo.interfaces.resinsight._resinsight_base import validate_case
+
+        validate_case(case)  # fail fast before extracting property data
         pname = property_name if property_name is not None else self.name
         if pname is None:
             raise ValueError("property_name must be given (GridProperty.name is None)")
@@ -1067,7 +1113,7 @@ class GridProperty(_Grid3D):
         writer = resinsight_interface.GridPropertyWriter(
             instance_or_port=instance_or_port
         )
-        writer.save(data, case_name, find_last)
+        writer.save(data, case, find_last)
 
     # ==================================================================================
     # Various public methods

--- a/src/xtgeo/interfaces/resinsight/__init__.py
+++ b/src/xtgeo/interfaces/resinsight/__init__.py
@@ -1,21 +1,9 @@
 """XTGeo interface.resinsight package."""
 
-from ._grid import GridDataResInsight, GridReader, GridWriter
-from ._grid_property import (
-    GridPropertyDataResInsight,
-    GridPropertyReader,
-    GridPropertyWriter,
-)
 from ._rips_package import PropertyDataType, PropertyType, rips
 from .rips_utils import RipsApiUtils
 
 __all__ = [
-    "GridDataResInsight",
-    "GridPropertyDataResInsight",
-    "GridPropertyReader",
-    "GridPropertyWriter",
-    "GridReader",
-    "GridWriter",
     "PropertyDataType",
     "PropertyType",
     "RipsApiUtils",

--- a/src/xtgeo/interfaces/resinsight/_deprecation.py
+++ b/src/xtgeo/interfaces/resinsight/_deprecation.py
@@ -1,0 +1,47 @@
+"""Helpers for handling deprecated (renamed) arguments in the ResInsight API."""
+
+from __future__ import annotations
+
+import warnings
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def resolve_deprecated_alias(
+    new_value: T | None,
+    old_value: T | None,
+    *,
+    new_name: str,
+    old_name: str,
+    stacklevel: int = 3,
+) -> T | None:
+    """Return the effective value for an argument that was renamed.
+
+    ``None`` marks "not provided" (the ResInsight case/property arguments are
+    never legitimately ``None``). Emits a :class:`DeprecationWarning` when the
+    deprecated (old) name is used, and raises :class:`TypeError` if both names
+    are supplied at once.
+
+    Args:
+        new_value: Value passed via the current argument name (or ``None``).
+        old_value: Value passed via the deprecated argument name (or ``None``).
+        new_name: The current argument name (used in messages).
+        old_name: The deprecated argument name (used in messages).
+        stacklevel: Stack level forwarded to :func:`warnings.warn` so the warning
+            points at the caller of the public function (default 3).
+    """
+    if old_value is not None:
+        if new_value is not None:
+            raise TypeError(
+                f"Got values for both '{new_name}' and its deprecated alias "
+                f"'{old_name}'; please pass only '{new_name}'."
+            )
+        warnings.warn(
+            f"The '{old_name}' argument is deprecated and will be removed in a "
+            f"future version; use '{new_name}' instead.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+        return old_value
+    return new_value

--- a/src/xtgeo/interfaces/resinsight/_grid.py
+++ b/src/xtgeo/interfaces/resinsight/_grid.py
@@ -129,11 +129,20 @@ class GridReader(_BaseResInsightDataRW):
     ) -> None:
         super().__init__(instance_or_port)
 
-    def load(self, case_name: str, find_last: bool = True) -> GridDataResInsight:
-        """Load metadata from selected ResInsight case."""
-        case = self.get_case(case_name=case_name, find_last=find_last)
-        if case is None:
-            raise RuntimeError(f"Cannot find any case with name '{case_name}'")
+    def load(
+        self, case: str | RipsCaseType, find_last: bool = True
+    ) -> GridDataResInsight:
+        """Load metadata from selected ResInsight case.
+
+        Args:
+            case: A ``rips`` case object, or the name of the case to look up.
+            find_last: When *case* is a name shared by several cases, select the
+                last match if ``True`` (default), otherwise the first.
+        """
+        resolved = self.resolve_case(case, find_last=find_last)
+        if resolved is None:
+            raise RuntimeError(f"Cannot find any case with name '{case}'")
+        case = resolved
 
         zcorn, coord, actnum, nx, ny, nz = case.export_corner_point_grid()  # type: ignore[attr-defined]
         return GridDataResInsight(
@@ -158,20 +167,24 @@ class GridWriter(_BaseResInsightDataRW):
         super().__init__(instance_or_port)
 
     def save(
-        self, data: GridDataResInsight, gname: str, find_last: bool = True
+        self,
+        data: GridDataResInsight,
+        case: str | RipsCaseType,
+        find_last: bool = True,
     ) -> RipsCaseType:
         """Save grid to selected ResInsight case.
 
         Args:
             data: The grid metadata to save.
-            gname: The name of the case to create or replace in ResInsight.
+            case: A ``rips`` case object to replace, or the name of the case to
+                create or replace in ResInsight.
                 If a case with the same name already exists, it will be replaced with
                 the new grid data.
                 If multiple cases share the same name, the one to replace is determined
                 by the `find_last` parameter.
 
             find_last: Controls which existing case to replace when multiple cases
-                share the same `gname`. If `True` (default), the last matching case is
+                share the same `case`. If `True` (default), the last matching case is
                 replaced; if `False`, the first matching case is replaced.
 
         Returns:
@@ -181,17 +194,18 @@ class GridWriter(_BaseResInsightDataRW):
         (e.g. it's loaded from grid file), a warning is logged and a new case with the
         same name is created instead of replacing the existing one.
         """
+        resolved = self.resolve_case(case, find_last=find_last)
+        case_name = case if isinstance(case, str) else case.name
         try:
-            case = self.get_case(case_name=gname, find_last=find_last)
-            if case:
-                grid_type = type(case).__name__.split(".")[-1]
+            if resolved:
+                grid_type = type(resolved).__name__.split(".")[-1]
                 if grid_type == "CornerPointCase":
                     logger.debug(
                         "Found existing case named '%s'. Replacing its grid data.",
-                        gname,
+                        case_name,
                     )
                     # Replace existing case
-                    case.replace_corner_point_grid(  # type: ignore[attr-defined]
+                    resolved.replace_corner_point_grid(  # type: ignore[attr-defined]
                         data.nx,
                         data.ny,
                         data.nz,
@@ -199,24 +213,25 @@ class GridWriter(_BaseResInsightDataRW):
                         data.zcornsv,
                         data.actnumsv,
                     )
-                    case.file_path = data.filesrc
-                    case.update()
-                    return case
+                    resolved.file_path = data.filesrc
+                    resolved.update()
+                    return resolved
                 logger.warning(
                     "Existing case named '%s' is of type '%s', which is not "
                     "compatible with grid data. Creating a new case with same name "
                     "instead.",
-                    gname,
+                    case_name,
                     grid_type,
                 )
             else:
                 logger.debug(
-                    "No existing case named '%s' found. Creating a new case.", gname
+                    "No existing case named '%s' found. Creating a new case.",
+                    case_name,
                 )
 
             # Create a new case
             new_case = self.get_project().create_corner_point_grid(  # type: ignore[attr-defined]
-                name=gname,
+                name=case_name,
                 nx=data.nx,
                 ny=data.ny,
                 nz=data.nz,

--- a/src/xtgeo/interfaces/resinsight/_grid_property.py
+++ b/src/xtgeo/interfaces/resinsight/_grid_property.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from xtgeo.grid3d.grid import Grid
     from xtgeo.grid3d.grid_property import GridProperty
 
-    from ._rips_package import ResInsightInstanceOrPortType
+    from ._rips_package import ResInsightInstanceOrPortType, RipsCaseType
 
 logger = null_logger(__name__)
 
@@ -206,18 +206,28 @@ class GridPropertyReader(_BaseResInsightDataRW):
 
     def load(
         self,
-        case_name: str,
+        case: str | RipsCaseType,
         property_name: str,
         property_type: str | PropertyType = "STATIC_NATIVE",
         time_step_index: int = 0,
         find_last: bool = True,
     ) -> GridPropertyDataResInsight:
-        """Load a grid property from selected ResInsight case."""
+        """Load a grid property from selected ResInsight case.
+
+        Args:
+            case: A ``rips`` case object, or the name of the case to look up.
+            property_name: Name of the property to read.
+            property_type: The ResInsight property type (or a plain string).
+            time_step_index: Time step index (default 0).
+            find_last: When *case* is a name shared by several cases, select the
+                last match if ``True`` (default), otherwise the first.
+        """
         validated_type = _validate_property_type(property_type)
 
-        case = self.get_case(case_name=case_name, find_last=find_last)
-        if case is None:
-            raise RuntimeError(f"Cannot find any case with name '{case_name}'")
+        resolved = self.resolve_case(case, find_last=find_last)
+        if resolved is None:
+            raise RuntimeError(f"Cannot find any case with name '{case}'")
+        case = resolved
 
         dims = case.grids()[0].dimensions()  # type: ignore[attr-defined]
         nx, ny, nz = dims.i, dims.j, dims.k
@@ -283,22 +293,30 @@ class GridPropertyWriter(_BaseResInsightDataRW):
     def save(
         self,
         data: GridPropertyDataResInsight,
-        case_name: str,
+        case: str | RipsCaseType,
         find_last: bool = True,
     ) -> None:
-        """Save a grid property into selected ResInsight case."""
-        case = self.get_case(case_name=case_name, find_last=find_last)
-        if case is None:
+        """Save a grid property into selected ResInsight case.
+
+        Args:
+            data: The grid property data to save.
+            case: A ``rips`` case object, or the name of the case to look up.
+            find_last: When *case* is a name shared by several cases, select the
+                last match if ``True`` (default), otherwise the first.
+        """
+        resolved = self.resolve_case(case, find_last=find_last)
+        if resolved is None:
             raise RuntimeError(
-                f"Cannot find any case with name '{case_name}' for property export"
+                f"Cannot find any case with name '{case}' for property export"
             )
+        case = resolved
 
         # Validate grid dimensions before writing.
         dims = case.grids()[0].dimensions()  # type: ignore[attr-defined]
         if (data.nx, data.ny, data.nz) != (dims.i, dims.j, dims.k):
             raise ValueError(
                 f"Property '{data.name}' has dimensions "
-                f"{data.nx}x{data.ny}x{data.nz}, but case '{case_name}' grid "
+                f"{data.nx}x{data.ny}x{data.nz}, but case '{case.name}' grid "
                 f"has {dims.i}x{dims.j}x{dims.k}"
             )
 
@@ -329,11 +347,11 @@ class GridPropertyWriter(_BaseResInsightDataRW):
                 data.name,
                 validated_type,
                 data.time_step_index,
-                case_name,
+                case.name,
             )
 
         except Exception as exc:
             raise RuntimeError(
                 f"Failed to save property '{data.name}' to ResInsight case "
-                f"'{case_name}': {exc}"
+                f"'{case.name}': {exc}"
             ) from exc

--- a/src/xtgeo/interfaces/resinsight/_resinsight_base.py
+++ b/src/xtgeo/interfaces/resinsight/_resinsight_base.py
@@ -19,6 +19,30 @@ if TYPE_CHECKING:
 logger = null_logger(__name__)
 
 
+def validate_case(case: str | RipsCaseType) -> None:
+    """Validate a case argument, raising :class:`TypeError` if it is invalid.
+
+    A valid case is either a case name (``str``) or a ``rips`` Case object
+    exposing a string ``name`` attribute. This is a cheap, dependency-free guard
+    so callers can fail fast before doing expensive work (e.g. extracting grid
+    data) or before creating a case with an empty name.
+
+    Args:
+        case: A case name (str) or a ``rips`` Case object.
+
+    Raises:
+        TypeError: If *case* is neither a string nor an object exposing a string
+            ``name`` attribute.
+    """
+    if isinstance(case, str):
+        return
+    if not isinstance(getattr(case, "name", None), str):
+        raise TypeError(
+            "case must be a case name (str) or a rips Case object with a "
+            f"'name' attribute, but got {type(case).__name__}"
+        )
+
+
 class _BaseResInsightDataRW:
     """Common init and lookup utilities for ResInsight read/write operations."""
 
@@ -41,6 +65,26 @@ class _BaseResInsightDataRW:
     def get_project(self) -> RipsProjectType:
         """Get the active ResInsight project."""
         return self.get_ripsapi_utils().project
+
+    def resolve_case(
+        self, case: str | RipsCaseType, find_last: bool = True
+    ) -> RipsCaseType | None:
+        """Resolve a target case from either a case object or a case name.
+
+        Args:
+            case: Either a ``rips`` case object (returned as-is) or the case name
+                to look up in the project (see :meth:`get_case`).
+            find_last: When *case* is a name and several cases share it, select the
+                last match if ``True`` (default), otherwise the first.
+
+        Raises:
+            TypeError: If *case* is neither a string nor a rips Case object
+                exposing a string ``name`` attribute.
+        """
+        if isinstance(case, str):
+            return self.get_case(case_name=case, find_last=find_last)
+        validate_case(case)
+        return case
 
     def get_case(self, case_name: str, find_last: bool = True) -> RipsCaseType | None:
         """Resolve target case from project by its name.

--- a/tests/test_interfaces/test_resinsight/test_grid_public_api.py
+++ b/tests/test_interfaces/test_resinsight/test_grid_public_api.py
@@ -72,6 +72,22 @@ def test_grid_from_resinsight_auto_discover(resinsight_instance):
     assert grid.nlay == 3
 
 
+def test_grid_from_resinsight_case_object(resinsight_instance):
+    """A rips case object can be passed directly instead of a case name.
+
+    This disambiguates the two cases both named "EXAMPLE": here we explicitly
+    pick the first one (the Drogon grid, 92 x 146 x 67).
+    """
+    cases = [c for c in resinsight_instance.project.cases() if c.name == "EXAMPLE"]
+    assert len(cases) >= 2, "conftest should load two cases named EXAMPLE"
+
+    grid = xtgeo.grid_from_resinsight(resinsight_instance, cases[0])
+    assert isinstance(grid, xtgeo.Grid)
+    assert grid.ncol == 92
+    assert grid.nrow == 146
+    assert grid.nlay == 67
+
+
 # ---------------------------------------------------------------------------
 # Grid.to_resinsight
 # ---------------------------------------------------------------------------
@@ -80,7 +96,7 @@ def test_grid_from_resinsight_auto_discover(resinsight_instance):
 def test_to_resinsight_creates_new_case(resinsight_instance):
     """to_resinsight should create a new case in ResInsight and return it."""
     grid = xtgeo.create_box_grid((3, 3, 2), increment=(10.0, 10.0, 5.0))
-    case = grid.to_resinsight(resinsight_instance, gname="GRID_NEW")
+    case = grid.to_resinsight(resinsight_instance, case="GRID_NEW")
 
     assert case is not None, "to_resinsight should return the created case"
     assert case.name == "GRID_NEW"
@@ -94,15 +110,32 @@ def test_to_resinsight_creates_new_case(resinsight_instance):
 def test_to_resinsight_replaces_existing_case(resinsight_instance):
     """to_resinsight should replace an existing case when called with the same name."""
     grid_a = xtgeo.create_box_grid((2, 2, 2))
-    grid_a.to_resinsight(resinsight_instance, gname="GRID_REPLACE")
+    grid_a.to_resinsight(resinsight_instance, case="GRID_REPLACE")
 
     grid_b = xtgeo.create_box_grid((5, 4, 3))
-    case = grid_b.to_resinsight(resinsight_instance, gname="GRID_REPLACE")
+    case = grid_b.to_resinsight(resinsight_instance, case="GRID_REPLACE")
 
     assert case is not None, "to_resinsight should return the replaced case"
     assert case.name == "GRID_REPLACE"
 
     reloaded = xtgeo.grid_from_resinsight(resinsight_instance, "GRID_REPLACE")
+    assert reloaded.ncol == grid_b.ncol
+    assert reloaded.nrow == grid_b.nrow
+    assert reloaded.nlay == grid_b.nlay
+
+
+def test_to_resinsight_replaces_case_object(resinsight_instance):
+    """to_resinsight should replace a case given directly as a rips case object."""
+    grid_a = xtgeo.create_box_grid((2, 2, 2))
+    case = grid_a.to_resinsight(resinsight_instance, case="GRID_OBJ_REPLACE")
+
+    grid_b = xtgeo.create_box_grid((6, 5, 4))
+    replaced = grid_b.to_resinsight(resinsight_instance, case=case)
+
+    assert replaced is not None
+    assert replaced.name == "GRID_OBJ_REPLACE"
+
+    reloaded = xtgeo.grid_from_resinsight(resinsight_instance, replaced)
     assert reloaded.ncol == grid_b.ncol
     assert reloaded.nrow == grid_b.nrow
     assert reloaded.nlay == grid_b.nlay
@@ -117,7 +150,7 @@ def test_roundtrip_from_resinsight_to_resinsight(resinsight_instance):
     """A grid read from ResInsight should survive a write → read roundtrip unchanged."""
     original = xtgeo.grid_from_resinsight(resinsight_instance, "EXAMPLE")
 
-    original.to_resinsight(resinsight_instance, gname="GRID_ROUNDTRIP")
+    original.to_resinsight(resinsight_instance, case="GRID_ROUNDTRIP")
 
     reloaded = xtgeo.grid_from_resinsight(resinsight_instance, "GRID_ROUNDTRIP")
 
@@ -133,7 +166,7 @@ def test_roundtrip_box_grid(resinsight_instance):
     """A synthetic box grid should round-trip through ResInsight without loss."""
     original = xtgeo.create_box_grid((4, 3, 2), increment=(5.0, 5.0, 2.0))
 
-    original.to_resinsight(resinsight_instance, gname="GRID_BOX_ROUNDTRIP")
+    original.to_resinsight(resinsight_instance, case="GRID_BOX_ROUNDTRIP")
 
     reloaded = xtgeo.grid_from_resinsight(resinsight_instance, "GRID_BOX_ROUNDTRIP")
 
@@ -143,3 +176,27 @@ def test_roundtrip_box_grid(resinsight_instance):
     assert np.array_equal(reloaded.get_actnum().values, original.get_actnum().values), (
         "Active cell mask should be identical after roundtrip"
     )
+
+
+# ---------------------------------------------------------------------------
+# Deprecated argument aliases (backward compatibility)
+# ---------------------------------------------------------------------------
+
+
+def test_grid_from_resinsight_case_name_alias_deprecated(resinsight_instance):
+    """The deprecated 'case_name' alias still works but emits a warning."""
+    with pytest.warns(DeprecationWarning, match="case_name"):
+        grid = xtgeo.grid_from_resinsight(resinsight_instance, case_name="EXAMPLE")
+    assert isinstance(grid, xtgeo.Grid)
+
+    # Passing both the new name and the deprecated alias is an error.
+    with pytest.raises(TypeError, match="only 'case'"):
+        xtgeo.grid_from_resinsight(resinsight_instance, "EXAMPLE", case_name="EXAMPLE")
+
+
+def test_to_resinsight_gname_alias_deprecated(resinsight_instance):
+    """The deprecated 'gname' alias for Grid.to_resinsight still works but warns."""
+    grid = xtgeo.create_box_grid((2, 2, 2))
+    with pytest.warns(DeprecationWarning, match="gname"):
+        case = grid.to_resinsight(resinsight_instance, gname="GRID_GNAME_ALIAS")
+    assert case.name == "GRID_GNAME_ALIAS"

--- a/tests/test_interfaces/test_resinsight/test_gridprop_data.py
+++ b/tests/test_interfaces/test_resinsight/test_gridprop_data.py
@@ -247,7 +247,7 @@ def test_writer_rejects_dimension_mismatch(resinsight_instance):
     )
     writer = GridPropertyWriter(instance_or_port=resinsight_instance)
     with pytest.raises(ValueError, match="dimensions"):
-        writer.save(data, case_name="EXAMPLE")
+        writer.save(data, case="EXAMPLE")
 
 
 def test_writer_rejects_nonexistent_case(resinsight_instance):
@@ -255,4 +255,4 @@ def test_writer_rejects_nonexistent_case(resinsight_instance):
     data = _make_data()
     writer = GridPropertyWriter(instance_or_port=resinsight_instance)
     with pytest.raises(RuntimeError, match="Cannot find any case with name"):
-        writer.save(data, case_name="NONEXISTENT_CASE")
+        writer.save(data, case="NONEXISTENT_CASE")

--- a/tests/test_interfaces/test_resinsight/test_gridprop_public_api.py
+++ b/tests/test_interfaces/test_resinsight/test_gridprop_public_api.py
@@ -83,6 +83,18 @@ def test_gridproperty_from_resinsight_no_case_raises(resinsight_instance):
         )
 
 
+def test_gridproperty_from_resinsight_case_object(resinsight_instance):
+    """A rips case object can be passed directly instead of a case name."""
+    _write_generated_property(resinsight_instance)
+    # _write_generated_property targets the last matching "EXAMPLE" case.
+    case = [c for c in resinsight_instance.project.cases() if c.name == "EXAMPLE"][-1]
+    prop = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance, case, "SYNTH_PORO", property_type="GENERATED"
+    )
+    assert isinstance(prop, xtgeo.GridProperty)
+    assert prop.name == "SYNTH_PORO"
+
+
 # ---------------------------------------------------------------------------
 # GridProperty.to_resinsight
 # ---------------------------------------------------------------------------
@@ -97,7 +109,7 @@ def test_to_resinsight_continuous(resinsight_instance):
 
     original.to_resinsight(
         resinsight_instance,
-        case_name="EXAMPLE",
+        case="EXAMPLE",
         property_name="SYNTH_PORO_COPY",
         property_type="GENERATED",
     )
@@ -106,6 +118,35 @@ def test_to_resinsight_continuous(resinsight_instance):
         resinsight_instance,
         "EXAMPLE",
         "SYNTH_PORO_COPY",
+        property_type="GENERATED",
+    )
+
+    assert_allclose(
+        original.values.compressed(), reloaded.values.compressed(), atol=1e-6
+    )
+
+
+def test_to_resinsight_case_object(resinsight_instance):
+    """A rips case object can be passed directly to the write path."""
+    _write_generated_property(resinsight_instance)
+    original = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance, "EXAMPLE", "SYNTH_PORO", property_type="GENERATED"
+    )
+
+    # Pick the last matching "EXAMPLE" case,
+    # which is the one _write_generated_property wrote to.
+    case = [c for c in resinsight_instance.project.cases() if c.name == "EXAMPLE"][-1]
+    original.to_resinsight(
+        resinsight_instance,
+        case=case,
+        property_name="SYNTH_PORO_CASE_OBJ",
+        property_type="GENERATED",
+    )
+
+    reloaded = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance,
+        case,
+        "SYNTH_PORO_CASE_OBJ",
         property_type="GENERATED",
     )
 
@@ -150,7 +191,7 @@ def test_to_resinsight_discrete(resinsight_instance):
 
     region_prop.to_resinsight(
         resinsight_instance,
-        case_name="EXAMPLE",
+        case="EXAMPLE",
         property_type="GENERATED",
     )
 
@@ -172,12 +213,12 @@ def test_to_resinsight_discrete(resinsight_instance):
 def test_roundtrip_box_grid_property(resinsight_instance):
     """A synthetic box grid + property should roundtrip through ResInsight."""
     grid = xtgeo.create_box_grid((4, 3, 2), increment=(5.0, 5.0, 2.0))
-    grid.to_resinsight(resinsight_instance, gname="PROP_TEST_GRID")
+    grid.to_resinsight(resinsight_instance, case="PROP_TEST_GRID")
 
     prop = xtgeo.GridProperty(grid, name="SYNTH", values=0.42, discrete=False)
     prop.to_resinsight(
         resinsight_instance,
-        case_name="PROP_TEST_GRID",
+        case="PROP_TEST_GRID",
         property_name="SYNTH",
         property_type="GENERATED",
     )
@@ -192,3 +233,24 @@ def test_roundtrip_box_grid_property(resinsight_instance):
     assert reloaded.nrow == 3
     assert reloaded.nlay == 2
     assert_allclose(reloaded.values.compressed(), 0.42, atol=1e-6)
+
+
+def test_gridproperty_from_resinsight_case_name_alias_deprecated(resinsight_instance):
+    """The deprecated 'case_name' alias still works but emits a warning."""
+    _write_generated_property(resinsight_instance)
+    with pytest.warns(DeprecationWarning, match="case_name"):
+        prop = xtgeo.gridproperty_from_resinsight(
+            resinsight_instance,
+            case_name="EXAMPLE",
+            property_name="SYNTH_PORO",
+            property_type="GENERATED",
+        )
+    assert prop.name == "SYNTH_PORO"
+
+    with pytest.raises(TypeError, match="only 'case'"):
+        xtgeo.gridproperty_from_resinsight(
+            resinsight_instance,
+            "EXAMPLE",
+            property_name="SYNTH_PORO",
+            case_name="EXAMPLE",
+        )

--- a/tests/test_interfaces/test_resinsight/test_resinsight_base.py
+++ b/tests/test_interfaces/test_resinsight/test_resinsight_base.py
@@ -1,0 +1,55 @@
+"""Unit tests for the shared ResInsight read/write base helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import xtgeo
+from xtgeo.interfaces.resinsight._resinsight_base import (
+    _BaseResInsightDataRW,
+    validate_case,
+)
+
+
+def test_resolve_case_returns_case_object_unchanged():
+    base = _BaseResInsightDataRW(instance_or_port=None)
+    case = SimpleNamespace(name="KEEP")
+    assert base.resolve_case(case) is case
+
+
+@pytest.mark.parametrize("bad", [123, object(), None, SimpleNamespace(name=42)])
+def test_resolve_case_rejects_invalid_argument(bad):
+    base = _BaseResInsightDataRW(instance_or_port=None)
+    with pytest.raises(TypeError, match="case must be a case name"):
+        base.resolve_case(bad)
+
+
+@pytest.mark.parametrize("good", ["MYCASE", SimpleNamespace(name="FC")])
+def test_validate_case_accepts_valid_argument(good):
+    assert validate_case(good) is None
+
+
+@pytest.mark.parametrize("bad", [123, object(), None, SimpleNamespace(name=42)])
+def test_validate_case_rejects_invalid_argument(bad):
+    with pytest.raises(TypeError, match="case must be a case name"):
+        validate_case(bad)
+
+
+# ---------------------------------------------------------------------------
+# Early validation at the public API boundary (before expensive extraction)
+# ---------------------------------------------------------------------------
+
+
+def test_grid_to_resinsight_rejects_invalid_case_early():
+    grd = xtgeo.create_box_grid((2, 2, 2))
+    with pytest.raises(TypeError, match="case must be a case name"):
+        grd.to_resinsight(5000, case=123)
+
+
+def test_gridproperty_to_resinsight_rejects_invalid_case_early():
+    gprop = xtgeo.GridProperty(ncol=2, nrow=2, nlay=2, values=np.ones((2, 2, 2)))
+    with pytest.raises(TypeError, match="case must be a case name"):
+        gprop.to_resinsight(5000, case=123)

--- a/tests/test_interfaces/test_resinsight/test_resinsight_grid.py
+++ b/tests/test_interfaces/test_resinsight/test_resinsight_grid.py
@@ -195,7 +195,7 @@ def test_writer_roundtrip_new_case(resinsight_instance):
     data = reader.load("EXAMPLE")
 
     writer = GridWriter(resinsight_instance)
-    case = writer.save(data, gname="NEW_CASE")
+    case = writer.save(data, case="NEW_CASE")
 
     assert case is not None, "save should return the created case"
     assert case.name == "NEW_CASE"
@@ -228,7 +228,7 @@ def test_writer_replace_case(resinsight_instance: RipsInstanceType):
     writer = GridWriter(resinsight_instance)
     data = GridDataResInsight.from_xtgeo_grid(grid, name="TEST_GRID", filesrc="")
 
-    case = writer.save(data, gname="SIMPLE", find_last=False)
+    case = writer.save(data, case="SIMPLE", find_last=False)
 
     assert case is not None, "save should return the created case"
     assert case.name == "SIMPLE"
@@ -254,7 +254,7 @@ def test_writer_replace_case(resinsight_instance: RipsInstanceType):
     # Create a new grid with different dimensions and save it with the same case name
     grid2 = xtgeo.create_box_grid((3, 3, 3))
     data2 = GridDataResInsight.from_xtgeo_grid(grid2, name="TEST_GRID_2", filesrc="")
-    case2 = writer.save(data2, gname="SIMPLE", find_last=False)
+    case2 = writer.save(data2, case="SIMPLE", find_last=False)
 
     assert case2 is not None, "save should return the replaced case"
     assert case2.name == "SIMPLE"
@@ -285,7 +285,7 @@ def test_writer_roundtrip_replace_case(resinsight_instance):
     data = reader.load("EXAMPLE")
 
     writer = GridWriter(resinsight_instance)
-    writer.save(data, gname="EXAMPLE")
+    writer.save(data, case="EXAMPLE")
 
     reloaded_data = reader.load("EXAMPLE")
     assert reloaded_data.name == "EXAMPLE", (


### PR DESCRIPTION
Resolves #1717 

Unlike RMS, ResInsight allows multiple grids/cases with the same name, so a name is not a unique identifier. To avoid ambiguity, this PR lets users pass a grid/case object directly when interacting with ResInsight, while still accepting a name (string) to keep the interface consistent with RMS.

**Changes**
1. Rename  gname / case_name  →  case . The old names were unintuitive once an object can be passed. The public  Grid.to_resinsight  /  GridProperty.to_resinsight  keep backward compatibility via a deprecated  gname  alias that emits a warning.
2. Argument validation. A  case  that is neither a string nor a Case-like object (with a string  name ) now raises a clear  TypeError  early, instead of silently creating a case with an empty name or failing later with a confusing  AttributeError .
3. Hide internal classes.  GridReader ,  GridWriter ,  RegularSurfaceReader , etc. live in private modules but were re-exported in the public package namespace; they are no longer exposed. Internal callers now import them directly from their private modules.

Added unit tests for the new validation and updated existing tests/call sites.

**Note:**
Commit https://github.com/equinor/xtgeo/pull/1718/commits/ab945e09ea13507674c61d760bcae6142568b1f3 is up for discussion. I copied this pattern from RMS interface, but feels like the internal classes should not be exposed.


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
