### PR TITLE
CI: Add Codecov Test Analytics upload with JUnit report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,16 +185,24 @@ jobs:
         id: resinsight
         uses: './.github/actions/setup_resinsight'
 
-      - name: Generate coverage report
+      - name: Generate coverage and test results reports
         run: |
           ${{ steps.resinsight.outputs.install-path}}/bin/ResInsight --console --version
           export RESINSIGHT_EXECUTABLE="${{ steps.resinsight.outputs.install-path}}/bin/ResInsight"
-          uv run pytest -n 4 --dist=loadgroup tests --doctest-modules --generate-plots --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml
+          uv run pytest -n 4 --dist=loadgroup tests --doctest-modules --generate-plots --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml --junitxml=junit.xml -o junit_family=legacy
 
-      - name: Upload coverage to Codecov
+      - name: Upload test coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: xtgeocoverage.xml
+          disable_search: true
+      
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
 
   opm-integration:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,23 @@
+codecov:
+  strict_yaml_branch: default
+  notify:
+    wait_for_ci: true
+  require_ci_to_pass: true
+comment:
+  behavior: default
+  layout: reach,diff,flags,tree,reach
+  show_carryforward_flags: false
+coverage:
+  precision: 2
+  range:
+    - 70.0
+    - 90.0
+  round: down
+  status:
+    changes: false
+    default_rules:
+      flag_coverage_not_uploaded_behavior: include
+    patch: true
+    project: true
 fixes:
-    - "*/site-packages/xtgeo::src/xtgeo"
+  - "*/site-packages/xtgeo::src/xtgeo"


### PR DESCRIPTION
Resolves #1735 

This PR improves Codecov integration in CI by uploading both coverage and JUnit test results from the test workflow, enabling Codecov Test Analytics in addition to standard coverage reporting.

Changes included:

- Updated `test.yml` to generate junit.xml during pytest.
- Kept coverage upload and added an explicit test-results upload to Codecov from the same CI job.
- Expanded `codecov.yml` with stricter CI/notification and coverage status settings to make PR feedback and gating more consistent.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
