### PR TITLE
ENH: Expose RMS ASCII precision to public API and default to 8

### DIFF
--- a/src/xtgeo/io/_welldata/_blockedwell_io.py
+++ b/src/xtgeo/io/_welldata/_blockedwell_io.py
@@ -166,9 +166,14 @@ class BlockedWellData(WellData):
     def to_rms_ascii(
         self,
         filepath: FileLike,
-        precision: int = 4,
+        precision: int = 8,
     ) -> None:
-        """Write blocked well data to RMS ASCII file."""
+        """Write blocked well data to RMS ASCII file.
+
+        Args:
+            filepath: Output RMS ASCII file path or stream.
+            precision: Number of decimal places for floats (default: 8).
+        """
         from xtgeo.io._welldata._fformats._rms_ascii import write_rms_ascii_blockedwell
 
         write_rms_ascii_blockedwell(

--- a/src/xtgeo/io/_welldata/_fformats/_rms_ascii.py
+++ b/src/xtgeo/io/_welldata/_fformats/_rms_ascii.py
@@ -315,14 +315,14 @@ def _write_rms_ascii_header(
 def write_rms_ascii_well(
     well: WellData,
     filepath: FileLike,
-    precision: int = 4,
+    precision: int = 8,
 ) -> None:
     """Write well data to RMS ASCII file or stream.
 
     Args:
         well: WellData object to write
         filepath: Output RMS ASCII file path or a file-like stream object
-        precision: Number of decimal places for floats (default: 4)
+        precision: Number of decimal places for floats (default: 8)
 
     """
     wrapper = FileWrapper(filepath, mode="w")
@@ -344,7 +344,7 @@ def write_rms_ascii_well(
 def _write_rms_ascii_data(
     fwell_write: TextIO,
     well: WellData,
-    precision: int = 4,
+    precision: int = 8,
 ) -> None:
     """Write RMS ASCII data section to open file handle.
 
@@ -441,14 +441,14 @@ def read_rms_ascii_blockedwell(
 def write_rms_ascii_blockedwell(
     blocked_well: BlockedWellData,
     filepath: FileLike,
-    precision: int = 4,
+    precision: int = 8,
 ) -> None:
     """Write blocked well data to RMS ASCII file.
 
     Args:
         blocked_well: BlockedWellData object to write
         filepath: Output RMS ASCII file path
-        precision: Number of decimal places for floats (default: 4)
+        precision: Number of decimal places for floats (default: 8)
 
     """
     i_log = WellLog(

--- a/src/xtgeo/io/_welldata/_well_io.py
+++ b/src/xtgeo/io/_welldata/_well_io.py
@@ -284,9 +284,14 @@ class WellData:
     def to_rms_ascii(
         self,
         filepath: FileLike,
-        precision: int = 4,
+        precision: int = 8,
     ) -> None:
-        """Write well data to RMS ASCII file."""
+        """Write well data to RMS ASCII file.
+
+        Args:
+            filepath: Output RMS ASCII file path or stream.
+            precision: Number of decimal places for floats (default: 8).
+        """
         from xtgeo.io._welldata._fformats._rms_ascii import write_rms_ascii_well
 
         write_rms_ascii_well(well=self, filepath=filepath, precision=precision)

--- a/src/xtgeo/well/_blockedwells_io_factory.py
+++ b/src/xtgeo/well/_blockedwells_io_factory.py
@@ -22,7 +22,7 @@ logger = null_logger(__name__)
 
 
 def _export_rms_ascii_blockedwells(
-    blockedwells: BlockedWells, bwfile_wrapper: FileWrapper
+    blockedwells: BlockedWells, bwfile_wrapper: FileWrapper, precision: int
 ) -> None:
     """Export multiple blocked wells to RMS ASCII format, as one file.
 
@@ -89,7 +89,7 @@ def _export_rms_ascii_blockedwells(
                 logs=blockedwelldata.logs + index_logs,
             )
             _write_rms_ascii_header(fhandle, temp_well)
-            _write_rms_ascii_data(fhandle, temp_well)
+            _write_rms_ascii_data(fhandle, temp_well, precision)
 
     logger.debug(
         "Successfully exported %d blocked wells to RMS ASCII", len(blockedwells._wells)
@@ -127,6 +127,7 @@ def blockedwells_to_stacked_file(
     bwfile_wrapper: FileWrapper,
     fformat: str | None,
     compression: str | None = "lzf",
+    precision: int = 8,
 ) -> None:
     """Export BlockedWells instance to stacked file based on format, as one file.
 
@@ -143,7 +144,7 @@ def blockedwells_to_stacked_file(
     fmt = bwfile_wrapper.fileformat(fformat)
 
     if fmt == FileFormat.RMSWELL:
-        _export_rms_ascii_blockedwells(blockedwells, bwfile_wrapper)
+        _export_rms_ascii_blockedwells(blockedwells, bwfile_wrapper, precision)
     elif fmt == FileFormat.CSV:
         _export_csv_blockedwells(blockedwells, bwfile_wrapper)
     else:

--- a/src/xtgeo/well/_wells_io_factory.py
+++ b/src/xtgeo/well/_wells_io_factory.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
 logger = null_logger(__name__)
 
 
-def _export_rms_ascii_wells(wells: Wells, wfile_wrapper: FileWrapper) -> None:
+def _export_rms_ascii_wells(
+    wells: Wells, wfile_wrapper: FileWrapper, precision: int
+) -> None:
     """Export multiple wells to RMS ASCII format.
 
     Each well is written with its full header and data section, separated by
@@ -46,7 +48,7 @@ def _export_rms_ascii_wells(wells: Wells, wfile_wrapper: FileWrapper) -> None:
             # Convert Well to WellData and write directly to file handle
             welldata = _well_io_factory._well_to_welldata(well)
             _write_rms_ascii_header(fhandle, welldata)
-            _write_rms_ascii_data(fhandle, welldata)
+            _write_rms_ascii_data(fhandle, welldata, precision)
 
     logger.debug("Successfully exported %d wells to RMS ASCII", len(wells._wells))
 
@@ -79,6 +81,7 @@ def wells_to_stacked_file(
     wells: Wells,
     wfile_wrapper: FileWrapper,
     fformat: str | None,
+    precision: int = 8,
 ) -> None:
     """Export Wells instance to file based on format.
 
@@ -94,7 +97,7 @@ def wells_to_stacked_file(
     fmt = wfile_wrapper.fileformat(fformat)
 
     if fmt == FileFormat.RMSWELL:
-        _export_rms_ascii_wells(wells, wfile_wrapper)
+        _export_rms_ascii_wells(wells, wfile_wrapper, precision)
     elif fmt == FileFormat.CSV:
         _export_csv_wells(wells, wfile_wrapper)
     else:

--- a/src/xtgeo/well/blocked_well.py
+++ b/src/xtgeo/well/blocked_well.py
@@ -205,6 +205,7 @@ class BlockedWell(Well):
         bwfile,
         fformat=None,
         compression: str | None = "lzf",
+        precision: int = 8,
     ):
         """Export BlockedWell to file.
 
@@ -213,6 +214,7 @@ class BlockedWell(Well):
             fformat: File format ('rms_ascii'/'rmswell', 'csv', 'hdf'/'hdf5'/'h5').
                 If None (default), uses 'rms_ascii'.
             compression: Compression for HDF5 format only. Default is 'lzf'.
+            precision: Number of decimal places for RMS ASCII floats. Default is 8.
 
         Returns:
             Path to file (or file object if stream was provided)
@@ -244,7 +246,9 @@ class BlockedWell(Well):
             blockedwelldata = _blockedwell_io_factory._blockedwell_to_blockedwelldata(
                 self
             )
-            blockedwelldata.to_file(bwfile.name, fformat=WellFileFormat.RMS_ASCII)
+            blockedwelldata.to_file(
+                bwfile.name, fformat=WellFileFormat.RMS_ASCII, precision=precision
+            )
 
         elif fformat in FileFormat.CSV.value:
             blockedwelldata = _blockedwell_io_factory._blockedwell_to_blockedwelldata(

--- a/src/xtgeo/well/blocked_wells.py
+++ b/src/xtgeo/well/blocked_wells.py
@@ -163,6 +163,8 @@ class BlockedWells(Wells):
         bwfile: FileLike,
         fformat: str | None = "rms_ascii",
         compression: str | None = "lzf",
+        *,
+        precision: int = 8,
     ) -> Path | io.BytesIO | io.StringIO:
         """Export multiple blocked wells to a single concatenated (stacked) file.
 
@@ -177,6 +179,8 @@ class BlockedWells(Wells):
             fformat: File format ('rms_ascii'/'rmswell' or 'csv').
                 Default is 'rms_ascii'. HDF5 is not supported.
             compression: Not used, kept for API compatibility.
+            precision: Keyword-only. Number of decimal places for RMS ASCII
+                floats. Default is 8.
 
         Returns:
             Path to the file that was written.
@@ -198,7 +202,7 @@ class BlockedWells(Wells):
         bwfile_wrapper.check_folder(raiseerror=OSError)
 
         _blockedwells_io_factory.blockedwells_to_stacked_file(
-            self, bwfile_wrapper, fformat, compression
+            self, bwfile_wrapper, fformat, compression, precision
         )
 
         return bwfile_wrapper.file

--- a/src/xtgeo/well/well1.py
+++ b/src/xtgeo/well/well1.py
@@ -539,6 +539,7 @@ class Well:
         wfile: str | Path | io.BytesIO,
         fformat: str | None = "rms_ascii",
         compression: str | None = "lzf",
+        precision: int = 8,
     ):
         """Export well to file or memory stream.
 
@@ -546,6 +547,7 @@ class Well:
             wfile: File name or stream.
             fformat: File format ('rms_ascii'/'rmswell', 'csv', 'hdf/hdf5/h5').
             compression: Compression for HDF5 format only. Default is 'lzf'.
+            precision: Number of decimal places for RMS ASCII floats. Default is 8.
 
         Example::
 
@@ -571,7 +573,9 @@ class Well:
             from xtgeo.io._welldata import WellFileFormat
 
             welldata = _well_io_factory._well_to_welldata(self)
-            welldata.to_file(wfile.name, fformat=WellFileFormat.RMS_ASCII)
+            welldata.to_file(
+                wfile.name, fformat=WellFileFormat.RMS_ASCII, precision=precision
+            )
 
         elif fformat in FileFormat.CSV.value:
             from xtgeo.io._welldata import WellFileFormat

--- a/src/xtgeo/well/wells.py
+++ b/src/xtgeo/well/wells.py
@@ -195,6 +195,8 @@ class Wells:
         self,
         wfile: FileLike,
         fformat: str | None = "rms_ascii",
+        *,
+        precision: int = 8,
     ) -> Path | io.BytesIO | io.StringIO:
         """Export multiple wells to a single concatenated (stacked) file.
 
@@ -208,6 +210,8 @@ class Wells:
             wfile: File name or stream.
             fformat: File format ('rms_ascii'/'rmswell' or 'csv'). HDF5 format
                 is not supported for multiple wells.
+            precision: Keyword-only. Number of decimal places for RMS ASCII
+                floats. Default is 8.
 
         Returns:
             Path to the file that was written.
@@ -226,7 +230,7 @@ class Wells:
         wfile_wrapper = FileWrapper(wfile, mode="wb", obj=self)
         wfile_wrapper.check_folder(raiseerror=OSError)
 
-        _wells_io_factory.wells_to_stacked_file(self, wfile_wrapper, fformat)
+        _wells_io_factory.wells_to_stacked_file(self, wfile_wrapper, fformat, precision)
 
         return wfile_wrapper.file
 

--- a/tests/test_io/test_welldata/test_fformat_rms_ascii.py
+++ b/tests/test_io/test_welldata/test_fformat_rms_ascii.py
@@ -287,6 +287,26 @@ def test_welldata_to_file_from_file_precision(tmp_path):
     assert "1.2345" not in content
 
 
+def test_welldata_to_file_uses_eight_decimal_places_by_default(tmp_path):
+    """Test default RMS ASCII precision preserves small values for welldata."""
+    log = WellLog(name="PERM", values=np.array([0.00012345]))
+    well = WellData(
+        name="DEFAULT-PRECISION",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0]),
+        survey_y=np.array([200.0]),
+        survey_z=np.array([1000.0]),
+        logs=(log,),
+    )
+
+    filepath = tmp_path / "well_default_precision.txt"
+    well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    assert "0.00012345" in filepath.read_text()
+
+
 def test_welldata_to_file_from_file_with_nan_values(tmp_path):
     """Test WellData with NaN values using to_file/from_file."""
     log = WellLog(name="INCOMPLETE", values=np.array([10.0, np.nan, 30.0]))
@@ -620,6 +640,30 @@ def test_blockedwell_to_file_from_file_precision(tmp_path):
     content = filepath.read_text()
     # Should have 3 decimal places
     assert "1.235" in content or "1.234" in content
+
+
+def test_blockedwell_to_file_uses_eight_decimal_places_by_default(tmp_path):
+    """Test default RMS ASCII precision preserves small values for BlockedWellData."""
+    log = WellLog(name="PERM", values=np.array([0.00012345]))
+
+    blocked_well = BlockedWellData(
+        name="BLOCKED-DEFAULT-PRECISION",
+        xpos=100.0,
+        ypos=200.0,
+        zpos=0.0,
+        survey_x=np.array([100.0]),
+        survey_y=np.array([200.0]),
+        survey_z=np.array([1000.0]),
+        i_index=np.array([10.0]),
+        j_index=np.array([20.0]),
+        k_index=np.array([1.0]),
+        logs=(log,),
+    )
+
+    filepath = tmp_path / "blocked_default_precision.txt"
+    blocked_well.to_file(filepath=filepath, fformat=WellFileFormat.RMS_ASCII)
+
+    assert "0.00012345" in filepath.read_text()
 
 
 def test_blockedwell_to_file_from_file_stream(tmp_path):

--- a/tests/test_well/test_blockedwell.py
+++ b/tests/test_well/test_blockedwell.py
@@ -16,6 +16,18 @@ def fixture_loadwell1(testdata_path):
     return xtgeo.blockedwell_from_file(wfile)
 
 
+def test_to_file_rms_ascii_precision(loadwell1, tmp_path):
+    """Test the public BlockedWell export exposes RMS ASCII precision."""
+    default_file = tmp_path / "default.bw"
+    loadwell1.to_file(default_file)
+    assert "462688.15942400" in default_file.read_text()
+
+    custom_file = tmp_path / "custom.bw"
+    loadwell1.to_file(custom_file, precision=4)
+    assert "462688.1594" in custom_file.read_text()
+    assert "462688.15942400" not in custom_file.read_text()
+
+
 def test_import_blockedwell(loadwell1):
     """Import blocked well from file."""
 

--- a/tests/test_well/test_blockedwells_io.py
+++ b/tests/test_well/test_blockedwells_io.py
@@ -68,6 +68,18 @@ def test_blockedwells_to_stacked_file_rms_ascii(tmp_path, testblockedwells):
         assert bw.lognames == orig.lognames
 
 
+def test_blockedwells_to_stacked_file_rms_ascii_precision(tmp_path, testblockedwells):
+    """Test the public stacked BlockedWell export exposes RMS ASCII precision."""
+    default_file = tmp_path / "default_bwells.rmswell"
+    testblockedwells.to_stacked_file(default_file, fformat="rms_ascii")
+    assert "463812.89941400" in default_file.read_text()
+
+    custom_file = tmp_path / "custom_bwells.rmswell"
+    testblockedwells.to_stacked_file(custom_file, fformat="rms_ascii", precision=4)
+    assert "463812.8994" in custom_file.read_text()
+    assert "463812.89941400" not in custom_file.read_text()
+
+
 def test_blockedwells_to_stacked_file_hdf5_raises(tmp_path, testblockedwells):
     """Test that HDF5 format raises appropriate error."""
     outfile = tmp_path / "all_bwells.h5"

--- a/tests/test_well/test_well.py
+++ b/tests/test_well/test_well.py
@@ -70,6 +70,18 @@ def fixture_create_well():
     return Well(25.0, 444.1, 464.1, "91/99-1", dfr)
 
 
+def test_to_file_rms_ascii_precision(simple_well, tmp_path):
+    """Test the public Well export exposes RMS ASCII precision."""
+    default_file = tmp_path / "default.rmswell"
+    simple_well.to_file(default_file)
+    assert "0.01000000" in default_file.read_text()
+
+    custom_file = tmp_path / "custom.rmswell"
+    simple_well.to_file(custom_file, precision=4)
+    assert "0.0100" in custom_file.read_text()
+    assert "0.01000000" not in custom_file.read_text()
+
+
 def test_import(loadwell1, snapshot, helpers):
     """Import well from file."""
 

--- a/tests/test_well/test_wells_io.py
+++ b/tests/test_well/test_wells_io.py
@@ -68,6 +68,18 @@ def test_wells_to_stacked_file_rms_ascii(tmp_path, testwells):
         assert w.lognames == orig.lognames
 
 
+def test_wells_to_stacked_file_rms_ascii_precision(tmp_path, testwells):
+    """Test the public stacked Well export exposes RMS ASCII precision."""
+    default_file = tmp_path / "default_wells.rmswell"
+    testwells.to_stacked_file(default_file, fformat="rms_ascii")
+    assert "767.37810000" in default_file.read_text()
+
+    custom_file = tmp_path / "custom_wells.rmswell"
+    testwells.to_stacked_file(custom_file, fformat="rms_ascii", precision=4)
+    assert "767.3781" in custom_file.read_text()
+    assert "767.37810000" not in custom_file.read_text()
+
+
 def test_wells_to_stacked_file_hdf_raises(tmp_path, testwells):
     """Test that HDF5 format raises appropriate error."""
     outfile = tmp_path / "all_wells.hdf5"


### PR DESCRIPTION
Resolves #1772 

RMS ASCII precision was not exposed to public API and set default to 4. This could cause unnecessary rounding of small log value (<5E-5). In this PR, it is set to 8 digits as default to align with other tool.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
