### PR TITLE
CI: Improve Codecov uploads in the coverage job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,20 +189,62 @@ jobs:
         run: |
           ${{ steps.resinsight.outputs.install-path}}/bin/ResInsight --console --version
           export RESINSIGHT_EXECUTABLE="${{ steps.resinsight.outputs.install-path}}/bin/ResInsight"
-          uv run pytest -n 4 --dist=loadgroup tests --doctest-modules --generate-plots --disable-warnings --cov=xtgeo --cov-report=xml:xtgeocoverage.xml --junitxml=junit.xml -o junit_family=legacy
+          uv run pytest -n 4 --dist=loadgroup tests --doctest-modules --generate-plots --disable-warnings --durations=25 --cov=xtgeo --cov-report=xml:xtgeocoverage.xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload test coverage to Codecov
+        id: codecov-coverage
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: xtgeocoverage.xml
+          flags: unittests
           disable_search: true
-      
-      - name: Upload test results to Codecov
+          fail_ci_if_error: true
+
+      - name: Codecov retry sleep
+        if: ${{ steps.codecov-coverage.outcome == 'failure' }}
+        run: sleep 30
+
+      - name: Upload test coverage to Codecov (retry)
+        if: ${{ steps.codecov-coverage.outcome == 'failure' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: xtgeocoverage.xml
+          flags: unittests
+          disable_search: true
+          fail_ci_if_error: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Publish test summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2.6
+        with:
+          paths: junit.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           files: junit.xml
+          disable_search: true
+
+      - name: Test for a clean repository
+        run: |
+          # Remove things we have generated on purpose:
+          ls -la
+          rm -rf .coverage
+          rm -f xtgeocoverage.xml junit*.xml
+          rm -f codecov.SHA*
+          rm -f codecov
+          rm -f .coverage.*
+          git status --porcelain
+          test -z "$(git status --porcelain)"
 
   opm-integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Uploads were skipped whenever pytest failed, so failing PRs produced no coverage report and no test analytics — precisely when that data is most useful. Guard the upload steps with !cancelled() so they run regardless of the test outcome.

Also:
- Add report_type: test_results to the junit upload so it is routed to Codecov Test Analytics rather than parsed as a coverage report.
- Retry the coverage upload once after a 30s.
- Tag the coverage upload with a "unittests" flag so additional lanes can be added later without overwriting each other.
- Add a clean-repository check to catch tests that leak files into the working tree.
- Ignore the generated xtgeocoverage.xml and junit.xml.

Fixed Test Analytics
https://app.codecov.io/gh/equinor/xtgeo/tests/AdilKhurshid%2Fxtgeo%3Acodecov 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
