### PR TITLE
DOC: Add missing documentation and update broken cross-references

### DIFF
--- a/docs/api-grids.rst
+++ b/docs/api-grids.rst
@@ -19,6 +19,8 @@ Functions
 
 .. autofunction:: xtgeo.grid_from_surfaces
 
+.. autofunction:: xtgeo.grid_merge
+
 Classes
 """""""
 
@@ -38,6 +40,8 @@ Functions
 
 .. autofunction:: xtgeo.gridproperty_from_resinsight
 
+.. autofunction:: xtgeo.gridproperty_from_cube
+
 Classes
 """""""
 
@@ -48,9 +52,29 @@ Classes
 Grid properties (multiple)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Functions
+"""""""""
+
+.. autofunction:: xtgeo.gridproperties_from_file
+
+.. autofunction:: xtgeo.gridproperties_dataframe
+
+.. autofunction:: xtgeo.list_gridproperties
+
 Classes
 """""""
 
 .. autoclass:: xtgeo.GridProperties
 
     .. autoclasstoc::
+
+Grid enumerations
+^^^^^^^^^^^^^^^^^
+
+.. autoclass:: xtgeo.GridRelative
+    :members:
+    :undoc-members:
+
+.. autoclass:: xtgeo.Units
+    :members:
+    :undoc-members:

--- a/docs/api-other.rst
+++ b/docs/api-other.rst
@@ -1,6 +1,34 @@
 Other APIs
 ----------
 
+Common utilities
+^^^^^^^^^^^^^^^^
+
+The :mod:`xtgeo.common` module provides shared utilities. Its
+underscore-prefixed enums are re-exported for internal use across XTGeo
+modules only, and are therefore not documented here.
+
+.. autofunction:: xtgeo.common.null_logger
+
+XTGDescription
+""""""""""""""
+
+.. autoclass:: xtgeo.common.XTGDescription
+
+    .. autoclasstoc::
+
+XTGShowProgress
+"""""""""""""""
+
+.. autoclass:: xtgeo.common.XTGShowProgress
+
+    .. autoclasstoc::
+
+Utilities
+^^^^^^^^^
+
+.. autofunction:: xtgeo.generic_hash
+
 Roxar utilities
 ^^^^^^^^^^^^^^^
 
@@ -46,5 +74,54 @@ MetaDataWell
 """"""""""""
 
 .. autoclass:: xtgeo.MetaDataWell
+
+    .. autoclasstoc::
+
+MetaDataTriangulatedSurface
+"""""""""""""""""""""""""""
+
+.. autoclass:: xtgeo.MetaDataTriangulatedSurface
+
+    .. autoclasstoc::
+
+Constants
+^^^^^^^^^
+
+XTGeo uses the following values to represent undefined (masked) nodes.
+
+.. autodata:: xtgeo.UNDEF
+
+.. autodata:: xtgeo.UNDEF_LIMIT
+
+.. autodata:: xtgeo.UNDEF_INT
+
+.. autodata:: xtgeo.UNDEF_INT_LIMIT
+
+Exceptions
+^^^^^^^^^^
+
+.. autoexception:: xtgeo.BlockedWellsNotFoundError
+
+.. autoexception:: xtgeo.DateNotFoundError
+
+.. autoexception:: xtgeo.GridNotFoundError
+
+.. autoexception:: xtgeo.InvalidFileFormatError
+
+.. autoexception:: xtgeo.KeywordFoundNoDateError
+
+.. autoexception:: xtgeo.KeywordNotFoundError
+
+.. autoexception:: xtgeo.WellNotFoundError
+
+.. autoexception:: xtgeo.XTGeoCLibError
+
+Messaging
+^^^^^^^^^
+
+XTGeoDialog
+"""""""""""
+
+.. autoclass:: xtgeo.XTGeoDialog
 
     .. autoclasstoc::

--- a/docs/api-surface.rst
+++ b/docs/api-surface.rst
@@ -16,12 +16,29 @@ Functions
 
 .. autofunction:: xtgeo.surface_from_roxar
 
+.. autofunction:: xtgeo.surface_from_rms
+
 .. autofunction:: xtgeo.create_synthetic_surface
 
 Classes
 """""""
 
 .. autoclass:: xtgeo.RegularSurface
+
+    .. autoclasstoc::
+
+TriangulatedSurface
+^^^^^^^^^^^^^^^^^^^
+
+Functions
+"""""""""
+
+.. autofunction:: xtgeo.triangulated_surface_from_file
+
+Classes
+"""""""
+
+.. autoclass:: xtgeo.TriangulatedSurface
 
     .. autoclasstoc::
 

--- a/src/xtgeo/__init__.py
+++ b/src/xtgeo/__init__.py
@@ -53,6 +53,7 @@ from xtgeo.common.exceptions import (
     KeywordNotFoundError,
     WellNotFoundError,
 )
+from xtgeo.common.sys import generic_hash
 
 _xprint("Import common... done")
 
@@ -96,6 +97,7 @@ from xtgeo.xyz.points import (
 
 _xprint("Import various XTGeo modules... wells...")
 
+from xtgeo.grid3d import grid, grid_properties, grid_property
 from xtgeo.grid3d._ecl_grid import GridRelative, Units
 from xtgeo.grid3d.grid import Grid
 from xtgeo.grid3d.grid_properties import (
@@ -181,7 +183,6 @@ __all__ = [
     "GridProperties",
     "GridProperty",
     "GridRelative",
-    "GridRelative",
     "InvalidFileFormatError",
     "KeywordFoundNoDateError",
     "KeywordNotFoundError",
@@ -194,14 +195,13 @@ __all__ = [
     "Points",
     "Polygons",
     "RegularSurface",
-    "TriangulatedSurface",
     "RoxUtils",
     "Surfaces",
+    "TriangulatedSurface",
     "UNDEF",
     "UNDEF_INT",
     "UNDEF_INT_LIMIT",
     "UNDEF_LIMIT",
-    "Units",
     "Units",
     "Well",
     "WellNotFoundError",
@@ -221,7 +221,7 @@ __all__ = [
     "cube1",
     "cube_from_file",
     "cube_from_roxar",
-    "grid",
+    "generic_hash",
     "grid",
     "grid_from_cube",
     "grid_from_file",
@@ -230,8 +230,6 @@ __all__ = [
     "grid_from_surfaces",
     "grid_merge",
     "grid_properties",
-    "grid_properties",
-    "grid_property",
     "grid_property",
     "gridproperties_dataframe",
     "gridproperties_from_file",

--- a/src/xtgeo/common/log.py
+++ b/src/xtgeo/common/log.py
@@ -24,7 +24,8 @@ def null_logger(name: str) -> logging.Logger:
     Returns:
         logging.Logger: A logger object configured with a NullHandler.
 
-    Example:
+    Examples::
+
         # In a library module
         logger = null_logger(__name__)
         logger.info("This info won't be logged to the console by default.")

--- a/src/xtgeo/common/sys.py
+++ b/src/xtgeo/common/sys.py
@@ -71,16 +71,16 @@ def generic_hash(
     This hash can e.g. be used to compare two instances for equality.
 
     Args:
-        gid: Any string as signature, e.g. cumulative attributes of an instance.
+        gid: String to hash, e.g. cumulative attributes of an instance.
         hashmethod: Supported methods are "md5", "sha256", "blake2b"
-            or use a full function signature e.g. hashlib.sha128.
+            or a hash constructor such as ``hashlib.sha256``.
             Defaults to md5.
 
     Returns:
         Hash signature.
 
     Raises:
-        KeyError: String in hashmethod has an invalid option
+        ValueError: The hashmethod is not a valid option
 
     .. versionadded:: 2.14
 

--- a/src/xtgeo/cube/cube1.py
+++ b/src/xtgeo/cube/cube1.py
@@ -60,7 +60,9 @@ def cube_from_file(
 
     Args:
         mfile (str): Name of file
-        fformat (str): See :meth:`Cube.from_file`
+        fformat (str): File format, one of 'segy', 'storm' or 'xtg'. If 'guess'
+            (default), the format is detected from the file extension or the
+            file signature.
         iline (Literal[189, 193]): Byte position of the inline number field in
             each trace header. Default is 189 (SEGY standard). Only 189 and 193
             are valid; use ``iline=193, xline=189`` for files with non-standard
@@ -401,7 +403,7 @@ class Cube:
     def generate_hash(self, hashmethod="md5"):
         """Return a unique hash ID for current instance.
 
-        See :meth:`~xtgeo.common.sys.generic_hash()` for documentation.
+        See :func:`xtgeo.generic_hash` for available hash methods.
 
         .. versionadded:: 2.14
         """

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -169,12 +169,14 @@ def grid_from_file(
             special value "all" can be get all properties found in the INIT file
         restartprops (str list): Optional, see initprops
         restartdates (int list): Optional, required if restartprops
-        ijkrange (list-like): Optional, only applicable for hdf files, see
-            :meth:`Grid.from_hdf`.
-        zerobased (bool): Optional, only applicable for hdf files, see
-            :meth:`Grid.from_hdf`.
-        mmap (bool): Optional, only applicable for xtgf files, see
-            :meth:`Grid.from_xtgf`.
+        ijkrange (list-like): Optional, only applicable for hdf files. A 6-item
+            sequence (i1, i2, j1, j2, k1, k2) limiting the import to a subgrid
+            range. The items "min" and "max" are accepted as open bounds.
+        zerobased (bool): Optional, only applicable for hdf files. If True, the
+            ``ijkrange`` indices are interpreted as zero-based; default is False,
+            i.e. one-based indexing.
+        mmap (bool): Optional, only applicable for xtgf files. If True, memory
+            mapping is used when reading the file.
 
     Example::
 
@@ -1138,7 +1140,7 @@ class Grid(_Grid3D):
     ) -> str:
         """Return a unique hash ID for current instance (for persistance).
 
-        See :meth:`~xtgeo.common.sys.generic_hash()` for documentation.
+        See :func:`xtgeo.generic_hash` for available hash methods.
 
         .. versionadded:: 2.14
         """
@@ -1898,8 +1900,8 @@ class Grid(_Grid3D):
                 of points in the polygons, where tolerance is 0.1. Another
                 alternative to True is to input a Dict on the form
                 ``{"tolerance": 2.0, "preserve_topology": True}``, cf. the
-                :func:`Polygons.simplify()` method. For details on e.g. tolerance, see
-                Shapely's simplify() method.
+                :meth:`xtgeo.Polygons.simplify()` method. For details on e.g.
+                tolerance, see Shapely's simplify() method.
             filter_array: An numpy boolean array with equal shape as the grid dimension,
                 used to filter the grid cells and define where to extract boundaries.
 
@@ -1915,7 +1917,7 @@ class Grid(_Grid3D):
             boundary = grid.get_boundary_polygons(filter_array=filter_array)
 
         See also:
-            The :func:`Polygons.boundary_from_points()` class method.
+            The :meth:`xtgeo.Polygons.boundary_from_points()` class method.
 
         """
         return _grid_boundary.create_boundary(
@@ -2343,7 +2345,7 @@ class Grid(_Grid3D):
         When *nnc_table* is supplied the method additionally computes
         transmissibilities across the boundary of a nested hybrid grid.  The
         table is produced by
-        :func:`fmu.tools.nestedhybridgrid.create_nested_hybrid_grid` and
+        ``fmu.tools.nestedhybridgrid.create_nested_hybrid_grid`` and
         encodes every mother ↔ refined cell pair that should be connected.
 
         Args:

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -221,8 +221,8 @@ def gridproperty_from_resinsight(
             Since case names are not unique in ResInsight, passing a case object
             avoids the ambiguity that name-based lookup can introduce.
         property_name: Name of the property (e.g. ``"PORO"``, ``"PRESSURE"``).
-        property_type: A :class:`~xtgeo.interfaces.resinsight.PropertyType`
-            member or a plain string such as ``"STATIC_NATIVE"``,
+        property_type: A ``PropertyType`` member or a plain string such as
+            ``"STATIC_NATIVE"``,
             ``"DYNAMIC_NATIVE"``, ``"GENERATED"``, or ``"INPUT_PROPERTY"``.
             Strings are validated and coerced to the enum internally.
         time_step_index: Time step index (default 0).
@@ -237,7 +237,7 @@ def gridproperty_from_resinsight(
         RuntimeError: If rips is unavailable/too old, or if the case/property
             cannot be read.
         ValueError: If *property_type* is not a valid
-            :class:`~xtgeo.interfaces.resinsight.PropertyType`.
+            ``PropertyType``.
 
     Example::
 
@@ -1051,9 +1051,8 @@ class GridProperty(_Grid3D):
                 object. Since case names are not unique in ResInsight, passing a
                 case object avoids the ambiguity that name-based lookup can
                 introduce.
-            property_type: A
-                :class:`~xtgeo.interfaces.resinsight.PropertyType`
-                member or a plain string such as ``"GENERATED"``.
+            property_type: A ``PropertyType`` member or a plain string such as
+                ``"GENERATED"``.
                 Strings are validated and coerced to the enum internally.
             property_name: Name to give the property in ResInsight. If ``None``,
                 the current :attr:`name` is used.
@@ -1069,7 +1068,7 @@ class GridProperty(_Grid3D):
             RuntimeError: If rips is unavailable/too old, or if the
                 case/property cannot be written.
             ValueError: If *property_type* is not a valid
-                :class:`~xtgeo.interfaces.resinsight.PropertyType`.
+                ``PropertyType``.
 
         Example::
 

--- a/src/xtgeo/metadata/metadata.py
+++ b/src/xtgeo/metadata/metadata.py
@@ -448,11 +448,12 @@ class MetaDataTriangulatedSurface(MetaData):
             metadata: The metadata instance to validate.
             equal_values:
                 If True, check that the values in required_metadata equal
-                    the values in metadata._required.
-                If False, only basic tests are performed
+                the values in metadata._required.
+                If False, only basic tests are performed.
 
-        Returns:
-            True if all required fields match.
+        Raises:
+            TypeError: If the input types are wrong.
+            ValueError: If the required metadata do not validate.
         """
 
         if not isinstance(required_metadata, dict):

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -1019,7 +1019,7 @@ class RegularSurface:
     def generate_hash(self, hashmethod="md5"):
         """Return a unique hash ID for current instance.
 
-        See :meth:`~xtgeo.common.sys.generic_hash()` for documentation.
+        See :func:`xtgeo.generic_hash` for available hash methods.
 
         .. versionadded:: 2.14
         """
@@ -1181,7 +1181,7 @@ class RegularSurface:
 
         Note, for zmap_ascii and storm_binary an unrotation will be done
         automatically. The sampling will be somewhat finer than the
-        original map in order to prevent aliasing. See :func:`unrotate`.
+        original map in order to prevent aliasing. See :meth:`unrotate`.
 
         Args:
             mfile: Name of file,
@@ -2952,8 +2952,8 @@ class RegularSurface:
                 of points in the polygons, where tolerance is 0.1. Another
                 alternative to True is to input a Dict on the form
                 ``{"tolerance": 2.0, "preserve_topology": True}``, cf. the
-                :func:`Polygons.simplify()` method. For details on e.g. tolerance, see
-                Shapely's simplify() method.
+                :meth:`xtgeo.Polygons.simplify()` method. For details on e.g.
+                tolerance, see Shapely's simplify() method.
 
         Returns:
             A XTGeo Polygons instance
@@ -2969,7 +2969,7 @@ class RegularSurface:
             boundary.filter_byid([0])  # polygon is updated in-place
 
         See also:
-            The :func:`Polygons.boundary_from_points()` class method.
+            The :meth:`xtgeo.Polygons.boundary_from_points()` class method.
 
         .. versionadded:: 3.1
         """

--- a/src/xtgeo/surface/triangulated_surface.py
+++ b/src/xtgeo/surface/triangulated_surface.py
@@ -512,7 +512,7 @@ class TriangulatedSurface:
     ) -> str:
         """Return a unique hash ID for current instance.
 
-        See :meth:`~xtgeo.common.sys.generic_hash()` for documentation.
+        See :func:`xtgeo.generic_hash` for available hash methods.
 
         """
 

--- a/src/xtgeo/well/blocked_well.py
+++ b/src/xtgeo/well/blocked_well.py
@@ -34,9 +34,10 @@ def blockedwell_from_file(
         bwfile (str): Name of file
         fformat (str): File format: rms_ascii, csv, hdf5.
             If None (default), auto-detect from file extension or file signature.
-        mdlogname (str): See :meth:`Well.from_file`
-        zonelogname (str): See :meth:`Well.from_file`
-        strict (bool): See :meth:`Well.from_file`
+        mdlogname (str): Name of measured depth log, if any.
+        zonelogname (str): Name of zone log, if any.
+        strict (bool): If True, then import will fail if zonelogname or
+            mdlogname are asked for but not present in the file.
         lognames: Name or list of lognames to import, default is "all"
         lognames_strict: If True, require all logs in lognames to be present
 
@@ -62,7 +63,14 @@ def blockedwell_from_roxar(
 ):
     """This makes an instance of a BlockedWell directly from Roxar RMS.
 
-    For arguments, see :meth:`BlockedWell.from_roxar`.
+    Args:
+        project: Name of RMS project, or use the magic ``project`` variable in RMS.
+        gname: Name of the grid model.
+        bwname: Name of the blocked well set.
+        wname: Name of the well.
+        lognames: List of lognames to import, or "all" for all present logs.
+        ijk: If True, import the IJK logs as well.
+        realisation: Realisation index, default is 0 (first).
 
     Example::
 
@@ -277,6 +285,16 @@ class BlockedWell(Well):
             raise ValueError("Input name is not a string.")
 
     def copy(self):
+        """Return a copy of the instance.
+
+        The copy is delegated to :meth:`xtgeo.Well.copy`, so the returned
+        object is a plain :class:`xtgeo.Well`. The ``gridname`` value is
+        carried over, but only as the private ``_gridname`` attribute, which
+        is not exposed as a property on :class:`xtgeo.Well`.
+
+        Returns:
+            A new :class:`xtgeo.Well` instance.
+        """
         newbw = super().copy()
 
         newbw._gridname = self._gridname

--- a/src/xtgeo/well/blocked_wells.py
+++ b/src/xtgeo/well/blocked_wells.py
@@ -114,7 +114,12 @@ def blockedwells_from_roxar(
 ):  # pragma: no cover
     """This makes an instance of a BlockedWells directly from Roxar RMS.
 
-    For arguments, see :meth:`BlockedWells.from_roxar`.
+    Args:
+        project: Name of RMS project, or use the magic ``project`` variable in RMS.
+        gname: Name of the grid model.
+        bwname: Name of the blocked well set.
+        lognames: List of lognames to import, or "all" for all present logs.
+        ijk: If True, import the IJK logs as well.
 
     Note the difference between classes BlockedWell and BlockedWells.
 

--- a/src/xtgeo/xyz/_xyz.py
+++ b/src/xtgeo/xyz/_xyz.py
@@ -304,7 +304,7 @@ class XYZ(ABC):
             (xmin, xmax, ymin, ymax, zmin, zmax)
 
         See also:
-            The class method :func:`Polygons.boundary_from_points()`
+            The class method :meth:`xtgeo.Polygons.boundary_from_points()`
 
         """
         df = self.get_dataframe(copy=False)
@@ -432,7 +432,7 @@ class XYZ(ABC):
             value: Value to add to Z values inside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`add_inside polygons()`.
+        :meth:`add_inside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="add", inside=True, version=0)
 
@@ -463,7 +463,7 @@ class XYZ(ABC):
             value: Value to add to Z values outside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`add_outside polygons()`.
+        :meth:`add_outside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="add", inside=False, version=0)
 
@@ -494,7 +494,7 @@ class XYZ(ABC):
             value: Value to subtract to Z values inside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`sub_inside polygons()`.
+        :meth:`sub_inside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="sub", inside=True, version=1)
 
@@ -525,7 +525,7 @@ class XYZ(ABC):
             value: Value to subtract to Z values outside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`sub_outside polygons()`.
+        :meth:`sub_outside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="sub", inside=False, version=0)
 
@@ -556,7 +556,7 @@ class XYZ(ABC):
             value: Value to multiply to Z values inside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`mul_inside polygons()`.
+        :meth:`mul_inside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="mul", inside=True, version=0)
 
@@ -587,7 +587,7 @@ class XYZ(ABC):
             value: Value to multiply to Z values outside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`mul_outside polygons()`.
+        :meth:`mul_outside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="mul", inside=False, version=0)
 
@@ -618,7 +618,7 @@ class XYZ(ABC):
             value: Value to divide Z values inside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`div_inside polygons()`.
+        :meth:`div_inside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="div", inside=True, version=0)
 
@@ -649,7 +649,7 @@ class XYZ(ABC):
             value: Value to divide Z values outside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`div_outside polygons()`.
+        :meth:`div_outside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="div", inside=False, version=0)
 
@@ -682,7 +682,7 @@ class XYZ(ABC):
             value: Value to set Z values inside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`set_inside polygons()`.
+        :meth:`set_inside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="set", inside=True, version=0)
 
@@ -713,7 +713,7 @@ class XYZ(ABC):
             value: Value to set Z values outside polygons.
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`set_outside polygons()`.
+        :meth:`set_outside_polygons()`.
         """
         self.operation_polygons(poly, value, opname="set", inside=False, version=0)
 
@@ -743,7 +743,7 @@ class XYZ(ABC):
             poly: A xtgeo Polygons instance
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`eli_inside polygons()`.
+        :meth:`eli_inside_polygons()`.
         """
         self.operation_polygons(poly, 0, opname="eli", inside=True, version=0)
 
@@ -768,7 +768,7 @@ class XYZ(ABC):
             poly: A xtgeo Polygons instance
 
         See notes under :meth:`operation_polygons()` and consider instead
-        :meth:`eli_outside polygons()`.
+        :meth:`eli_outside_polygons()`.
         """
         self.operation_polygons(poly, 0, opname="eli", inside=False, version=0)
 

--- a/src/xtgeo/xyz/points.py
+++ b/src/xtgeo/xyz/points.py
@@ -373,7 +373,7 @@ def _generate_docstring_points(xname: str, yname: str, zname: str) -> str:
     return f"""
     Class for Points data in XTGeo.
 
-    The Points class is a subclass of the :py:class:`~xtgeo.xyz._xyz.XYZ` abstract
+    The Points class is a subclass of the common ``XYZ`` abstract
     class, and the point set itself is a `pandas <http://pandas.pydata.org>`_
     dataframe object.
 
@@ -540,6 +540,15 @@ class Points(XYZ):
         return self._df.copy() if copy else self._df
 
     def set_dataframe(self, df: pd.DataFrame) -> None:
+        """Set the points dataframe, replacing any existing data.
+
+        The input dataframe is copied, so later changes to ``df`` itself will
+        not affect this instance. Note that Python objects stored in
+        object-dtype cells are not recursively cloned.
+
+        Args:
+            df: Dataframe holding at least the mandatory X, Y and Z columns.
+        """
         self._df = df.apply(deepcopy)
 
     def _random(self, nrandom: int = 10) -> None:

--- a/src/xtgeo/xyz/polygons.py
+++ b/src/xtgeo/xyz/polygons.py
@@ -134,7 +134,7 @@ def polygons_from_file(pfile: FileLike, fformat: str | None = "guess") -> Polygo
 
     Args:
         pfile (str): Name of file
-        fformat (str): See :meth:`Polygons.from_file`
+        fformat (str): One of the formats listed above. Default is 'guess'.
 
     Example::
 
@@ -352,6 +352,10 @@ class Polygons(XYZ):
 
     @property
     def pname(self) -> str:
+        """Name of the mandatory polygon ID column.
+
+        Setting this renames the column in the underlying dataframe.
+        """
         return self._pname
 
     @pname.setter
@@ -446,6 +450,18 @@ class Polygons(XYZ):
         return self._df.copy() if copy else self._df
 
     def set_dataframe(self, df: pd.DataFrame) -> None:
+        """Set the polygons dataframe, replacing any existing data.
+
+        The input dataframe is copied, so later changes to ``df`` itself will
+        not affect this instance; note that Python objects stored in
+        object-dtype cells are not recursively cloned. Optional attribute
+        names (``dtname``, ``dhname``, ``tname``, ``hname``) are reset to None
+        if the corresponding columns are absent.
+
+        Args:
+            df: Dataframe holding at least the mandatory X, Y, Z and
+                polygon ID columns.
+        """
         self._df = df.apply(deepcopy)
         self._name_to_none_if_missing()
 

--- a/tests/test_common/test_sys.py
+++ b/tests/test_common/test_sys.py
@@ -2,7 +2,14 @@ import hashlib
 
 import pytest
 
+import xtgeo
 from xtgeo.common.sys import generic_hash
+
+
+def test_generic_hash_is_exported():
+    """The generic_hash function shall be available as a top level API."""
+    assert "generic_hash" in xtgeo.__all__
+    assert xtgeo.generic_hash is generic_hash
 
 
 def test_generic_hash():


### PR DESCRIPTION
Close #1046 

Improving XTGeo documentations:
- Add missing public functions
- Fix broken cross-reference that point to public API removed in XTGeo 4.0

No tests added since it's only documentation and docstring changes.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
