### PR TITLE
Revert "FIX: Remove dependency-groups as it caused (...)"

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -36,7 +36,7 @@ install_and_test () {
 
 install_package () {
     pushd $CI_SOURCE_ROOT
-    pip install ".[dev]"
+    pip install --group dev
     popd
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,26 @@ docs = [
     "sphinx-toolbox>=3.5.0",
 ]
 
+[dependency-groups]
+dev = [
+    "clang-format",
+    "cmake-format",
+    "coverage>=4.1",
+    "hypothesis",
+    "mypy",
+    "pandas-stubs",
+    "psutil",
+    "pydocstyle",
+    "pytest",
+    "pytest-benchmark",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-runner",
+    "pytest-snapshot",
+    "pytest-xdist",
+    "ruff",
+]
+
 [tool.scikit-build]
 cmake.version = "CMakeLists.txt"
 build.verbose = true


### PR DESCRIPTION
Resolves #1702

Revert commit "FIX: Remove dependency-groups as it caused failures in wheel build (#1745)"
This reverts commit 278daebe4837fae6094eba6e213adaaba74142db.

Reverting commit as the wheel build issue introduced through #1702 in the first place no longer seems to be an issue. When the build issue is not an issue anymore we might as well just include the #1702 change. This means that #1702 is now resolved.

## Checklist

- [ ] Tests added (if not, comment why):
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
