### PR TITLE
FIX: Remove dependency-groups as it caused failures in wheel build

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -36,7 +36,7 @@ install_and_test () {
 
 install_package () {
     pushd $CI_SOURCE_ROOT
-    pip install --group dev
+    pip install ".[dev]"
     popd
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,26 +91,6 @@ docs = [
     "sphinx-toolbox>=3.5.0",
 ]
 
-[dependency-groups]
-dev = [
-    "clang-format",
-    "cmake-format",
-    "coverage>=4.1",
-    "hypothesis",
-    "mypy",
-    "pandas-stubs",
-    "psutil",
-    "pydocstyle",
-    "pytest",
-    "pytest-benchmark",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-runner",
-    "pytest-snapshot",
-    "pytest-xdist",
-    "ruff",
-]
-
 [tool.scikit-build]
 cmake.version = "CMakeLists.txt"
 build.verbose = true


### PR DESCRIPTION
Reverting change in #1702 

Remove dependency-groups, introduced by change in #1702 as it is causing failures in wheel build. We need to sort out the build failures before we can implement this change.

This was already reverted in the release branch from the last release https://github.com/equinor/xtgeo/tree/version-4.24.x but we forgot to also revert this on main.

## Checklist

- [ ] Tests added (if not, comment why):
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
