### PR TITLE
CI: Drop fragile `git -C C:/vcpkg pull` breaking Windows wheel builds

### DIFF
--- a/.github/actions/setup_xtgeo/action.yml
+++ b/.github/actions/setup_xtgeo/action.yml
@@ -24,7 +24,6 @@ runs:
       if: ${{ inputs.os == 'windows-latest' }}
       shell: bash
       run: |
-        git -C C:/vcpkg pull
         vcpkg install --triplet x64-windows
 
     - name: Install macOS dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,10 +137,7 @@ test-command = [
 ]
 
 [tool.cibuildwheel.windows]
-before-all = [
-    "git -C C:/vcpkg pull",
-    "vcpkg install --triplet x64-windows"
-]
+before-all = "vcpkg install --triplet x64-windows"
 
 [tool.cibuildwheel.linux]
 before-all = "yum update -y && yum install -y eigen3-devel fmt-devel || (apt-get update && apt-get install -y libeigen3-dev libfmt-dev)"


### PR DESCRIPTION
Resolves #1722 

Drop fragile `git -C C:/vcpkg pull` breaking Windows wheel builds

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
