### PR TITLE
TST: Replace numeric string check with expected log name

### DIFF
--- a/tests/test_roxarapi/test_roxarapi_reek.py
+++ b/tests/test_roxarapi/test_roxarapi_reek.py
@@ -1167,8 +1167,16 @@ def test_blocked_well_roxar_to_from_file(rms_project_path, tmp_path):
     bw.to_file(filename)
     with open(filename, "r") as fhandle:
         ff = str(fhandle.readlines())
-        assert "Unknown" in ff
-        assert "460297.7747" in ff
+        for expected in [
+            "OP_2",
+            "Zonelog",
+            "Poro",
+            "Facies",
+            "I_INDEX",
+            "J_INDEX",
+            "K_INDEX",
+        ]:
+            assert expected in ff
 
     bw_op2 = xtgeo.blockedwell_from_file(filename)
     assert bw_op2.name == "OP_2"


### PR DESCRIPTION
After #1776 the precision in exported RMS ASCII file increase from 4 digits to 8 digits. This cause an issue in one of the test due the test was designed to check for a numeric string.

Replace the check of numeric string with expected log name in the file.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
