### PR TITLE
ENH: Add support for subgrids in grid_from_resinsight and Grid.to_resinsight

### DIFF
--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -232,6 +232,12 @@ def grid_from_resinsight(
 ) -> Grid:
     """Load a corner-point grid from a ResInsight case into an XTGeo ``Grid``.
 
+    If the case contains a ``SUBGRIDS`` input property (a discrete property
+    with 1-based subgrid indices and subgrid names as category names — as
+    written by :meth:`Grid.to_resinsight` or imported from a ROFF file by
+    ResInsight), the grid's :attr:`subgrids` attribute is automatically
+    populated from that property.
+
     Args:
         instance_or_port: Optional ``rips.Instance`` or gRPC port. Use ``None``
             to auto-discover a running ResInsight instance.
@@ -259,21 +265,47 @@ def grid_from_resinsight(
         grid = xtgeo.grid_from_resinsight(instance, case)
 
     """
-    if case_name is not None:
-        from xtgeo.interfaces.resinsight._deprecation import resolve_deprecated_alias
 
+    from xtgeo.interfaces.resinsight import SUBGRIDS_PROPERTY_NAME
+    from xtgeo.interfaces.resinsight._deprecation import resolve_deprecated_alias
+    from xtgeo.interfaces.resinsight._grid import (
+        GridReader,
+        get_zoneprop_from_resinsight,
+    )
+
+    if case_name is not None:
         case = resolve_deprecated_alias(
             case, case_name, new_name="case", old_name="case_name"
         )
     if case is None:
         raise TypeError("grid_from_resinsight() missing required argument: 'case'")
 
-    from xtgeo.interfaces.resinsight._grid import GridReader
+    reader = GridReader(instance_or_port=instance_or_port)
+    rips_case = reader.resolve_case(case, find_last=find_last)
+    if rips_case is None:
+        raise RuntimeError(f"Cannot find any case with name '{case}'")
 
-    grid_resinsight = GridReader(
-        instance_or_port=instance_or_port,
-    ).load(case=case, find_last=find_last)
-    return grid_resinsight.to_xtgeo_grid()
+    grid_resinsight = reader.load(case=rips_case)
+    grid = grid_resinsight.to_xtgeo_grid()
+
+    if zoneprop := get_zoneprop_from_resinsight(instance_or_port, rips_case):
+        try:
+            grid.subgrids_from_zoneprop(zoneprop)
+            logger.info(
+                "Imported %s property from ResInsight case '%s'",
+                SUBGRIDS_PROPERTY_NAME,
+                rips_case.name,
+            )
+        except ValueError:
+            logger.warning(
+                "Failed to reconstruct subgrids from %s property in "
+                "ResInsight case '%s'; grid.subgrids will not be set.",
+                SUBGRIDS_PROPERTY_NAME,
+                rips_case.name,
+                exc_info=True,
+            )
+
+    return grid
 
 
 def create_box_grid(
@@ -1298,6 +1330,14 @@ class Grid(_Grid3D):
         The case named ``case`` will be created if it does not already exist,
         or an existing case will be replaced.
 
+        If the grid has subgrid zonation defined (see :attr:`subgrids`), a
+        discrete input property named ``"SUBGRIDS"`` is automatically exported
+        alongside the geometry.  Each cell receives a 1-based subgrid index
+        counted from the top layer (k=1) downwards, and the subgrid names are
+        registered as discrete category names in ResInsight.  This mirrors the
+        behaviour of ResInsight when it imports a ROFF grid that contains a
+        ``subgrids.nLayers`` tag.
+
         Args:
             instance_or_port: Optional ``rips.Instance`` or gRPC port. Use
                 ``None`` to auto-discover a running ResInsight instance.
@@ -1315,22 +1355,20 @@ class Grid(_Grid3D):
             The ResInsight case that was created or replaced.
 
         """
-        if gname is not None:
-            from xtgeo.interfaces.resinsight._deprecation import (
-                resolve_deprecated_alias,
-            )
-
-            case = resolve_deprecated_alias(
-                case, gname, new_name="case", old_name="gname"
-            )
-        if case is None:
-            raise TypeError("to_resinsight() missing required argument: 'case'")
-
+        from xtgeo.interfaces.resinsight import SUBGRIDS_PROPERTY_NAME
+        from xtgeo.interfaces.resinsight._deprecation import resolve_deprecated_alias
         from xtgeo.interfaces.resinsight._grid import (
             GridDataResInsight,
             GridWriter,
         )
         from xtgeo.interfaces.resinsight._resinsight_base import validate_case
+
+        if gname is not None:
+            case = resolve_deprecated_alias(
+                case, gname, new_name="case", old_name="gname"
+            )
+        if case is None:
+            raise TypeError("to_resinsight() missing required argument: 'case'")
 
         validate_case(case)  # fail fast before extracting grid data
         name = case if isinstance(case, str) else case.name
@@ -1341,7 +1379,32 @@ class Grid(_Grid3D):
         )
 
         writer = GridWriter(instance_or_port=instance_or_port)
-        return writer.save(data, case, find_last)
+        rips_case = writer.save(data, case, find_last)
+
+        # Export subgrid zonation as a discrete INPUT_PROPERTY named "SUBGRIDS".
+        zoneprop = self.get_zoneprop_from_subgrids()
+        if zoneprop is not None:
+            try:
+                zoneprop.to_resinsight(
+                    instance_or_port,
+                    rips_case,
+                    property_type="INPUT_PROPERTY",
+                    property_name=SUBGRIDS_PROPERTY_NAME,
+                    find_last=find_last,
+                )
+            except (RuntimeError, ValueError, TypeError):
+                logger.warning(
+                    f"Failed to export {SUBGRIDS_PROPERTY_NAME} property "
+                    "to ResInsight; grid geometry was still written successfully.",
+                    exc_info=True,
+                )
+            finally:
+                # get_zoneprop_from_subgrids appends to self.props; remove it
+                # so that this export call has no side effect on the grid.
+                if self.props and zoneprop in self.props:
+                    self.props.remove(zoneprop)
+
+        return rips_case
 
     def convert_units(self, units: Units) -> None:
         """

--- a/src/xtgeo/interfaces/resinsight/__init__.py
+++ b/src/xtgeo/interfaces/resinsight/__init__.py
@@ -1,11 +1,17 @@
 """XTGeo interface.resinsight package."""
 
+from typing_extensions import Final
+
 from ._rips_package import PropertyDataType, PropertyType, rips
 from .rips_utils import RipsApiUtils
+
+SUBGRIDS_PROPERTY_NAME: Final[str] = "SUBGRIDS"
+
 
 __all__ = [
     "PropertyDataType",
     "PropertyType",
     "RipsApiUtils",
     "rips",
+    "SUBGRIDS_PROPERTY_NAME",
 ]

--- a/src/xtgeo/interfaces/resinsight/_grid.py
+++ b/src/xtgeo/interfaces/resinsight/_grid.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
     from xtgeo.grid3d.grid import Grid
+    from xtgeo.grid3d.grid_property import GridProperty
 
     from ._rips_package import ResInsightInstanceOrPortType, RipsCaseType
 
@@ -245,3 +246,43 @@ class GridWriter(_BaseResInsightDataRW):
 
         except Exception as exc:
             raise RuntimeError(f"Failed to save ResInsight case data: {exc}") from exc
+
+
+def get_zoneprop_from_resinsight(
+    instance_or_port: ResInsightInstanceOrPortType | None,
+    rips_case: RipsCaseType,
+) -> GridProperty | None:
+    """Load the SUBGRIDS zone property from a ResInsight case, or return None."""
+    from . import SUBGRIDS_PROPERTY_NAME
+    from ._grid_property import GridPropertyReader
+    from ._rips_package import require_rips
+
+    rips = require_rips()
+
+    try:
+        prop_data = GridPropertyReader(instance_or_port=instance_or_port).load(
+            case=rips_case,
+            property_name=SUBGRIDS_PROPERTY_NAME,
+            property_type="INPUT_PROPERTY",
+        )
+    except (RuntimeError, ValueError, rips.RipsError):
+        logger.debug(
+            "Failed to load %s input property from ResInsight case '%s'; "
+            "grid.subgrids will not be set.",
+            SUBGRIDS_PROPERTY_NAME,
+            rips_case.name,
+            exc_info=True,
+        )
+        return None
+
+    subgrids_prop = prop_data.to_xtgeo_gridproperty()
+    if not subgrids_prop.isdiscrete:
+        logger.warning(
+            "Ignoring non-discrete %s property in ResInsight case '%s'; "
+            "grid.subgrids will not be set.",
+            SUBGRIDS_PROPERTY_NAME,
+            rips_case.name,
+        )
+        return None
+
+    return subgrids_prop

--- a/tests/test_interfaces/test_resinsight/test_grid_public_api.py
+++ b/tests/test_interfaces/test_resinsight/test_grid_public_api.py
@@ -12,6 +12,8 @@ They are run via the shared ``resinsight_instance`` fixture defined in
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pytest
 
@@ -200,3 +202,137 @@ def test_to_resinsight_gname_alias_deprecated(resinsight_instance):
     with pytest.warns(DeprecationWarning, match="gname"):
         case = grid.to_resinsight(resinsight_instance, gname="GRID_GNAME_ALIAS")
     assert case.name == "GRID_GNAME_ALIAS"
+
+
+# ---------------------------------------------------------------------------
+# SUBGRIDS input property
+# ---------------------------------------------------------------------------
+
+
+def test_to_resinsight_exports_subgrids_property(resinsight_instance):
+    """Grid.to_resinsight should write a SUBGRIDS input property when subgrids exist."""
+    grid = xtgeo.create_box_grid((4, 3, 6))
+    grid.set_subgrids({"Upper": 2, "Middle": 2, "Lower": 2})
+
+    orig_propnames = list(grid.propnames or [])
+    rips_case = grid.to_resinsight(resinsight_instance, case="GRID_SUBGRIDS_TEST")
+
+    # Verify that grid props were restored to their original state (no side-effect).
+    assert list(grid.propnames or []) == orig_propnames
+
+    subgrids_prop = xtgeo.gridproperty_from_resinsight(
+        resinsight_instance,
+        rips_case,
+        property_type="INPUT_PROPERTY",
+        property_name=xtgeo.interfaces.resinsight.SUBGRIDS_PROPERTY_NAME,
+    )
+    assert subgrids_prop is not None
+    assert subgrids_prop.isdiscrete
+
+    # 1-based index; Upper=1, Middle=2, Lower=3
+    vals = subgrids_prop.values.compressed()  # only unmasked (active) cells
+    assert set(vals) == {1, 2, 3}
+    assert subgrids_prop.codes == {1: "Upper", 2: "Middle", 3: "Lower"}
+
+
+def test_to_resinsight_no_subgrids_no_property(resinsight_instance):
+    """Grid.to_resinsight should not write SUBGRIDS when subgrids are not defined."""
+    grid = xtgeo.create_box_grid((3, 3, 4))
+    assert grid.subgrids is None
+
+    rips_case = grid.to_resinsight(resinsight_instance, case="GRID_NO_SUBGRIDS_TEST")
+
+    with pytest.raises(Exception):
+        xtgeo.gridproperty_from_resinsight(
+            resinsight_instance,
+            rips_case,
+            property_type="INPUT_PROPERTY",
+            property_name=xtgeo.interfaces.resinsight.SUBGRIDS_PROPERTY_NAME,
+        )
+
+
+# ---------------------------------------------------------------------------
+# SUBGRIDS round-trip import
+# ---------------------------------------------------------------------------
+
+
+def test_grid_from_resinsight_imports_subgrids(resinsight_instance):
+    """grid_from_resinsight should populate grid.subgrids from a SUBGRIDS property."""
+    original = xtgeo.create_box_grid((4, 3, 6))
+    original.set_subgrids({"Top": 2, "Mid": 2, "Base": 2})
+
+    rips_case = original.to_resinsight(
+        resinsight_instance, case="GRID_SUBGRIDS_IMPORT_TEST"
+    )
+
+    imported = xtgeo.grid_from_resinsight(resinsight_instance, rips_case)
+
+    assert imported.subgrids is not None, (
+        "subgrids should be populated from SUBGRIDS property"
+    )
+    assert imported.get_subgrids() == {"Top": 2, "Mid": 2, "Base": 2}
+
+
+def test_grid_from_resinsight_ignores_nondiscrete_subgrids_property(
+    resinsight_instance,
+):
+    """A non-discrete SUBGRIDS property should be ignored on import."""
+    grid = xtgeo.create_box_grid((4, 3, 6))
+    rips_case = grid.to_resinsight(
+        resinsight_instance, case="GRID_SUBGRIDS_IMPORT_NONDISCRETE_TEST"
+    )
+
+    nondiscrete_subgrids = xtgeo.GridProperty(
+        grid,
+        name=xtgeo.interfaces.resinsight.SUBGRIDS_PROPERTY_NAME,
+        values=1.5,
+        discrete=False,
+    )
+    nondiscrete_subgrids.to_resinsight(
+        resinsight_instance,
+        case=rips_case,
+        property_name=xtgeo.interfaces.resinsight.SUBGRIDS_PROPERTY_NAME,
+        property_type="INPUT_PROPERTY",
+    )
+
+    imported = xtgeo.grid_from_resinsight(resinsight_instance, rips_case)
+
+    assert imported.subgrids is None
+
+
+def test_grid_from_resinsight_subgrids_inactive_boundary_layers_warns_and_skips(
+    resinsight_instance, caplog
+):
+    """SUBGRIDS import should warn and skip when inactive layers break boundaries."""
+    grid = xtgeo.create_box_grid((4, 3, 10))
+    grid.set_subgrids({"Top": 4, "Middle": 3, "Bottom": 3})
+
+    # Make full zone-boundary layers inactive (boundary between Top and Middle).
+    grid._actnumsv[:, :, 3] = 0
+    grid._actnumsv[:, :, 4] = 0
+
+    rips_case = grid.to_resinsight(
+        resinsight_instance, case="GRID_SUBGRIDS_IMPORT_INACTIVE_BOUNDARY_TEST"
+    )
+
+    with caplog.at_level(logging.WARNING, logger="xtgeo.grid3d.grid"):
+        imported = xtgeo.grid_from_resinsight(resinsight_instance, rips_case)
+
+    assert imported.subgrids is None
+    assert any(
+        "Failed to reconstruct subgrids from SUBGRIDS property" in record.message
+        and "grid.subgrids will not be set." in record.message
+        for record in caplog.records
+    )
+
+
+def test_grid_from_resinsight_no_subgrids_property(resinsight_instance):
+    """grid_from_resinsight on a case without SUBGRIDS leaves grid.subgrids as None."""
+    grid = xtgeo.create_box_grid((3, 3, 4))
+    rips_case = grid.to_resinsight(
+        resinsight_instance, case="GRID_NO_SUBGRIDS_IMPORT_TEST"
+    )
+
+    imported = xtgeo.grid_from_resinsight(resinsight_instance, rips_case)
+
+    assert imported.subgrids is None


### PR DESCRIPTION
Resolves #1726 

ResInsight automatically import subgrids information from roff file as input grid property called SUBGRIDS

The information is useful and we should replicate similar behavior when exporting grid from XTGeo

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
