### PR TITLE
Extend grid refinement feature

### DIFF
--- a/src/xtgeo/grid3d/_grid_refine.py
+++ b/src/xtgeo/grid3d/_grid_refine.py
@@ -40,15 +40,15 @@ def refine(
         ("refine_layer", refine_layer),
     ]:
         if isinstance(factor, int):
-            if not 0 <= factor <= max_refine:
+            if not 1 <= factor <= max_refine:
                 raise ValueError(
-                    f"{name}={factor} is out of valid range [0, {max_refine}]"
+                    f"{name}={factor} is out of valid range [1, {max_refine}]"
                 )
         elif isinstance(factor, dict):
             for key, value in factor.items():
-                if not isinstance(value, int) or not 0 <= value <= max_refine:
+                if not isinstance(value, int) or not 1 <= value <= max_refine:
                     raise ValueError(
-                        f"{name}[{key}]={value} is out of valid range [0, {max_refine}]"
+                        f"{name}[{key}]={value} is out of valid range [1, {max_refine}]"
                     )
         else:
             raise TypeError(f"{name} must be int or dict[int, int], got {type(factor)}")
@@ -214,15 +214,15 @@ def refine_vertically(
 
     # Validate refinement factor is within valid range
     if isinstance(rfactor, int):
-        if not 0 <= rfactor <= max_refine:
+        if not 1 <= rfactor <= max_refine:
             raise ValueError(
-                f"rfactor={rfactor} is out of valid range [0, {max_refine}]"
+                f"rfactor={rfactor} is out of valid range [1, {max_refine}]"
             )
     elif isinstance(rfactor, dict):
         for key, value in rfactor.items():
-            if not isinstance(value, int) or not 0 <= value <= max_refine:
+            if not isinstance(value, int) or not 1 <= value <= max_refine:
                 raise ValueError(
-                    f"rfactor[{key}]={value} is out of valid range [0, {max_refine}]"
+                    f"rfactor[{key}]={value} is out of valid range [1, {max_refine}]"
                 )
     else:
         raise TypeError(f"rfactor must be int or dict[int, int], got {type(rfactor)}")

--- a/src/xtgeo/grid3d/_grid_refine.py
+++ b/src/xtgeo/grid3d/_grid_refine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -17,10 +18,140 @@ if TYPE_CHECKING:
     from xtgeo.grid3d import Grid, GridProperty
 
 
+def _is_non_text_sequence(value: object) -> bool:
+    return isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    )
+
+
+def _expand_section_factors(
+    ncells: int, factors: Sequence[int], name: str
+) -> list[int]:
+    """Expand a per-section list of refinement factors to a per-cell list.
+
+    The cells along the chosen direction are split into ``len(factors)``
+    approximately equal sections, mirroring :func:`numpy.array_split` semantics:
+    when ``ncells`` is not divisible by the number of sections, the earlier
+    sections receive one extra cell each. Each section is then assigned the
+    refinement factor at the matching position of ``factors``.
+
+    Example:
+        ``_expand_section_factors(10, [2, 3, 1], "refine_col")`` produces
+        ``[2, 2, 2, 2, 3, 3, 3, 1, 1, 1]`` (sections of size 4, 3, 3).
+
+    Args:
+        ncells: Number of cells in the direction being refined.
+        factors: Per-section refinement factors. Must contain at least one
+            entry, contain only positive integers and have no more entries
+            than ``ncells``.
+        name: Argument name used in error messages.
+
+    Returns:
+        A list of length ``ncells`` holding the per-cell refinement factor.
+
+    Raises:
+        ValueError: If ``factors`` is empty, contains non-positive values or
+            has more entries than ``ncells``.
+        TypeError: If any factor is not an ``int``.
+    """
+    n_sections = len(factors)
+    if n_sections == 0:
+        raise ValueError(f"{name} list must contain at least one factor")
+    if n_sections > ncells:
+        raise ValueError(
+            f"{name} list has {n_sections} sections, but the grid only has "
+            f"{ncells} cells in that direction"
+        )
+    for idx, factor in enumerate(factors):
+        # bool is a subclass of int; reject it explicitly to avoid surprises
+        if not isinstance(factor, int) or isinstance(factor, bool):
+            raise TypeError(
+                f"{name}[{idx}]={factor!r} must be int, got {type(factor).__name__}"
+            )
+        if not 1 <= factor <= np.iinfo(np.uint16).max:
+            raise ValueError(
+                f"{name}[{idx}]={factor} must be in range "
+                f"[1, {np.iinfo(np.uint16).max}] "
+                f"(use 1 to leave a section unchanged)"
+            )
+
+    base, extra = divmod(ncells, n_sections)
+    expanded: list[int] = []
+    for k, factor in enumerate(factors):
+        size = base + (1 if k < extra else 0)
+        expanded.extend([factor] * size)
+    return expanded
+
+
+def _validate_refine_dict(name: str, factor: dict[int, int], max_refine: int) -> None:
+    for key, value in factor.items():
+        if isinstance(key, bool) or not isinstance(key, int):
+            raise TypeError(
+                f"{name}[{key!r}] key must be int, got {type(key).__name__}"
+            )
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(
+                f"{name}[{key}]={value!r} must be int, got {type(value).__name__}"
+            )
+        if not 1 <= value <= max_refine:
+            raise ValueError(
+                f"{name}[{key}]={value} is out of valid range [1, {max_refine}]"
+            )
+
+
+def _validate_refine_factor(
+    name: str, factor: int | Sequence[int] | dict[int, int], max_refine: int
+) -> None:
+    if isinstance(factor, bool):
+        expected = (
+            "int or dict[int, int]"
+            if name == "refine_layer"
+            else "int, sequence of int or dict[int, int]"
+        )
+        raise TypeError(f"{name} must be {expected}, got {type(factor).__name__}")
+    if isinstance(factor, int):
+        if not 1 <= factor <= max_refine:
+            raise ValueError(f"{name}={factor} is out of valid range [1, {max_refine}]")
+        return
+    if _is_non_text_sequence(factor):
+        if name == "refine_layer":
+            raise TypeError(
+                f"{name} must be int or dict[int, int], got {type(factor).__name__}"
+            )
+        return
+    if isinstance(factor, dict):
+        _validate_refine_dict(name, factor, max_refine)
+        return
+    if name == "refine_layer":
+        raise TypeError(
+            f"{name} must be int or dict[int, int], got {type(factor).__name__}"
+        )
+    raise TypeError(
+        f"{name} must be int, sequence of int or dict[int, int], got "
+        f"{type(factor).__name__}"
+    )
+
+
+def _build_lateral_refine_factors(
+    name: str, factor: int | Sequence[int] | dict[int, int], ncells: int
+) -> list[int]:
+    if isinstance(factor, int):
+        return [factor] * ncells
+    if _is_non_text_sequence(factor):
+        return _expand_section_factors(ncells, factor, name)
+
+    refine_factors = [1] * ncells
+    for index, item_factor in factor.items():
+        if not 0 < index <= ncells:
+            raise ValueError(f"{name} key {index} is out of valid range [1, {ncells}]")
+        refine_factors[index - 1] = item_factor
+    return refine_factors
+
+
 def refine(
     self: Grid,
-    refine_col: int | dict[int, int],
-    refine_row: int | dict[int, int],
+    refine_col: int | Sequence[int] | dict[int, int],
+    refine_row: int | Sequence[int] | dict[int, int],
     refine_layer: int | dict[int, int],
     zoneprop: GridProperty | None = None,
 ) -> Grid:
@@ -34,44 +165,19 @@ def refine(
     max_refine = np.iinfo(np.uint16).max
 
     # Validate refinement factors are within valid range
-    for name, factor in [
+    for name, factor in (
         ("refine_col", refine_col),
         ("refine_row", refine_row),
         ("refine_layer", refine_layer),
-    ]:
-        if isinstance(factor, int):
-            if not 1 <= factor <= max_refine:
-                raise ValueError(
-                    f"{name}={factor} is out of valid range [1, {max_refine}]"
-                )
-        elif isinstance(factor, dict):
-            for key, value in factor.items():
-                if not isinstance(value, int) or not 1 <= value <= max_refine:
-                    raise ValueError(
-                        f"{name}[{key}]={value} is out of valid range [1, {max_refine}]"
-                    )
-        else:
-            raise TypeError(f"{name} must be int or dict[int, int], got {type(factor)}")
+    ):
+        _validate_refine_factor(name, factor, max_refine)
 
-    if isinstance(refine_col, int):
-        refine_factor_column = [refine_col] * self.dimensions[0]
-    else:
-        refine_factor_column = [1] * self.dimensions[0]
-        for col, factor in refine_col.items():
-            if 0 < col < self.dimensions[0] and isinstance(factor, int) and factor > 0:
-                refine_factor_column[col - 1] = factor
-            else:
-                xtg.warning("Invalid refine_col item {col}:{factor}")
-
-    if isinstance(refine_row, int):
-        refine_factor_row = [refine_row] * self.dimensions[1]
-    else:
-        refine_factor_row = [1] * self.dimensions[1]
-        for row, factor in refine_row.items():
-            if 0 < row < self.dimensions[1] and isinstance(factor, int) and factor > 0:
-                refine_factor_row[row - 1] = factor
-            else:
-                xtg.warning("Invalid refine_row item {row}:{factor}")
+    refine_factor_column = _build_lateral_refine_factors(
+        "refine_col", refine_col, self.dimensions[0]
+    )
+    refine_factor_row = _build_lateral_refine_factors(
+        "refine_row", refine_row, self.dimensions[1]
+    )
 
     refine_factor_layer_dict = {}
     # case 1 rfactor as scalar value.
@@ -214,18 +320,32 @@ def refine_vertically(
 
     # Validate refinement factor is within valid range
     if isinstance(rfactor, int):
+        if isinstance(rfactor, bool):
+            raise TypeError(
+                f"rfactor must be int or dict[int, int], got {type(rfactor).__name__}"
+            )
         if not 1 <= rfactor <= max_refine:
             raise ValueError(
                 f"rfactor={rfactor} is out of valid range [1, {max_refine}]"
             )
     elif isinstance(rfactor, dict):
         for key, value in rfactor.items():
-            if not isinstance(value, int) or not 1 <= value <= max_refine:
+            if isinstance(key, bool) or not isinstance(key, int):
+                raise TypeError(
+                    f"rfactor[{key!r}] key must be int, got {type(key).__name__}"
+                )
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(
+                    f"rfactor[{key}]={value!r} must be int, got {type(value).__name__}"
+                )
+            if not 1 <= value <= max_refine:
                 raise ValueError(
                     f"rfactor[{key}]={value} is out of valid range [1, {max_refine}]"
                 )
     else:
-        raise TypeError(f"rfactor must be int or dict[int, int], got {type(rfactor)}")
+        raise TypeError(
+            f"rfactor must be int or dict[int, int], got {type(rfactor).__name__}"
+        )
 
     rfactord = {}
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -40,7 +40,7 @@ from .grid_properties import GridProperties
 
 if TYPE_CHECKING:
     import pathlib
-    from collections.abc import Callable, Hashable
+    from collections.abc import Callable, Hashable, Sequence
 
     import pandas as pd
 
@@ -3062,40 +3062,80 @@ class Grid(_Grid3D):
 
     def refine(
         self,
-        refine_col: int | dict[int, int],
-        refine_row: int | dict[int, int],
-        refine_layer: int | dict,
+        refine_col: int | Sequence[int] | dict[int, int],
+        refine_row: int | Sequence[int] | dict[int, int],
+        refine_layer: int | dict[int, int],
         zoneprop: GridProperty | None = None,
     ) -> None:
-        """Refine grid in all direction, proportionally.
+        """Refine grid in all directions, proportionally.
 
-        The refine_layer can be a scalar or a dictionary.
+        Each direction has its own refinement specification:
 
-        If refine_layer is a dict and zoneprop is None, then the current
-        subgrids array is used. If zoneprop is defined, the
+        - ``int``: refine every column / row / layer by the same factor.
+        - ``Sequence[int]`` *(lateral only)*: split the
+          grid in the chosen direction (``i`` for ``refine_col``, ``j`` for
+          ``refine_row``) into ``len(refine_col)`` or ``len(refine_row)``
+          approximately equal sections
+          and refine each section by the matching factor. When the cell
+          count does not divide evenly across sections, the earlier sections
+          get one extra cell (mirroring :func:`numpy.array_split`). For
+          example, with ``ncol = 10`` and ``refine_col = [2, 3, 1]`` the
+          first 4 columns are refined by 2, the next 3 by 3 and the last 3
+          are left unchanged.
+        - ``dict[int, int]`` *(lateral)*: explicitly map a 1-based column /
+          row index to a refinement factor; unspecified entries default to 1.
+        - ``dict[int, int]`` *(layer)*: see notes below.
+
+        The ``refine_layer`` argument can be a scalar or a dictionary.
+
+        If ``refine_layer`` is a dict and ``zoneprop`` is ``None``, the
+        current subgrids array is used. If ``zoneprop`` is defined, the
         current subgrid index will be redefined for the case. A warning will
-        be issued if subgrids are defined, but the give zone
-        property is inconsistent with this.
+        be issued if subgrids are defined, but the given zone property is
+        inconsistent with this.
 
-        Also, if a zoneprop is defined but no current subgrids in the grid,
-        then subgrids will be added to the grid, if more than 1 subgrid.
+        Also, if a ``zoneprop`` is defined but no current subgrids in the
+        grid, then subgrids will be added to the grid, if more than one
+        subgrid.
 
         Args:
             self (object): A grid XTGeo object
-            refine_col (scalar or dict): Refinement factor for each column.
-            refine_row (scalar or dict): Refinement factor for each row.
+            refine_col: Refinement factor in the I direction. Either a single
+                scalar applied to every column, a per-section sequence of
+                factors (the grid is split into ``len(refine_col)`` roughly
+                equal lateral sections), or a 1-based ``{column: factor}``
+                dict.
+            refine_row: Refinement factor in the J direction, same accepted
+                shapes as ``refine_col``.
             refine_layer (scalar or dict): Refinement factor for layer, if dict, then
                 the dictionary must be consistent with self.subgrids if this is
                 present.
             zoneprop (GridProperty): Zone property; must be defined if refine_layer
                 is a dict
 
-        Returns:
-            ValueError: if..
+        Raises:
+            ValueError: if a refinement factor is out of range or the layer
+                refinement does not match the grid subgrid definition.
             RuntimeError: if mismatch in dimensions for refine_layer and zoneprop
 
+        Examples::
+
+            # Refine every direction uniformly
+            grd.refine(2, 2, 3)
+
+            # Refine the I direction in three sections (factors 2, 3, 1) and
+            # the J direction in two sections (factors 1, 2):
+            grd.refine([2, 3, 1], [1, 2], 1)
+
+            # Mix list-based lateral refinement with a layer dict:
+            grd.refine([1, 3, 1], 2, {1: 2, 2: 4})
+
         Note:
-            Maximum refinement value for e.g. ``refine_layer`` is 65535 per zone.
+            Valid refinement factors are integers in the range ``[1, 65535]``
+            for all input types (scalar, list/tuple, dict). Use ``1`` to leave
+            a direction or section unchanged.
+            A list/tuple must contain at most ``ncol`` (for ``refine_col``) or
+            ``nrow`` (for ``refine_row``) entries.
 
         """
         _grid_refine.refine(

--- a/tests/test_grid3d/test_grid_refinement.py
+++ b/tests/test_grid3d/test_grid_refinement.py
@@ -2,6 +2,7 @@
 
 import pathlib
 
+import numpy as np
 import pytest
 
 import xtgeo
@@ -227,3 +228,215 @@ def test_refine_vertically_per_zone(testdata_path):
     grd.refine_vertically(refinement)  # no zoneprop
 
     assert grd.get_subgrids() == {"subgrid_0": 64, "subgrid_1": 60}
+
+
+def test_refine_lateral_with_list_even_split():
+    """Refine I/J using a list of per-section factors with an even split."""
+
+    grid = xtgeo.create_box_grid((9, 6, 4), increment=(10, 10, 5))
+    avg_dx1 = grid.get_dx().values.mean()
+    avg_dy1 = grid.get_dy().values.mean()
+
+    # 9 cols / 3 sections -> 3 cols per section, factors [1, 2, 3]
+    # 6 rows / 2 sections -> 3 rows per section, factors [2, 4]
+    grid.refine([1, 2, 3], [2, 4], 1)
+
+    expected_ncol = 3 * 1 + 3 * 2 + 3 * 3
+    expected_nrow = 3 * 2 + 3 * 4
+    assert grid.dimensions == (expected_ncol, expected_nrow, 4)
+
+    # The total physical extent in X/Y must be preserved, so the mean cell
+    # size scales like ncol_before / ncol_after.
+    avg_dx2 = grid.get_dx().values.mean()
+    avg_dy2 = grid.get_dy().values.mean()
+    assert avg_dx2 == pytest.approx(avg_dx1 * 9 / expected_ncol, abs=1e-6)
+    assert avg_dy2 == pytest.approx(avg_dy1 * 6 / expected_nrow, abs=1e-6)
+
+
+def test_refine_lateral_with_list_uneven_split():
+    """List sections that don't divide evenly should follow numpy.array_split."""
+
+    grid = xtgeo.create_box_grid((10, 7, 2), increment=(10, 10, 5))
+
+    # 10 cols / 3 sections -> sizes 4, 3, 3 (extras to earlier sections)
+    # 7 rows / 4 sections -> sizes 2, 2, 2, 1
+    grid.refine([2, 1, 3], [1, 2, 1, 2], 1)
+
+    expected_ncol = 4 * 2 + 3 * 1 + 3 * 3
+    expected_nrow = 2 * 1 + 2 * 2 + 2 * 1 + 1 * 2
+    assert grid.dimensions == (expected_ncol, expected_nrow, 2)
+
+
+def test_refine_lateral_with_list_and_attached_props():
+    """List-based refinement must keep attached properties in sync."""
+
+    grid = xtgeo.create_box_grid((6, 4, 3), increment=(10, 10, 5))
+    discrete = xtgeo.GridProperty(grid, name="ZONE", discrete=True, values=1)
+    # Tag each I-section with a distinct value so we can verify ordering after
+    # refinement.
+    discrete.values[0:2, :, :] = 10
+    discrete.values[2:4, :, :] = 20
+    discrete.values[4:6, :, :] = 30
+
+    # 6 cols / 3 sections -> 2 cols per section, factors [1, 2, 3]
+    # 4 rows kept identical via scalar 1
+    grid.refine([1, 2, 3], 1, 1)
+
+    expected_ncol = 2 * 1 + 2 * 2 + 2 * 3
+    assert grid.dimensions == (expected_ncol, 4, 3)
+
+    zone = grid.get_prop_by_name("ZONE")
+    assert zone.dimensions == (expected_ncol, 4, 3)
+    assert zone.geometry is grid
+
+    vals_i = zone.values[:, 0, 0].tolist()
+    # First section (factor 1) keeps 2 cells of value 10,
+    # second section (factor 2) yields 2*2 = 4 cells of value 20,
+    # third section (factor 3) yields 2*3 = 6 cells of value 30.
+    assert vals_i == [10] * 2 + [20] * 4 + [30] * 6
+
+
+def test_refine_lateral_with_tuple_is_equivalent_to_list():
+    """A tuple of factors must behave the same as the equivalent list."""
+
+    grid_list = xtgeo.create_box_grid((8, 4, 2), increment=(10, 10, 5))
+    grid_tuple = grid_list.copy()
+
+    grid_list.refine([1, 2, 1, 2], [1, 3], 1)
+    grid_tuple.refine((1, 2, 1, 2), (1, 3), 1)
+
+    assert grid_list.dimensions == grid_tuple.dimensions
+    np.testing.assert_allclose(grid_list.get_dx().values, grid_tuple.get_dx().values)
+    np.testing.assert_allclose(grid_list.get_dy().values, grid_tuple.get_dy().values)
+
+
+def test_refine_lateral_list_single_section_equivalent_to_scalar():
+    """A single-element list should match the equivalent scalar refinement."""
+
+    base = xtgeo.create_box_grid((5, 5, 2), increment=(10, 10, 5))
+    g_scalar = base.copy()
+    g_list = base.copy()
+
+    g_scalar.refine(3, 2, 1)
+    g_list.refine([3], [2], 1)
+
+    assert g_scalar.dimensions == g_list.dimensions
+    np.testing.assert_allclose(g_scalar.get_dx().values, g_list.get_dx().values)
+    np.testing.assert_allclose(g_scalar.get_dy().values, g_list.get_dy().values)
+
+
+def test_refine_lateral_list_only_one_direction():
+    """Passing a list in one direction and scalar in the other must work."""
+
+    grid = xtgeo.create_box_grid((6, 5, 2), increment=(10, 10, 5))
+    avg_dy1 = grid.get_dy().values.mean()
+
+    grid.refine([1, 2, 3], 1, 1)
+
+    expected_ncol = 2 * 1 + 2 * 2 + 2 * 3
+    assert grid.dimensions == (expected_ncol, 5, 2)
+    # J direction (and its dy) must be untouched
+    assert grid.get_dy().values.mean() == pytest.approx(avg_dy1, abs=1e-6)
+
+
+def test_refine_lateral_range_is_supported():
+    """Any non-text sequence should work for the lateral section form."""
+
+    grid_range = xtgeo.create_box_grid((6, 4, 2), increment=(10, 10, 5))
+    grid_list = grid_range.copy()
+
+    grid_range.refine(range(1, 4), range(1, 3), 1)
+    grid_list.refine([1, 2, 3], [1, 2], 1)
+
+    assert grid_range.dimensions == grid_list.dimensions
+    np.testing.assert_allclose(grid_range.get_dx().values, grid_list.get_dx().values)
+    np.testing.assert_allclose(grid_range.get_dy().values, grid_list.get_dy().values)
+
+
+@pytest.mark.parametrize(
+    "refine_col, refine_row",
+    [
+        ({1: 2, "a": 3}, 1),
+        (1, {1: 2, "b": 3}),
+        ({1: True}, 1),
+        (1, {1: True}),
+    ],
+)
+def test_refine_lateral_dict_validation_errors(refine_col, refine_row):
+    """Dict keys and values must be validated with clear errors."""
+
+    grid = xtgeo.create_box_grid((5, 5, 2), increment=(10, 10, 5))
+    with pytest.raises(TypeError):
+        grid.refine(refine_col, refine_row, 1)
+
+
+@pytest.mark.parametrize(
+    "refine_col, refine_row",
+    [
+        ({0: 2}, 1),
+        ({6: 2}, 1),  # ncol=5
+        (1, {0: 2}),
+        (1, {6: 2}),  # nrow=5
+    ],
+)
+def test_refine_lateral_dict_out_of_range_indices(refine_col, refine_row):
+    """Out-of-range lateral dict indices must be rejected."""
+
+    grid = xtgeo.create_box_grid((5, 5, 2), increment=(10, 10, 5))
+    with pytest.raises(ValueError):
+        grid.refine(refine_col, refine_row, 1)
+
+
+def test_refine_vertically_rejects_bool():
+    """Vertical refinement must reject bool inputs explicitly."""
+
+    grid = xtgeo.create_box_grid((5, 5, 4), increment=(10, 10, 5))
+
+    with pytest.raises(TypeError):
+        grid.refine_vertically(True)
+
+    with pytest.raises(TypeError):
+        grid.refine_vertically({1: True})
+
+
+def test_refine_vertical_scalar_zero_rejected():
+    """Zero refinement must be rejected for vertical scalar APIs."""
+
+    grid = xtgeo.create_box_grid((5, 5, 4), increment=(10, 10, 5))
+
+    with pytest.raises(ValueError):
+        grid.refine(1, 1, 0)
+
+    with pytest.raises(ValueError):
+        grid.refine_vertically(0)
+
+
+@pytest.mark.parametrize(
+    "refine_col, refine_row, expected_exc",
+    [
+        (0, 1, ValueError),
+        (1, 0, ValueError),
+        ([], 1, ValueError),
+        (1, (), ValueError),
+        ([1, 2, 3, 4, 5, 6, 7], 1, ValueError),  # more sections than ncol=5
+        (1, [1, 2, 3, 4, 5, 6, 7], ValueError),  # more sections than nrow=5
+        ([0, 2], 1, ValueError),
+        ([1, -1], 1, ValueError),
+        ([1.5, 2], 1, (TypeError, ValueError)),
+        (1, ["a", "b"], (TypeError, ValueError)),
+    ],
+)
+def test_refine_lateral_list_validation_errors(refine_col, refine_row, expected_exc):
+    """Invalid list inputs must raise a clear error."""
+
+    grid = xtgeo.create_box_grid((5, 5, 2), increment=(10, 10, 5))
+    with pytest.raises(expected_exc):
+        grid.refine(refine_col, refine_row, 1)
+
+
+def test_refine_lateral_list_rejects_for_layer():
+    """A list passed to refine_layer is not supported and must error."""
+
+    grid = xtgeo.create_box_grid((5, 5, 4), increment=(10, 10, 5))
+    with pytest.raises(TypeError):
+        grid.refine(1, 1, [1, 2])


### PR DESCRIPTION
Resolves #1615 

Extend grid refinement feature to support non-uniform refinement factor laterally.
Also fix bug to reject grid refinement factor = 0.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
