### PR TITLE
CLN: Remove unused MAXDATES constant

### DIFF
--- a/src/lib/include/xtgeo/xtgeo.h
+++ b/src/lib/include/xtgeo/xtgeo.h
@@ -87,9 +87,8 @@ extern "C"
 #define UNDEF_ECLINT 0
 #define UNDEF_ECLFLOAT 0
 
-/* eclipse and roff binary read max keywords and dates */
+/* eclipse and roff binary read max keywords */
 #define MAXKEYWORDS 1000000
-#define MAXDATES 1000
 
     /*
      *======================================================================================

--- a/src/xtgeo/common/constants.py
+++ b/src/xtgeo/common/constants.py
@@ -19,7 +19,6 @@ UNDEF_MAP_IRAPB = 1e30
 UNDEF_MAP_IRAPA = 9999900.0000
 
 MAXKEYWORDS = _cxtgeo.MAXKEYWORDS  # maximum keywords for ECL and ROFF scanning
-MAXDATES = _cxtgeo.MAXDATES  # maximum keywords for ECL scanning
 
 # for XYZ data, restricted to float32 and int32
 UNDEF_CONT = UNDEF

--- a/src/xtgeo/grid3d/_grid3d_utils.py
+++ b/src/xtgeo/grid3d/_grid3d_utils.py
@@ -10,7 +10,7 @@ import resfo
 import roffio
 
 from xtgeo.common import null_logger
-from xtgeo.common.constants import MAXDATES, MAXKEYWORDS
+from xtgeo.common.constants import MAXKEYWORDS
 
 if TYPE_CHECKING:
     from xtgeo.io._file import FileWrapper
@@ -46,7 +46,6 @@ def scan_keywords(
 
 def scan_dates(
     pfile: FileWrapper,
-    maxdates: int = MAXDATES,
     dataframe: bool = False,
 ) -> list | pd.DataFrame:
     """Quick scan dates in a simulation restart file.

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from xtgeo.common import XTGDescription, XTGeoDialog, null_logger
-from xtgeo.common.constants import MAXDATES, MAXKEYWORDS
+from xtgeo.common.constants import MAXKEYWORDS
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.io._file import FileFormat, FileWrapper
 
@@ -655,7 +655,7 @@ class GridProperties(_Grid3D):
     def scan_dates(
         pfile: FileLike,
         fformat: Literal["unrst"] = "unrst",
-        maxdates: int = MAXDATES,
+        maxdates: int | None = None,
         dataframe: bool = False,
         datesonly: bool = False,
     ) -> list | pd.DataFrame:
@@ -664,7 +664,7 @@ class GridProperties(_Grid3D):
         Args:
             pfile (str): Name of file or file handle with properties
             fformat (str): unrst (so far)
-            maxdates (int): Maximum number of dates to collect
+            maxdates (int | None): Ignored; retained for backwards compatibility
             dataframe (bool): If True, return a Pandas dataframe instead
             datesonly (bool): If True, SEQNUM is skipped,
 
@@ -687,7 +687,7 @@ class GridProperties(_Grid3D):
         _pfile = FileWrapper(pfile)
         _pfile.check_file(raiseerror=ValueError)
 
-        dlist = utils.scan_dates(_pfile, maxdates=maxdates, dataframe=dataframe)
+        dlist = utils.scan_dates(_pfile, dataframe=dataframe)
 
         if datesonly and dataframe:
             assert isinstance(dlist, pd.DataFrame)

--- a/tests/test_grid3d/test_grid_properties.py
+++ b/tests/test_grid3d/test_grid_properties.py
@@ -11,6 +11,7 @@ import resfo
 from hypothesis import assume, given
 
 import xtgeo
+from xtgeo.common import constants
 from xtgeo.common.exceptions import InvalidFileFormatError
 from xtgeo.grid3d import GridProperties, GridProperty, _grid3d_utils as grid3d_utils
 from xtgeo.io._file import FileWrapper
@@ -183,6 +184,13 @@ def test_scan_dates(testdata_path):
         (34, 19920505),
         (35, 19920619),
     ]
+    assert GridProperties.scan_dates(testdata_path / RFILE1, maxdates=1) == (
+        GridProperties.scan_dates(testdata_path / RFILE1)
+    )
+
+
+def test_maxdates_constant_is_removed():
+    assert not hasattr(constants, "MAXDATES")
 
 
 def test_scan_dates_invalid_file(testdata_path):


### PR DESCRIPTION
Resolves #1734 

Remove unused MAXDATES constant but preserve the public API for backward compatibility


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
