### PR TITLE
DOC: Fix description for load_values/ values for metadata support

### DIFF
--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -124,7 +124,9 @@ def surface_from_file(
             'signature' is used to guess format first, then file extension.
         template: Only valid if ``ijxyz`` format, where an existing Cube or
             RegularSurface instance is applied to get correct topology.
-        values (bool): If True (default), surface values will be read (Irap binary only)
+        values (bool): If True (default), surface values will be read. If False,
+            only metadata will be read. Supported for Irap binary, ZMAP ASCII, XTG,
+            and HDF5 formats.
         engine (str): Key indended for developers initially, now deprecated and have no
             effect. To be removed in future versions.
         dtype: Requsted numpy dtype of values; default is float64, alternatively float32
@@ -1108,8 +1110,8 @@ class RegularSurface:
                 is currently supported. If None or guess, the file 'signature' is
                 used to guess format first, then file extension.
             load_values: If True (default), then full array is read, if False
-                only metadata will be read. Valid for Irap binary only. This allows
-                lazy loading in e.g. ensembles.
+                only metadata will be read. Supported for Irap binary, ZMAP ASCII,
+                XTG, and HDF5 formats. This allows lazy loading in e.g. ensembles.
             kwargs: some readers allow additonal options
 
         Keyword Args:
@@ -1141,7 +1143,7 @@ class RegularSurface:
     def load_values(self):
         """Import surface values in cases where metadata only is loaded.
 
-        Currently, only Irap binary format is supported.
+        Supported for Irap binary, ZMAP ASCII, XTG, and HDF5 formats.
 
         Example::
 


### PR DESCRIPTION
Resolves #609 

Updated `regular_surface.py:124` to document that metadata-only loading is supported for:

```
Irap binary
ZMAP ASCII
XTG
HDF5
```
The same correction was applied to `_read_file(load_values=...)` and `regular_surface.py:1143`

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
