### PR TITLE
fix(xyz): return empty data when no well yields points

### DIFF
--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -130,6 +130,8 @@ def _wells_importer(
         if wp is not None:
             dflist.append(wp)
 
+    if not dflist:
+        return {}
     dfr = pd.concat(dflist, ignore_index=True)
 
     attrs = {}
@@ -175,6 +177,8 @@ def _wells_dfrac_importer(
         if wpf is not None:
             dflist.append(wpf)
 
+    if not dflist:
+        return {}
     dfr = pd.concat(dflist, ignore_index=True)
 
     attrs = {}

--- a/tests/test_xyz/test_points.py
+++ b/tests/test_xyz/test_points.py
@@ -901,6 +901,50 @@ def test_wells_importer_skips_none_wells_and_object_dtype_attrs() -> None:
     assert result["attributes"]["Category"] == "float"
 
 
+def test_wells_importer_returns_empty_when_no_well_has_data() -> None:
+    """Test ``_wells_importer`` returns empty data when every well yields ``None``.
+
+    What is tested:
+        When no well provides zonation points (e.g. the wells have no zonelog),
+        ``dflist`` stays empty and the importer must not call ``pd.concat`` on it.
+
+    Expected behaviour:
+        * An empty dict is returned, so ``points_from_wells`` builds an empty
+          ``Points`` instance instead of raising ``ValueError: No objects to
+          concatenate``.
+    """
+    from unittest.mock import MagicMock
+
+    from xtgeo.xyz.points import _wells_importer
+
+    well_none = MagicMock()
+    well_none.get_zonation_points.return_value = None
+
+    assert _wells_importer([well_none]) == {}
+    assert len(xtgeo.points_from_wells([well_none]).get_dataframe()) == 0
+
+
+def test_wells_dfrac_importer_returns_empty_when_no_well_has_data() -> None:
+    """Test ``_wells_dfrac_importer`` returns empty data when all wells yield ``None``.
+
+    What is tested:
+        When ``get_fraction_per_zone`` returns ``None`` for every well, the
+        importer must not call ``pd.concat`` on the empty list.
+
+    Expected behaviour:
+        * An empty dict is returned instead of raising ``ValueError: No objects
+          to concatenate``.
+    """
+    from unittest.mock import MagicMock
+
+    from xtgeo.xyz.points import _wells_dfrac_importer
+
+    well_none = MagicMock()
+    well_none.get_fraction_per_zone.return_value = None
+
+    assert _wells_dfrac_importer([well_none], "FACIES", [1]) == {}
+
+
 def test_wells_dfrac_importer_skips_none_wells() -> None:
     """Test ``_wells_dfrac_importer`` silently skips wells that return ``None``.
 


### PR DESCRIPTION
Resolves #1678

`xtgeo.points_from_wells()` raised `ValueError: No objects to concatenate` when none of the given wells produced zonation points (e.g. wells without a zonelog), because `_wells_importer` called `pd.concat` on an empty list. The sibling `polygons._wells_importer` already guards this with an early `if not dflist: return {}`; this mirrors that in `points._wells_importer` and `_wells_dfrac_importer`, so an empty `Points` instance is returned as the docstring ("None if empty data") implies.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary - N/A, no user-facing API change
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers - N/A, diff is two lines
- [ ] Moved issue status on project board - no access
- [x] Checked the boxes in this checklist

The two new tests in `tests/test_xyz/test_points.py` fail on main with the reported `ValueError` and pass with the fix. This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
