### PR TITLE
PERF: Speed up UNRST date scanning

### DIFF
--- a/src/xtgeo/grid3d/_grid3d_utils.py
+++ b/src/xtgeo/grid3d/_grid3d_utils.py
@@ -57,15 +57,16 @@ def scan_dates(
     seqnum = -1
     for item in resfo.lazy_read(pfile.file):
         kw = item.read_keyword().strip()
-        data = item.read_array()
 
         if kw == "SEQNUM":
+            data = item.read_array()
             seqnum = data[0]
             continue
 
         # With LGRs multiple INTEHEADs may occur. Ensure we get the date
         # from the first INTEHEAD after a SEQNUM.
         if kw == "INTEHEAD" and seqnum != -1:
+            data = item.read_array()
             # Index 66 = year, 65 = month, 64 = day
             date = int(f"{data[66]}{data[65]:02d}{data[64]:02d}")
             dates.append((seqnum, date))
@@ -110,23 +111,30 @@ def _scan_ecl_keywords_w_dates(
     dataframe: bool = False,
 ) -> list[KeywordDateTuple] | pd.DataFrame:
     """Add a date column to the keyword"""
-    xkeys = _scan_ecl_keywords(pfile, maxkeys=maxkeys, dataframe=False)
-    assert isinstance(xkeys, list)
-    xdates = scan_dates(pfile, maxdates=MAXDATES, dataframe=False)
-    assert isinstance(xdates, list)
-
     result = []
-    # now merge these two:
-    nv = -1
     date = 0
-    for item in xkeys:
-        name, dtype, reclen, bytepos = item
-        if name == "SEQNUM":
-            nv += 1
-            date = xdates[nv][1]
+    seqnum_pos = None
+    for item in resfo.lazy_read(pfile.file):
+        name = item.read_keyword().strip()
+        dtype = item.read_type().strip()
+        reclen = item.read_length()
+        bytepos = item.stream.tell()
 
-        entry = (name, dtype, reclen, bytepos, date)
-        result.append(entry)
+        if name == "SEQNUM":
+            item.read_array()
+            seqnum_pos = len(result)
+            date = 0
+
+        if name == "INTEHEAD" and seqnum_pos is not None:
+            data = item.read_array()
+            # Index 66 = year, 65 = month, 64 = day
+            date = int(f"{data[66]}{data[65]:02d}{data[64]:02d}")
+            for index in range(seqnum_pos, len(result)):
+                prev_name, prev_type, prev_reclen, prev_bytepos, _ = result[index]
+                result[index] = (prev_name, prev_type, prev_reclen, prev_bytepos, date)
+            seqnum_pos = None
+
+        result.append((name, dtype, reclen, bytepos, date))
 
     return (
         pd.DataFrame.from_records(

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -5,12 +5,15 @@ import logging
 import pathlib
 
 import hypothesis.strategies as st
+import numpy as np
 import pytest
+import resfo
 from hypothesis import assume, given
 
 import xtgeo
 from xtgeo.common.exceptions import InvalidFileFormatError
-from xtgeo.grid3d import GridProperties, GridProperty
+from xtgeo.grid3d import GridProperties, GridProperty, _grid3d_utils as grid3d_utils
+from xtgeo.io._file import FileWrapper
 
 from .grid_generator import xtgeo_grids
 from .gridprop_generator import grid_properties as gridproperties_elements, keywords
@@ -186,6 +189,69 @@ def test_scan_dates_invalid_file(testdata_path):
     """Raise an error before trying to scan a non-existent file."""
     with pytest.raises(ValueError, match="does not exist"):
         GridProperties.scan_dates(testdata_path / pathlib.Path("notafile.UNRST"))
+
+
+def test_scan_dates_dataframe(testdata_path):
+    expected = GridProperties.scan_dates(testdata_path / RFILE1)
+    scan_df = GridProperties.scan_dates(testdata_path / RFILE1, dataframe=True)
+    assert scan_df.columns.tolist() == ["SEQNUM", "DATE"]
+    assert list(scan_df.itertuples(index=False, name=None)) == expected
+
+
+def test_scan_keywords_with_dates_matches_scan_dates(testdata_path):
+    scan_df = GridProperties.scan_dates(testdata_path / RFILE1, dataframe=True)
+    kw_df = grid3d_utils.scan_keywords(
+        FileWrapper(testdata_path / RFILE1),
+        fformat="xecl",
+        dataframe=True,
+        dates=True,
+    )
+    seqnum_dates = (
+        kw_df.loc[kw_df["KEYWORD"] == "SEQNUM", "DATE"].drop_duplicates().to_list()
+    )
+    assert seqnum_dates == scan_df["DATE"].to_list()
+
+
+def test_scan_dates_lgr_uses_first_intehead_per_seqnum():
+    def intehead_array(year, month, day):
+        arr = np.zeros(411, dtype=np.int32)
+        arr[64] = day
+        arr[65] = month
+        arr[66] = year
+        return arr
+
+    unrst = io.BytesIO()
+    resfo.write(
+        unrst,
+        [
+            ("HEAD    ", np.array([1], dtype=np.int32)),
+            ("SEQNUM  ", np.array([7], dtype=np.int32)),
+            ("PROPA   ", np.array([11], dtype=np.int32)),
+            ("INTEHEAD", intehead_array(2024, 1, 2)),
+            ("INTEHEAD", intehead_array(2024, 1, 9)),
+            ("PROPB   ", np.array([12], dtype=np.int32)),
+            ("SEQNUM  ", np.array([8], dtype=np.int32)),
+            ("PROPC   ", np.array([13], dtype=np.int32)),
+            ("INTEHEAD", intehead_array(2024, 1, 3)),
+            ("INTEHEAD", intehead_array(2024, 1, 8)),
+        ],
+    )
+    unrst.seek(0)
+    assert GridProperties.scan_dates(unrst) == [(7, 20240102), (8, 20240103)]
+
+    unrst.seek(0)
+    keywords = grid3d_utils.scan_keywords(
+        FileWrapper(unrst),
+        fformat="xecl",
+        dataframe=True,
+        dates=True,
+    )
+    assert keywords.loc[keywords["KEYWORD"] == "INTEHEAD", "DATE"].to_list() == [
+        20240102,
+        20240102,
+        20240103,
+        20240103,
+    ]
 
 
 def test_dates_from_restart(testdata_path):

--- a/tests/test_grid3d/test_gridprop_import_eclrun.py
+++ b/tests/test_grid3d/test_gridprop_import_eclrun.py
@@ -13,10 +13,12 @@ from hypothesis import HealthCheck, assume, given, settings
 
 import xtgeo
 import xtgeo.grid3d._find_gridprop_in_eclrun as xtg_im_ecl
+from xtgeo.grid3d import _grid3d_utils as grid3d_utils
 from xtgeo.grid3d._ecl_inte_head import InteHead
 from xtgeo.grid3d._ecl_logi_head import LogiHead
 from xtgeo.grid3d._ecl_output_file import Phases
 from xtgeo.grid3d._grdecl_format import match_keyword
+from xtgeo.io._file import FileWrapper
 
 from .grdecl_grid_generator import finites
 from .grid_generator import xtgeo_grids
@@ -49,6 +51,64 @@ def test_date_from_intehead():
     intehead.day = 31
 
     assert xtg_im_ecl.date_from_intehead(intehead) == 20011231
+
+
+def test_scan_ecl_keywords_w_dates_uses_first_intehead_after_seqnum():
+    def intehead_array(year, month, day):
+        arr = np.zeros(411, dtype=np.int32)
+        arr[64] = day
+        arr[65] = month
+        arr[66] = year
+        return arr
+
+    unrst = io.BytesIO()
+    resfo.write(
+        unrst,
+        [
+            ("HEAD    ", np.array([1], dtype=np.int32)),
+            ("SEQNUM  ", np.array([7], dtype=np.int32)),
+            ("PROPA   ", np.array([11], dtype=np.int32)),
+            ("INTEHEAD", intehead_array(2024, 1, 2)),
+            ("INTEHEAD", intehead_array(2024, 1, 9)),
+            ("PROPB   ", np.array([12], dtype=np.int32)),
+            ("SEQNUM  ", np.array([8], dtype=np.int32)),
+            ("PROPC   ", np.array([13], dtype=np.int32)),
+            ("INTEHEAD", intehead_array(2024, 1, 3)),
+            ("PROPD   ", np.array([14], dtype=np.int32)),
+        ],
+    )
+    unrst.seek(0)
+
+    keywords = grid3d_utils._scan_ecl_keywords_w_dates(
+        FileWrapper(unrst),
+        dataframe=False,
+    )
+
+    assert [kw[0] for kw in keywords] == [
+        "HEAD",
+        "SEQNUM",
+        "PROPA",
+        "INTEHEAD",
+        "INTEHEAD",
+        "PROPB",
+        "SEQNUM",
+        "PROPC",
+        "INTEHEAD",
+        "PROPD",
+    ]
+    assert [kw[-1] for kw in keywords] == [
+        0,
+        20240102,
+        20240102,
+        20240102,
+        20240102,
+        20240102,
+        20240103,
+        20240103,
+        20240103,
+        20240103,
+    ]
+    assert all(len(kw) == 5 for kw in keywords)
 
 
 @dataclass


### PR DESCRIPTION
Resolves #1622 

Improve performance when scanning date from restart file by skipping read unnecessary data.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
