### PR TITLE
DOC: Fix documentation for asmasked

### DIFF
--- a/docs/array_handling.rst
+++ b/docs/array_handling.rst
@@ -1,0 +1,27 @@
+Array handling
+==============
+
+.. _asmasked-vs-activeonly:
+
+``asmasked`` and ``activeonly``
+--------------------------------
+
+Several methods use the ``asmasked`` or ``activeonly`` argument to control how
+inactive or undefined cells and nodes are returned. These arguments are
+different names for the same conceptual flag when passed to different methods:
+whether inactive or undefined entries are included. They do not, however,
+produce exactly the same output:
+
+* ``asmasked=True`` preserves the shape of the data and masks inactive or
+  undefined entries. ``asmasked=False`` includes those entries, using the
+  representation documented by the method. Methods that return an array
+  directly commonly return a ``numpy.ma.MaskedArray`` when this argument is
+  true and a ``numpy.ndarray`` when it is false.
+* ``activeonly=True`` removes inactive or undefined entries from the result.
+  ``activeonly=False`` includes them, using the representation documented by
+  the method, commonly ``None``, ``numpy.nan``, or a specified fill value.
+
+In other words, both arguments control the treatment of inactive or undefined
+entries. Use ``asmasked`` when a method offers a choice between a masked and an
+unmasked array, and ``activeonly`` when a method offers a choice between
+filtering and retaining those entries.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ The repository is hosted on `GitHub <https://github.com/equinor/xtgeo>`_.
    getting_started
    tutorial/tutorial_index
    datamodels
+   array_handling
    xtgeo_4_migration
    apireference
 

--- a/src/xtgeo/grid3d/grid.py
+++ b/src/xtgeo/grid3d/grid.py
@@ -64,20 +64,6 @@ if TYPE_CHECKING:
 xtg = xtgeo.common.XTGeoDialog()
 logger = null_logger(__name__)
 
-# --------------------------------------------------------------------------------------
-# Comment on "asmasked" vs "activeonly:
-#
-# "asmasked"=True will return a np.ma array, while "asmasked" = False will
-# return a np.ndarray
-#
-# The "activeonly" will filter out masked entries, or use None or np.nan
-# if "activeonly" is False.
-#
-# Use word "zerobased" for a bool regarding if startcell basis is 1 or 0
-#
-# For functions with mask=... ,they should be replaced with asmasked=...
-# --------------------------------------------------------------------------------------
-
 
 def _estimate_grid_ijk_handedness(coordsv: np.array) -> Literal["left", "right"] | None:
     """Helper: estimate the ijk handedness from the coordinates.
@@ -1540,6 +1526,7 @@ class Grid(_Grid3D):
 
         Args:
             activeonly (bool): If True (default), return only active cells.
+                See :ref:`asmasked-vs-activeonly`.
             ijk (bool): If True (default), show cell indices, IX JY KZ columns
             xyz (bool): If True (default), show cell center coordinates.
             doubleformat (bool): If True, floats are 64 bit, otherwise 32 bit.
@@ -2000,7 +1987,8 @@ class Grid(_Grid3D):
         Args:
             name (str): name of property in the XTGeo GridProperty object.
             asmasked (bool): Actnum is returned with all cells shown
-                as default. Use asmasked=True to make 0 entries masked.
+                as default. Use asmasked=True to make 0 entries masked. See
+                :ref:`asmasked-vs-activeonly`.
             dual (bool): If True, and the grid is a dualporo/perm grid, an
                 extended ACTNUM is applied (numbers 0..3)
 
@@ -2083,7 +2071,8 @@ class Grid(_Grid3D):
                 (experimental)
             asmasked (bool): True if only for active cells, False for all cells.
                 With `False` the inactive cells are included, but the numpy
-                array is still a MaskedArray instance.
+                array is still a MaskedArray instance. See
+                :ref:`asmasked-vs-activeonly`.
             metric (str): One of the following metrics:
                 * "euclid": sqrt(dx^2 + dy^2 + dz^2)
                 * "horizontal": sqrt(dx^2 + dy^2)
@@ -2120,7 +2109,8 @@ class Grid(_Grid3D):
             name (str): names of properties
             asmasked (bool). If True, make a np.ma array where inactive cells
                 are masked. Otherwise the inactive cells are included, but the numpy
-                array is still a MaskedArray instance.
+                array is still a MaskedArray instance. See
+                :ref:`asmasked-vs-activeonly`.
             metric (str): One of the following metrics:
                 * "euclid": sqrt(dx^2 + dy^2 + dz^2)
                 * "horizontal": sqrt(dx^2 + dy^2)
@@ -2151,7 +2141,8 @@ class Grid(_Grid3D):
             name (str): names of properties
             asmasked (bool). If True, make a np.ma array where inactive cells
                 are masked. Otherwise the inactive cells are included, but the numpy
-                array is still a MaskedArray instance.
+                array is still a MaskedArray instance. See
+                :ref:`asmasked-vs-activeonly`.
             metric (str): One of the following metrics:
                 * "euclid": sqrt(dx^2 + dy^2 + dz^2)
                 * "horizontal": sqrt(dx^2 + dy^2)
@@ -2589,7 +2580,8 @@ class Grid(_Grid3D):
         Args:
             names: a 3 x tuple of names per property (default is X_UTME,
             Y_UTMN, Z_TVDSS).
-            asmasked: If True, then inactive cells is masked (numpy.ma).
+            asmasked: If True, then inactive cells is masked (numpy.ma). See
+                :ref:`asmasked-vs-activeonly`.
         """
         return _grid_etc1.get_xyz(self, names=tuple(names), asmasked=asmasked)
 

--- a/src/xtgeo/grid3d/grid_properties.py
+++ b/src/xtgeo/grid3d/grid_properties.py
@@ -181,21 +181,6 @@ def gridproperties_from_file(
     )
 
 
-# --------------------------------------------------------------------------------------
-# Comment on 'asmasked' vs 'activeonly:
-#
-# 'asmasked'=True will return a np.ma array, while 'asmasked' = False will
-# return a np.ndarray
-#
-# The 'activeonly' will filter out masked entries, or use None or np.nan
-# if 'activeonly' is False.
-#
-# Use word 'zerobased' for a bool regrading startcell basis is 1 or 0
-#
-# For functions with mask=... ,they should be replaced with asmasked=...
-# --------------------------------------------------------------------------------------
-
-
 def gridproperties_dataframe(
     gridproperties: Iterable[GridProperties],
     grid: Grid | None = None,
@@ -213,7 +198,8 @@ def gridproperties_dataframe(
         gridproperties: List (also GridProperties or iterable) of GridProperty
             to create dataframe of.
         activeonly (bool): If True, return only active cells, NB!
-            If True, will require a grid instance (see grid key)
+            If True, will require a grid instance (see grid key). See
+            :ref:`asmasked-vs-activeonly`.
         ijk (bool): If True, show cell indices, IX JY KZ columns
         xyz (bool): If True, show cell center coordinates (needs grid).
         doubleformat (bool): If True, floats are 64 bit, otherwise 32 bit.
@@ -547,7 +533,8 @@ class GridProperties(_Grid3D):
 
         Args:
             names: a 3 x tuple of names per property (default IX, JY, KZ).
-            asmasked: If True, then active cells only.
+            asmasked: If True, then active cells only. See
+                :ref:`asmasked-vs-activeonly`.
             zerobased: If True, counter start from 0, otherwise 1 (default=1).
         """
         return _grid_etc1.get_ijk(
@@ -564,7 +551,8 @@ class GridProperties(_Grid3D):
         Args:
             name (str): name of property in the XTGeo GridProperty object.
             asmasked (bool): ACTNUM is returned with all cells
-                as default. Use asmasked=True to make 0 entries masked.
+                as default. Use asmasked=True to make 0 entries masked. See
+                :ref:`asmasked-vs-activeonly`.
 
         Example::
 
@@ -604,7 +592,8 @@ class GridProperties(_Grid3D):
 
         Args:
             activeonly (bool): If True, return only active cells, NB!
-                If True, will require a grid instance (see grid key)
+                If True, will require a grid instance (see grid key). See
+                :ref:`asmasked-vs-activeonly`.
             ijk (bool): If True, show cell indices, IX JY KZ columns
             xyz (bool): If True, show cell center coordinates (needs grid).
             doubleformat (bool): If True, floats are 64 bit, otherwise 32 bit.

--- a/src/xtgeo/grid3d/grid_property.py
+++ b/src/xtgeo/grid3d/grid_property.py
@@ -58,20 +58,6 @@ if TYPE_CHECKING:
 
     Roxar_DType = Union[type[np.uint8], type[np.uint16], type[np.float32]]
 
-# --------------------------------------------------------------------------------------
-# Comment on 'asmasked' vs 'activeonly:
-#
-# 'asmasked'=True will return a np.ma array, while 'asmasked' = False will
-# return a np.ndarray
-#
-# The 'activeonly' will filter out masked entries, or use None or np.nan
-# if 'activeonly' is False.
-#
-# Use word 'zerobased' for a bool regrading startcell basis is 1 or 0
-#
-# For functions with mask=... ,they should be replaced with asmasked=...
-# --------------------------------------------------------------------------------------
-
 # ======================================================================================
 # Functions outside the class, for rapid access. Will be exposed as
 # xxx = xtgeo.gridproperty_from_file.
@@ -1216,7 +1202,8 @@ class GridProperty(_Grid3D):
             name: Name of property in the XTGeo GridProperty object.
                 Default is "ACTNUM".
             asmasked: Default is False, so that actnum is returned with all cells
-                shown. Use asmasked=True to make 0 entries masked.
+                shown. Use asmasked=True to make 0 entries masked. See
+                :ref:`asmasked-vs-activeonly`.
 
         Returns:
             The ACTNUM GridProperty object.

--- a/src/xtgeo/surface/regular_surface.py
+++ b/src/xtgeo/surface/regular_surface.py
@@ -21,17 +21,6 @@ or::
 
 """
 
-# --------------------------------------------------------------------------------------
-# Comment on 'asmasked' vs 'activeonly:
-# 'asmasked'=True will return a np.ma array, with some fill_value if
-# if asmasked = False
-#
-# while 'activeonly' will filter
-# out maked entries, or use np.nan if 'activeonly' is False
-#
-# For functions with mask=... ,the should be replaced with asmasked=...
-# --------------------------------------------------------------------------------------
-
 from __future__ import annotations
 
 import functools
@@ -1567,11 +1556,12 @@ class RegularSurface:
         Args:
             order (str): Flatteting is in C (default) or F order
             asmasked (bool): If true, return as MaskedArray, other as standard
-                numpy ndarray with undef as np.nan or fill_value
+                numpy ndarray with undef as np.nan or fill_value. See
+                :ref:`asmasked-vs-activeonly`.
             fill_value (str): Relevent only if asmasked is False, this
                 will be the value of undef entries
             activeonly (bool): If True, only active cells. Keys 'asmasked' and
-                'fill_value' are not revelant.
+                'fill_value' are not relevant. See :ref:`asmasked-vs-activeonly`.
 
         Returns:
             A numpy 1D array or MaskedArray
@@ -1811,7 +1801,8 @@ class RegularSurface:
 
         Args:
             zero_based (bool): If False, first number is 1, not 0
-            asmasked (bool): If True, UNDEF map nodes are skipped
+            asmasked (bool): If True, UNDEF map nodes are masked. See
+                :ref:`asmasked-vs-activeonly`.
             order (str): 'C' (default) or 'F' order (row vs column major)
         """
         return _regsurf_oper.get_ij_values(
@@ -1823,7 +1814,8 @@ class RegularSurface:
 
         Args:
             zero_based (bool): If False, first number is 1, not 0
-            activeonly (bool): If True, UNDEF map nodes are skipped
+            activeonly (bool): If True, UNDEF map nodes are skipped. See
+                :ref:`asmasked-vs-activeonly`.
             order (str): 'C' (default) or 'F' order (row vs column major)
         """
         return _regsurf_oper.get_ij_values1d(
@@ -1835,7 +1827,8 @@ class RegularSurface:
 
         Args:
             order (str): 'C' (default) or 'F' order (row major vs column major)
-            asmasked (bool): If True , inactive nodes are masked.
+            asmasked (bool): If True, inactive nodes are masked. See
+                :ref:`asmasked-vs-activeonly`.
         """
         xvals, yvals = _regsurf_oper.get_xy_values(self, order=order, asmasked=asmasked)
 
@@ -1846,7 +1839,8 @@ class RegularSurface:
 
         Args:
             order (str): 'C' (default) or 'F' order (row major vs column major)
-            activeonly (bool): Only active cells are returned.
+            activeonly (bool): Only active cells are returned. See
+                :ref:`asmasked-vs-activeonly`.
         """
         xvals, yvals = _regsurf_oper.get_xy_values1d(
             self, order=order, activeonly=activeonly
@@ -1867,7 +1861,8 @@ class RegularSurface:
 
         Args:
             order (str): 'C' (default) or 'F' order (row major vs column major)
-            activeonly (bool): Only active cells are returned.
+            activeonly (bool): Only active cells are returned. See
+                :ref:`asmasked-vs-activeonly`.
             fill_value (float): If activeonly is False, value of inactive nodes
         """
         xcoord, ycoord = self.get_xy_values1d(order=order, activeonly=activeonly)
@@ -1892,7 +1887,7 @@ class RegularSurface:
                for Fortran order (column fastest)
             activeonly (bool): If True, only active nodes are listed. If
                 False, the values will have fill_value default None = NaN
-                as values
+                as values. See :ref:`asmasked-vs-activeonly`.
             fill_value (float): Value of inactive nodes if activeonly is False
 
         Example::


### PR DESCRIPTION
Resolves #729 

This PR moves the repeated explanation of `asmasked` and `activeonly` into one documentation page.

It explains that both options control how inactive or undefined values are handled:

- `asmasked=True` keeps the values but masks them.
- `activeonly=True` removes them from the result.

Relevant API documentation now links to this explanation, and the duplicated source comments have been removed.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If relevant, a benchmarking case has been run prior to this PR to set the base before
 your changes are applied.
- [ ] If relevant, benchmarking tests are added to demonstrate how the current change affects code speed 
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
