### PR TITLE
DOC:Update examples for outside RMS access

### DIFF
--- a/docs/tutorial/examples_rms.rst
+++ b/docs/tutorial/examples_rms.rst
@@ -41,8 +41,35 @@ Inside RMS GUI
 
     # Note: project save needs to be done by user (GUI action)
 
-Outside RMS, direct access
+Outside RMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+To use the RMS Python API outside the RMS application, first create and activate
+an ``rmsvenv``. The following commands create an environment for the default RMS
+version configured by `runrms <https://github.com/equinor/runrms>`_:
+
+.. code-block:: bash
+
+    rmsvenv
+    source rmsvenv/enable
+
+Once the environment is active, you can install packages with ``pip``, use
+``rmsapi`` to access RMS data, and open the ``rms`` application.
+
+Each ``rmsvenv`` is tied to a single RMS version. To use another RMS version,
+create a separate environment and specify a version configured by ``runrms``:
+
+.. code-block:: bash
+
+    rmsvenv -v 14.5.0
+
+You can also install your own XTGeo feature branches in the environment. Using
+a separate ``rmsvenv`` for each feature branch is recommended to avoid dependency
+conflicts.
+
+After creating and activating the ``rmsvenv``, the next step is to access an RMS
+project. Run your Python code from the activated environment and provide the RMS
+project file path, as shown below:
+
 .. code-block:: python
 
     import xtgeo
@@ -53,27 +80,14 @@ Outside RMS, direct access
     surf.values += 100
     surf.to_roxar(myproject)
 
-    # Note: project save is done automatic
+    # Note: project save is done automatically
 
-Outside RMS, project mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code-block:: python
+When you have finished working with RMS, deactivate the environment in the same
+way as a standard Python virtual environment:
 
-    import xtgeo
+.. code-block:: bash
 
-    myproject = "/some/file/path/reek.rms11.1.1"
-    rox = xtgeo.RoxUtils(myproject)
-
-    surf = xtgeo.surface_from_roxar(rox.project, "TopReek", "DS_extracted")
-    surf.values += 100
-    surf.to_roxar(rox.project)
-
-    # Note: project save is not done automatic, you need to:
-
-    rox.project.save()
-    rox.project.close()
-
-
+    deactivate
 
 Surface data
 ------------

--- a/docs/tutorial/examples_rms.rst
+++ b/docs/tutorial/examples_rms.rst
@@ -43,32 +43,12 @@ Inside RMS GUI
 
 Outside RMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-To use the RMS Python API outside the RMS application, first create and activate
-an ``rmsvenv``. The following commands create an environment for the default RMS
-version configured by `runrms <https://github.com/equinor/runrms>`_:
+To use the RMS Python API outside the RMS application, ``rmsapi`` must be
+installed in the Python environment. FMU users can use
+`rmsvenv <https://github.com/equinor/rmsvenv>`_ to create a suitable environment.
 
-.. code-block:: bash
-
-    rmsvenv
-    source rmsvenv/enable
-
-Once the environment is active, you can install packages with ``pip``, use
-``rmsapi`` to access RMS data, and open the ``rms`` application.
-
-Each ``rmsvenv`` is tied to a single RMS version. To use another RMS version,
-create a separate environment and specify a version configured by ``runrms``:
-
-.. code-block:: bash
-
-    rmsvenv -v 14.5.0
-
-You can also install your own XTGeo feature branches in the environment. Using
-a separate ``rmsvenv`` for each feature branch is recommended to avoid dependency
-conflicts.
-
-After creating and activating the ``rmsvenv``, the next step is to access an RMS
-project. Run your Python code from the activated environment and provide the RMS
-project file path, as shown below:
+Run your Python code from the environment and provide the RMS project file path,
+as shown below:
 
 .. code-block:: python
 
@@ -81,13 +61,6 @@ project file path, as shown below:
     surf.to_roxar(myproject)
 
     # Note: project save is done automatically
-
-When you have finished working with RMS, deactivate the environment in the same
-way as a standard Python virtual environment:
-
-.. code-block:: bash
-
-    deactivate
 
 Surface data
 ------------


### PR DESCRIPTION
Resolves #1579 

- Updated the RMS tutorial for running XTGeo outside the RMS application. 
- Added instructions for creating, activating, versioning, and deactivating an rmsvenv, clarifies project access and automatic saving, and removes the outdated RoxUtils project-mode example.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
